### PR TITLE
fix: harden Sales Navigator mutation safety

### DIFF
--- a/docs/plans/multi-agent-research-loop-project-plan.md
+++ b/docs/plans/multi-agent-research-loop-project-plan.md
@@ -1,0 +1,340 @@
+# Multi-Agent Sales Navigator Research Loop — Project Plan
+
+This document is the authoritative planning artifact for evolving **Sales Navigator Research Assistant** into a safer multi-agent research system. It is written for human operators and for agent runtimes (**Cursor**, **Codex**, **Hermes**) doing supervised implementation—not for autonomous live Sales Navigator mutations.
+
+---
+
+## Executive Summary
+
+The repository already ships a substantial supervised pipeline: CLI orchestration, SQLite-backed runs, territory/account coverage, fast-list import with grouped company resolution, background territory runners, **autoresearch:mvp** dry-safe automation, Playwright plus **browser-harness** plus **hybrid** drivers, operator review dashboard, and explicit `--live-save` / `--live-connect` opt-in for mutations.
+
+**North-star outcomes**
+
+1. **Better lead identification** — fewer misses and clearer evidence trails without weakening guardrails.
+2. **Avoid wrong-list contamination** — never promote weak identity or ambiguous company scope to “safe to save.”
+3. **Never remove correct membership accidentally** — especially list-row interactions that can toggle membership off (see P0 backlog).
+4. **Operator-approved mutations only** — no agent or CI path should execute live Sales Navigator writes or connects without explicit human intent and matching CLI flags.
+
+**Delivery strategy**: ship **milestone 1 (critical safety)** before expanding planner/metrics/orchestration work; treat evaluation metrics and dashboards as layered on top of hard safety invariants.
+
+---
+
+## Current Architecture Map
+
+### CLI entry and orchestration
+
+| Surface | Role |
+|--------|------|
+| `src/cli.js` | Single Node entry (`main`: `src/cli.js`); parses args via `src/lib/args.js`; routes commands to workflows. |
+| `src/core/orchestrator.js` | Territory runs: create runs, scoring, decisions, dry-run vs mutation semantics. |
+| `src/core/territory-sync.js` | Territory intake/sync from adapters. |
+| `src/core/decision-engine.js` | Candidate action decisions (`decideCandidateActions`). |
+
+### Coverage, batches, background processing
+
+| Module | Role |
+|--------|------|
+| `src/core/account-coverage.js` | Account coverage sweep, buckets, artifacts. |
+| `src/core/coverage-review.js` | Markdown coverage review rendering. |
+| `src/core/account-batch.js` | Named account batches, list naming templates. |
+| `src/core/background-territory-runner.js` | Queue/spec artifacts for background territory processing. |
+| `src/core/background-list-maintenance.js` | Background loop execution, checkpoints, variation registry, reports (`--live-save` optional). |
+
+### Fast import and identity
+
+| Module | Role |
+|--------|------|
+| `src/core/fast-list-import.js` | Resolve leads, grouped company pool, save plans, optional `--live-save`. |
+| `src/core/lead-identity-resolution.js` | Name/slug inference, confidence, `needsManualReview`. |
+| `src/core/lead-list-snapshot.js` | Snapshot reads for preflight/dedupe semantics. |
+
+### Company resolution
+
+| Module | Role |
+|--------|------|
+| `src/core/company-resolution.js` | Build artifacts, markdown, alias config loading. |
+| `src/core/company-resolution-retry.js` | Retry queues and checkpoints (CLI marks dry-safe only). |
+
+### Autoresearch MVP
+
+| Module | Role |
+|--------|------|
+| `src/core/autoresearch-mvp.js` | Dry-safe command bundles, prohibited mutation flags, dashboard helpers. |
+
+### Browser drivers
+
+| Module | Role |
+|--------|------|
+| `src/drivers/playwright-sales-nav.js` | Discovery-heavy flows; `saveCandidateToList`, company filter/scoping, URL checks for `/sales/lead/`. |
+| `src/drivers/browser-harness-sales-nav.js` | CDP-backed mutations; **already_saved** path checks selection **before** secondary clicks (lines ~418–426 region). |
+| `src/drivers/hybrid-sales-nav.js` | Playwright discovery + browser-harness mutations; `checkSessionHealth` ties mutation readiness to `allowMutations` and non-dry-run. |
+| `src/drivers/driver-adapter.js` | Adapter surface. |
+| `src/drivers/mock-driver.js` | Tests/offline. |
+
+### Storage, readiness, dashboard
+
+| Module | Role |
+|--------|------|
+| `src/lib/db.js` | SQLite repository factory. |
+| `src/lib/live-readiness.js` | Live readiness signals (includes Sales Nav URL helpers like `isSalesNavigatorLeadUrl`). |
+| `src/server/dashboard.js` | Review dashboard server (`serve-review-dashboard`). |
+
+### Adapters (readonly / ingest)
+
+| Module | Role |
+|--------|------|
+| `src/adapters/gtm-bigquery.js`, `src/adapters/salesforce-readonly.js` | External data; Salesforce secrets policy surfaced in live readiness. |
+
+### NPM scripts (from `package.json`)
+
+Operational scripts agents should reference precisely:
+
+- **Setup / health**: `npm run doctor`, `npm run check-driver-session`, `npm run bootstrap-session`, `npm run bootstrap-browser-harness`
+- **Territory / runs**: `npm run sync-territory`, `npm run run-territory`, `npm run resume-run`
+- **Coverage / batches**: `npm run account-coverage`; account batch flows are exposed through `node src/cli.js run-account-batch` rather than an npm script.
+- **Fast path**: `npm run fast-resolve-leads`, `npm run fast-list-import`, `npm run retry-failed-fast-list-import`, `npm run import-coverage`
+- **Background**: `npm run build-background-territory-queue`, `npm run run-background-territory-loop`
+- **Research MVP**: `npm run autoresearch:mvp`
+- **Dashboard**: `npm run serve-review-dashboard`
+- **Tests**: `npm test`, `npm run test:release-readiness`
+- **Pilot / live-oriented** (operator-only execution): `test-list-save`, `test-connect`, flows documented in `src/cli.js` help text (`--live-save`, `--live-connect`)
+
+---
+
+## Target Multi-Agent Architecture
+
+### Principles
+
+1. **Split cognition from execution**: planners and critics propose artifacts; **execution touchpoints** are CLI commands with stable contracts.
+2. **Single writer for mutations**: only designated operator-approved processes invoke `--live-save` / `--live-connect`; agents document implementation plans in `docs/` and dry-run/runtime outcomes in local `runtime/artifacts/**` review artifacts that are not committed.
+3. **Fail closed**: ambiguous scope, identity, or URL validity blocks promotion to save/connect—not “best effort save.”
+4. **Observable artifacts**: every batch produces machine-readable summaries plus human-readable Markdown for review.
+
+### Agent roles (logical)
+
+| Agent | Responsibility | Primary inputs | Primary outputs |
+|-------|----------------|----------------|-----------------|
+| **Supervisor / Product** | Goals, priorities, acceptance criteria | Business territory goals, risk appetite | Milestones, ordered backlog |
+| **Safety Auditor** | Invariants, threat modeling for list/connect flows | Driver code, CLI gates, tests | P0 findings, required tests |
+| **Research Planner** | Next searches, coverage gaps, retry strategy | Coverage artifacts, pilot config, prior run logs | Plan JSON/Markdown (e.g. under `docs/` or committed templates—not `runtime/`) |
+| **Implementation Agent** | Code + tests | Tasks from this plan | PR-ready diffs |
+| **Verification Agent** | Test runs, static checks, dry CLI smoke | Changed modules | Report: commands run + results |
+| **Operator** | Session bootstrap, live mutations, approvals | Dashboard + artifacts | Explicit CLI flags for live actions |
+
+### Allowed vs forbidden surfaces
+
+| Allowed | Forbidden without explicit operator approval |
+|---------|-----------------------------------------------|
+| Edit `src/**`, `tests/**`, `docs/**`, `config/**` (non-secret) | `--live-save`, `--live-connect`, `--allow-background-connects` on real sessions |
+| Run `npm test`, `npm run test:release-readiness`, dry CLI defaults | Writing cookies, storage state, or scraping production LinkedIn outside supervised bootstrap |
+| Read sample fixtures under repo | Bulk export of `runtime/`, `.env`, or session artifacts to shared channels |
+
+**Safety boundaries**
+
+- **`runtime/`**: local-only artifacts (logs, checkpoints, browser artifacts). Agents **must not** commit or normalize mutation of operator runtime content as “implementation.”
+- **`.env` / secrets**: never commit; live readiness already warns on Salesforce secret patterns (`src/lib/live-readiness.js`).
+- **Grouped keys / dedupe keys**: changes must preserve uniqueness semantics across grouped pools (`src/core/fast-list-import.js` grouped maps).
+
+---
+
+## Milestone Implementation Plan
+
+### Milestone 1 — Critical safety fixes (P0)
+
+**Objective**: Eliminate classes of “silent wrong save” and “accidental unsave,” align harness/playwright semantics, validate URLs before any save path reaches drivers where inconsistent.
+
+| Task | Acceptance criteria | Tests to add/run | Risk notes |
+|------|---------------------|------------------|------------|
+| **M1-T1**: Playwright list row selection must not toggle off existing membership | Saving when lead already on target list yields `already_saved` or no-op without deselecting; unit/integration tests mock DOM state | `npm test` + targeted driver tests in `tests/playwright-driver.test.js` | DOM variance across locales |
+| **M1-T2**: Unified Sales Nav lead URL validation | Shared helper used by Playwright + browser-harness + fast-import planning; rejects non-`/sales/lead/` URLs before mutation classification | Tests in `tests/fast-list-import.test.js` or new `tests/url-validation.test.js` | False rejects on rare URL shapes |
+| **M1-T3**: Browser-harness / hybrid fail-closed when company scope unverified | Document and enforce: coverage/account flows do not silently widen people search when company filter fails (align with Playwright `needs_manual_alias` / filter errors) | Extend `tests/browser-harness-driver.test.js`, hybrid smoke docs | May increase manual_review volume |
+| **M1-T4**: Identity confidence gates save | `needsManualReview` / low confidence cannot classify row as production-save eligibility without explicit override flag | `tests/fast-list-import.test.js`, `lead-identity-resolution` unit tests | Operator friction—mitigate with dashboard surfacing |
+| **M1-T5**: Grouped row keys collision-safe | Keys incorporate stable row IDs or hashed URLs where present; collision test fixture | `tests/fast-list-import.test.js` | Migration of existing artifacts |
+
+**Exit**: All new tests green; `npm run test:release-readiness` passes; documented operator checklist updated only if strictly necessary (prefer this plan doc iteration first).
+
+---
+
+### Milestone 2 — Research-loop planner
+
+**Objective**: Deterministic planner that consumes coverage artifacts and emits the **next** dry-safe CLI DAG (no mutation).
+
+| Task | Acceptance criteria | Tests | Risks |
+|------|---------------------|-------|-------|
+| Planner module or documented algorithm in code | Inputs/outputs versioned schema; reproducible given same artifacts | Unit tests with fixtures | Scope creep—keep v1 minimal |
+| Integration hook | callable from `autoresearch:mvp` or sibling dry command | Snapshot tests for emitted Markdown/JSON | |
+
+---
+
+### Milestone 3 — Evaluation metrics
+
+**Objective**: Measurable precision/recall proxies **without** requiring live labels—e.g., duplicate rate, manual_review rate, company-alias disagreement rate, sweep stability.
+
+| Task | Acceptance criteria | Tests | Risks |
+|------|---------------------|-------|-------|
+| Metrics aggregation | Defined fields on existing artifacts + optional small reporter CLI | Pure unit tests on calculators | Metric gaming—pair with audits |
+
+---
+
+### Milestone 4 — List mutation review artifact
+
+**Objective**: Export intended adds/removes **before** live-save with stable diff format for dashboard/email review.
+
+| Task | Acceptance criteria | Tests | Risks |
+|------|---------------------|-------|-------|
+| Diff artifact | Markdown + JSON alongside existing snapshot flows | Snapshot tests | PII handling—keep local |
+
+---
+
+### Milestone 5 — Lead quality diagnostics
+
+**Objective**: Explain **why** a lead scored/decisioned a certain way (signals, negatives).
+
+| Task | Acceptance criteria | Tests | Risks |
+|------|---------------------|-------|-------|
+| Diagnostic strings | Attached to candidate assessments in artifacts | Decision/scoring tests | Verbosity |
+
+---
+
+### Milestone 6 — Company alias suggestions
+
+**Objective**: Assist operators with ambiguous companies without auto-applying risky aliases.
+
+| Task | Acceptance criteria | Tests | Risks |
+|------|---------------------|-------|-------|
+| Suggest-only mode | Writes suggestions artifact; never silently patches prod territory JSON | Company resolution tests | Trust—pair with M1 |
+
+---
+
+### Milestone 7 — Agent orchestration wrapper (Hermes + Cursor/Codex)
+
+**Objective**: Thin wrapper docs + optional scripts that sequence dry phases and pause points for operators—not autonomous live loops.
+
+| Task | Acceptance criteria | Tests | Risks |
+|------|---------------------|-------|-------|
+| Wrapper contract | ENV hooks documented; single entry for “dry pipeline” | Lint/smoke only | Misleading “full auto” naming—avoid |
+
+---
+
+### Milestone 8 — Operator approval / dashboard flow
+
+**Objective**: Tie dashboard queues to planner outputs and mutation review artifacts.
+
+| Task | Acceptance criteria | Tests | Risks |
+|------|---------------------|-------|-------|
+| Dashboard UX/docs | Shows pending approvals; links to artifact paths | Dashboard tests (`tests/dashboard.test.js`) | Scope |
+
+---
+
+## P0 Bug Backlog (Supervisor Analysis → Concrete Tracking)
+
+Below items tie supervisor themes to **files** and **proposed tests**. Implementers should convert each into an issue with acceptance criteria mirroring Milestone 1.
+
+### B1 — List row click may toggle membership off (Playwright path)
+
+- **Symptom**: `clickVisibleListRow` (`src/drivers/playwright-sales-nav.js`, ~`clickVisibleListRow`) clicks matching buttons without detecting **already selected** state—could flip saved leads off target lists.
+- **Contrast**: Browser harness path explicitly handles `before_state.selected` (`src/drivers/browser-harness-sales-nav.js`, ~418–426).
+- **Proposed tests**: DOM-fixture test asserting **no click** when row already selected; golden tests for aria patterns.
+
+### B2 — Hybrid mutation readiness vs company-scope verification
+
+- **Symptom**: Discovery may succeed while company filter/scoping failed closed insufficiently on harness-only paths.
+- **Files**: `src/drivers/playwright-sales-nav.js` (company filter errors), `src/drivers/hybrid-sales-nav.js` (`checkSessionHealth`), account/openPeopleSearch flows.
+- **Proposed tests**: Hybrid unit tests forcing filter failure → **no candidate promotion** to save-eligible without explicit recovery state.
+
+### B3 — Name-only / truncated-name resolution must not imply safe-to-save
+
+- **Files**: `src/core/lead-identity-resolution.js` (`needsManualReview`, confidence tiers), consumers in `src/core/fast-list-import.js`, `src/core/decision-engine.js`.
+- **Proposed tests**: Fixtures with truncated names **without** slug inference → blocked from automatic save tier unless operator flag.
+
+### B4 — Grouped pool row key collisions
+
+- **Files**: `src/core/fast-list-import.js` — `resolvedRows.set(... lead.row || \`${groupKey}:${fullName}\`)`, `groupedRows.get(...)`.
+- **Proposed tests**: Two distinct rows normalize to same key → collision detected or keys include disambiguator (lead URL hash).
+
+### B5 — Sales Navigator URL consistency before live save
+
+- **Files**: Playwright validates `/linkedin\.com\/sales\/lead\//i` in `saveCandidateToList` (`src/drivers/playwright-sales-nav.js`); harness uses target URLs from caller—centralize validation (`src/lib/live-readiness.js` already exposes `isSalesNavigatorLeadUrl`).
+- **Proposed tests**: Invalid URLs rejected at planner/driver boundary uniformly.
+
+---
+
+## Cursor Usage Strategy
+
+### Models
+
+| Mode | Recommended use |
+|------|-----------------|
+| **composer-2** | Implementation: production code changes, tests, refactors constrained by acceptance criteria |
+| **composer-2-fast** | Reviews, plans, diffs-only critique, test-plan generation |
+
+### `--trust` requirement
+
+Workspace rules require `--trust` for headless Cursor CLI runs in this repo. Use it intentionally with tight prompts and file-scope constraints; it is not permission to touch `runtime/`, `.env`, lockfiles, or browser/session data unless the operator explicitly tasks it. Implementation agents should normally limit edits to `src/`, `tests/`, `docs/`, and non-secret `config/` files.
+
+### Prompt patterns that work well
+
+1. **Safety-first**: “Implement M1-T1 only; do not change hybrid routing; add tests before implementation where possible; cite failing invariant.”
+2. **Scope-bound**: “Touch only `src/drivers/playwright-sales-nav.js` and `tests/playwright-driver.test.js`; no README edits.”
+3. **Test-first**: “Write failing tests for URL validation helper then implement in `src/lib/` re-exported by drivers.”
+
+### Measuring Cursor limits / usage conservatively
+
+- **CLI `about`** may indicate **Team tier** but **does not expose** remaining tokens or pool balances—assume budgets are opaque.
+- **Conservative habits**: reuse composer-2-fast for exploratory reads/plans; batch file reads in Cursor instead of iterative micro-prompts; prefer repo grep/`npm test` locally over repeated LLM summarization of logs.
+- **Diff discipline**: ask implementation agents for smallest reversible commits per milestone task.
+
+---
+
+## Safety Gates — Live Save / Live Connect / Remove
+
+Summary aligned with `src/cli.js` enforcement patterns (representative—not exhaustive):
+
+| Operation area | Typical CLI affordance | Gate |
+|----------------|----------------------|------|
+| Smoke save test | `test-list-save ... --live-save` | Throws if `--live-save` omitted (`handleTestListSave`) |
+| Fast import saves | `fast-list-import`, `retry-failed-fast-list-import`, `import-coverage` | `--live-save` optional dry path; rejects `--live-connect` / `--allow-background-connects` |
+| Connect sends | `test-connect`, `connect-lead-list`, `pilot-connect-batch` | Requires `--live-connect` |
+| Remove members | `remove-lead-list-members` | Requires `--live-save` |
+| Autoresearch | `autoresearch-mvp` | Refuses live mutation flags entirely |
+| Fast resolve | `fast-resolve-leads` | Refuses live flags |
+| Background loop | `run-background-territory-loop` | Serial concurrency when `--live-save`; hybrid readiness |
+
+**Hermes/Cursor agents**: treat these gates as **hard dependencies**—never suggest wrapping live commands into unattended cron without operator signing each escalation path.
+
+---
+
+## Suggested First Three Cursor Implementation Prompts
+
+Copy-paste friendly; each assumes Milestone 1 posture.
+
+### Prompt A — Centralize Sales Navigator lead URL validation
+
+> Introduce a single exported validator (reuse logic from `isSalesNavigatorLeadUrl` in `src/lib/live-readiness.js` or consolidate there). Call it from Playwright `saveCandidateToList`, browser-harness mutation entry, and fast-list-import planning paths where URLs become save-eligible. Add unit tests covering valid `/sales/lead/` URLs and rejecting `/in/` or malformed URLs. Do not modify `runtime/` or `.env`. Run `npm test`.
+
+### Prompt B — Playwright list selection parity with harness already_saved semantics
+
+> In `clickVisibleListRow` / save panel flow (`src/drivers/playwright-sales-nav.js`), detect when the target list row is already selected **before** clicking; return `{ status: 'already_saved', ... }` aligned with harness payload shape consumed by `saveFastListImport`. Add regression tests with mocked page/locator behavior. Run targeted tests plus `npm run test:release-readiness`.
+
+### Prompt C — Confidence gate from `resolveLeadIdentity` through fast-list-import save eligibility
+
+> Trace `needsManualReview` and confidence from `src/core/lead-identity-resolution.js` into fast-list-import decisioning so rows flagged manual review cannot appear as eligible for `--live-save` batch saves unless an explicit opt-in flag exists (default off). Tests in `tests/fast-list-import.test.js` must demonstrate blocked vs allowed paths.
+
+---
+
+## Document Control
+
+- **Location**: `docs/plans/multi-agent-research-loop-project-plan.md`
+- **Living updates**: revise milestones when Milestone 1 exits; keep P0 backlog synchronized with implemented fixes (strike-through or appendix changelog optional).
+
+---
+
+## Appendix — Tests Commands Cheat Sheet
+
+```bash
+npm run doctor
+npm test
+npm run test:release-readiness
+```
+
+Dry-safe research and artifact generation remain valid **without** LinkedIn login; browser-backed workflows require operator session bootstrap per `AGENTS.md` / `CLAUDE.md`.

--- a/src/core/fast-list-import.js
+++ b/src/core/fast-list-import.js
@@ -27,6 +27,7 @@ const {
   finishRunTimings,
   timePhase,
 } = require('./speed-telemetry');
+const { isSalesNavigatorLeadUrl } = require('../lib/live-readiness');
 
 const FAST_IMPORT_ARTIFACTS_DIR = path.join(ARTIFACTS_DIR, 'fast-import');
 const LEARNED_LEAD_RESOLUTION_SUGGESTIONS_PATH = path.join(FAST_IMPORT_ARTIFACTS_DIR, 'learned-lead-resolution-suggestions.json');
@@ -338,7 +339,7 @@ function scoreFastResolveCandidate(lead, candidate, aliasTerms = []) {
     .slice(0, 5);
   const titleMatch = expectedTitleTokens.some((token) => title.includes(token));
   const locationMatch = expectedLocationTokens.some((token) => candidateLocation.includes(token));
-  const hasSalesNavigatorUrl = /linkedin\.com\/sales\/lead\//i.test(candidate?.salesNavigatorUrl || candidate?.profileUrl || '');
+  const hasSalesNavigatorUrl = isSalesNavigatorLeadUrl(candidate?.salesNavigatorUrl || candidate?.profileUrl || '');
   const additionalSignals = [
     slugMatch,
     titleMatch,
@@ -546,7 +547,7 @@ function parseMarkdownLeadRows(markdown) {
       score: Number(row.score) || null,
       tier: Number(row.tier) || null,
       publicLinkedInUrl,
-      salesNavigatorUrl: /linkedin\.com\/sales\/lead\//i.test(publicLinkedInUrl) ? publicLinkedInUrl : null,
+      salesNavigatorUrl: isSalesNavigatorLeadUrl(publicLinkedInUrl) ? publicLinkedInUrl : null,
       location: row.standort || row.location || '',
       source: row.quelle || row.source || '',
     });
@@ -571,7 +572,7 @@ function dedupeLeads(leads) {
       ...lead,
       accountName: lead.accountName || lead.company || '',
       fullName: lead.fullName || lead.name || '',
-      salesNavigatorUrl: lead.salesNavigatorUrl || (/linkedin\.com\/sales\/lead\//i.test(lead.profileUrl || '') ? lead.profileUrl : null),
+      salesNavigatorUrl: lead.salesNavigatorUrl || (isSalesNavigatorLeadUrl(lead.profileUrl || '') ? lead.profileUrl : null),
       publicLinkedInUrl: lead.publicLinkedInUrl || lead.profileUrl || null,
     });
   }
@@ -604,7 +605,7 @@ function loadCoverageLeadIndex(coverageDir = COVERAGE_ARTIFACTS_DIR) {
       ];
       for (const candidate of candidates) {
         const url = candidate.salesNavigatorUrl || candidate.profileUrl;
-        if (!url || !/linkedin\.com\/sales\/lead\//i.test(url)) {
+        if (!url || !isSalesNavigatorLeadUrl(url)) {
           continue;
         }
         const nameKey = normalizeLookupValue(candidate.fullName || candidate.name);
@@ -634,7 +635,7 @@ function loadCoverageLeadIndex(coverageDir = COVERAGE_ARTIFACTS_DIR) {
 
 function resolveLeadsWithCoverage(leads, coverageIndex = loadCoverageLeadIndex()) {
   return dedupeLeads(leads).map((lead) => {
-    if (lead.salesNavigatorUrl && /linkedin\.com\/sales\/lead\//i.test(lead.salesNavigatorUrl)) {
+    if (lead.salesNavigatorUrl && isSalesNavigatorLeadUrl(lead.salesNavigatorUrl)) {
       return {
         ...lead,
         resolutionStatus: 'resolved',
@@ -702,7 +703,7 @@ function normalizeImportRowsFromParsedArtifact(parsed = {}, options = {}) {
       title: row.title || row.titel || '',
       score: normalizeImportScore(row.score),
       coverageBucket: row.coverageBucket || null,
-      salesNavigatorUrl: row.salesNavigatorUrl || (/linkedin\.com\/sales\/lead\//i.test(row.profileUrl || '') ? row.profileUrl : null),
+      salesNavigatorUrl: row.salesNavigatorUrl || (isSalesNavigatorLeadUrl(row.profileUrl || '') ? row.profileUrl : null),
       publicLinkedInUrl: row.publicLinkedInUrl || row.profileUrl || null,
       location: row.location || row.standort || '',
     }))
@@ -810,7 +811,7 @@ function loadFailedFastListImportPlan(artifactPath, {
     : new Set(Array.isArray(retryStatuses) ? retryStatuses : RETRYABLE_FAST_IMPORT_STATUSES);
   const leads = rows
     .filter((row) => retryableStatuses.has(row.status))
-    .filter((row) => row.salesNavigatorUrl && /linkedin\.com\/sales\/lead\//i.test(row.salesNavigatorUrl))
+    .filter((row) => row.salesNavigatorUrl && isSalesNavigatorLeadUrl(row.salesNavigatorUrl))
     .map((row) => ({
       ...row,
       resolutionStatus: 'resolved',

--- a/src/drivers/browser-harness-sales-nav.js
+++ b/src/drivers/browser-harness-sales-nav.js
@@ -2,6 +2,7 @@ const { spawnSync } = require('node:child_process');
 const { DriverAdapter } = require('./driver-adapter');
 const { buildCompanyFilterTargets } = require('./playwright-sales-nav');
 const { limitCandidatesByTemplate, normalizeCandidateLimit } = require('../core/candidate-limits');
+const { isSalesNavigatorLeadUrl } = require('../lib/live-readiness');
 
 const SALES_HOME_URL = 'https://www.linkedin.com/sales/home';
 const COMPANY_SEARCH_URL = 'https://www.linkedin.com/sales/search/company';
@@ -242,7 +243,7 @@ wait_for_load()
     }
 
     const targetUrl = candidate.salesNavigatorUrl || candidate.profileUrl;
-    if (!targetUrl || !/linkedin\.com\/sales\/lead\//i.test(targetUrl)) {
+    if (!targetUrl || !isSalesNavigatorLeadUrl(targetUrl)) {
       throw new Error(`Candidate ${candidate.fullName || 'unknown'} does not point to a Sales Navigator lead URL`);
     }
 
@@ -493,6 +494,9 @@ wait(${Math.max(1, this.options.settleMs / 300)})
     const targetUrl = candidate.salesNavigatorUrl || candidate.profileUrl;
     if (!targetUrl) {
       throw new Error(`Candidate ${candidate.fullName || 'unknown'} has no profile URL`);
+    }
+    if (!isSalesNavigatorLeadUrl(targetUrl)) {
+      throw new Error(`Candidate ${candidate.fullName || 'unknown'} does not point to a Sales Navigator lead URL`);
     }
     const shouldFlushCache = this.connectAttemptCount > 0
       && this.options.connectCacheFlushEvery > 0

--- a/src/drivers/playwright-sales-nav.js
+++ b/src/drivers/playwright-sales-nav.js
@@ -4,6 +4,7 @@ const { chromium } = require('playwright');
 const { DriverAdapter } = require('./driver-adapter');
 const { classifyConnectMenuActionLabel } = require('../core/connect-menu');
 const { limitCandidatesByTemplate, normalizeCandidateLimit } = require('../core/candidate-limits');
+const { isSalesNavigatorLeadUrl } = require('../lib/live-readiness');
 
 const SALES_HOME_URL = 'https://www.linkedin.com/sales/home';
 const MIN_COMPANY_FILTER_CONFIDENCE = 0.7;
@@ -502,7 +503,7 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     if (!candidate.salesNavigatorUrl && !candidate.profileUrl) {
       throw new Error(`Candidate ${candidate.fullName} is missing a Sales Navigator URL`);
     }
-    if (!/linkedin\.com\/sales\/lead\//i.test(candidate.salesNavigatorUrl || candidate.profileUrl || '')) {
+    if (!isSalesNavigatorLeadUrl(candidate.salesNavigatorUrl || candidate.profileUrl || '')) {
       throw new Error(`Candidate ${candidate.fullName} does not point to a Sales Navigator lead URL`);
     }
 
@@ -522,8 +523,16 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
       await this.pacedWait(2);
       await waitForAnySelector(this.page, DEFAULT_SELECTORS.savePanelMarkers, 12000).catch(() => {});
 
-      const selected = await clickVisibleListRow(this.page, listInfo.listName);
-      if (selected) {
+      const rowOutcome = await clickVisibleListRow(this.page, listInfo.listName);
+      if (rowOutcome?.outcome === 'already_saved') {
+        await this.pacedWait(2);
+        return {
+          status: 'already_saved',
+          listName: listInfo.listName,
+          selectionMode: rowOutcome.selectionMode || 'existing_list',
+        };
+      }
+      if (rowOutcome?.outcome === 'clicked') {
         await this.pacedWait(2);
         return { status: 'saved', listName: listInfo.listName, selectionMode: 'existing_list' };
       }
@@ -600,6 +609,11 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
   async sendConnect(candidate, context) {
     if (!this.options.allowMutations) {
       return { status: context.dryRun ? 'simulated' : 'planned', note: 'mutations disabled' };
+    }
+
+    const connectTargetUrl = candidate.salesNavigatorUrl || candidate.profileUrl || '';
+    if (!connectTargetUrl || !isSalesNavigatorLeadUrl(connectTargetUrl)) {
+      throw new Error(`Candidate ${candidate.fullName || 'unknown'} does not point to a Sales Navigator lead URL`);
     }
 
     if (
@@ -2509,8 +2523,16 @@ async function saveCandidateToListFromVisibleResults(page, candidate, listInfo, 
       await page.waitForTimeout(Math.max(180, settleMs)).catch(() => {});
       await waitForAnySelector(page, DEFAULT_SELECTORS.savePanelMarkers, 12000).catch(() => {});
 
-      const selected = await clickVisibleListRow(page, listInfo.listName);
-      if (selected) {
+      const rowOutcome = await clickVisibleListRow(page, listInfo.listName);
+      if (rowOutcome?.outcome === 'already_saved') {
+        await page.waitForTimeout(Math.max(180, settleMs)).catch(() => {});
+        return {
+          status: 'already_saved',
+          listName: listInfo.listName,
+          selectionMode: 'results_row_fallback',
+        };
+      }
+      if (rowOutcome?.outcome === 'clicked') {
         await page.waitForTimeout(Math.max(180, settleMs)).catch(() => {});
         return { status: 'saved', listName: listInfo.listName, selectionMode: 'results_row_fallback' };
       }
@@ -2629,6 +2651,37 @@ async function tryClickVisibleText(page, textValue) {
   return false;
 }
 
+async function evaluateSalesNavListRowSelected(locator) {
+  return locator.evaluate((element) => {
+    const normalize = (value) => String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+    const nodes = [element, ...element.querySelectorAll('*')];
+    return nodes.some((node) => {
+      if (!node || typeof node.getAttribute !== 'function') {
+        return false;
+      }
+      const ariaChecked = String(node.getAttribute('aria-checked') || '').toLowerCase();
+      const ariaSelected = String(node.getAttribute('aria-selected') || '').toLowerCase();
+      const ariaPressed = String(node.getAttribute('aria-pressed') || '').toLowerCase();
+      const ariaCurrent = String(node.getAttribute('aria-current') || '').toLowerCase();
+      if (ariaChecked === 'true' || ariaSelected === 'true' || ariaPressed === 'true' || ariaCurrent === 'true') {
+        return true;
+      }
+      if (node.tagName === 'INPUT' && node.checked) {
+        return true;
+      }
+      const className = String(node.className || '').toLowerCase();
+      if (/(selected|checked|is-selected)/.test(className) && !/(unselected|unchecked)/.test(className)) {
+        return true;
+      }
+      const label = normalize(node.getAttribute('aria-label') || '');
+      return label.includes('selected')
+        || label.includes('ausgewählt')
+        || label.includes('saved')
+        || label.includes('gespeichert');
+    });
+  }).catch(() => false);
+}
+
 async function clickVisibleListRow(page, listName) {
   const escaped = escapeRegex(listName);
   const exactAria = page.locator(`button[aria-label*="${listName}"]`);
@@ -2645,8 +2698,11 @@ async function clickVisibleListRow(page, listName) {
     if (combined.includes('create new list') || combined.includes('saved searches')) {
       continue;
     }
+    if (await evaluateSalesNavListRowSelected(locator)) {
+      return { outcome: 'already_saved', listName, selectionMode: 'existing_list' };
+    }
     await locator.click().catch(() => {});
-    return true;
+    return { outcome: 'clicked', listName, selectionMode: 'existing_list' };
   }
 
   const buttonByText = page.getByRole('button', {
@@ -2663,11 +2719,19 @@ async function clickVisibleListRow(page, listName) {
     if (!new RegExp(escaped, 'i').test(text || '')) {
       continue;
     }
+    const ariaSecond = await locator.getAttribute('aria-label').catch(() => '');
+    const combinedSecond = `${text || ''} ${ariaSecond || ''}`.toLowerCase();
+    if (combinedSecond.includes('create new list') || combinedSecond.includes('saved searches')) {
+      continue;
+    }
+    if (await evaluateSalesNavListRowSelected(locator)) {
+      return { outcome: 'already_saved', listName, selectionMode: 'existing_list' };
+    }
     await locator.click().catch(() => {});
-    return true;
+    return { outcome: 'clicked', listName, selectionMode: 'existing_list' };
   }
 
-  return false;
+  return null;
 }
 
 function jitteredWait(base) {

--- a/src/lib/live-readiness.js
+++ b/src/lib/live-readiness.js
@@ -5,8 +5,33 @@ function isSalesNavigatorLeadUrl(value) {
   if (!value || typeof value !== 'string') {
     return false;
   }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
 
-  return /^https:\/\/www\.linkedin\.com\/sales\/lead\/[^?\s]+/i.test(value.trim());
+  let parsed;
+  try {
+    const candidate = /^[a-z][a-z0-9+.-]*:/i.test(trimmed)
+      ? trimmed
+      : `https://${trimmed.replace(/^\/+/, '')}`;
+    parsed = new URL(candidate);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (host !== 'linkedin.com' && !host.endsWith('.linkedin.com')) {
+    return false;
+  }
+
+  const path = parsed.pathname.replace(/\/+$/, '');
+  const match = path.match(/^\/sales\/lead\/([^/]+)$/i);
+  return Boolean(match && match[1] && match[1].trim());
 }
 
 function inspectSalesforceSecretModel({ sourceMode = 'auto', sourcePath = null, env = process.env }) {

--- a/tests/browser-harness-driver.test.js
+++ b/tests/browser-harness-driver.test.js
@@ -109,6 +109,59 @@ test('browser harness driver retries a transient close-frame transport failure o
   assert.equal(health.state, 'authenticated');
 });
 
+test('browser harness saveCandidateToList rejects non-Sales-Navigator URLs before invoking the mutation harness', async () => {
+  const driver = new BrowserHarnessSalesNavigatorDriver({
+    allowMutations: true,
+    commandRunner({ args }) {
+      if (args?.[0] === '--help') {
+        return { status: 0, stdout: 'help', stderr: '' };
+      }
+      assert.fail('commandRunner must not run a mutation command when the candidate URL fails validation');
+    },
+  });
+
+  await driver.openSession({ runId: 'test', dryRun: false });
+
+  await assert.rejects(
+    () => driver.saveCandidateToList(
+      {
+        fullName: 'Wrong URL',
+        salesNavigatorUrl: 'https://www.linkedin.com/in/someone',
+        profileUrl: 'https://www.linkedin.com/in/someone',
+      },
+      { listName: 'Existing Test List' },
+      { dryRun: false },
+    ),
+    /does not point to a Sales Navigator lead URL/,
+  );
+});
+
+test('browser harness sendConnect rejects non-Sales-Navigator URLs before invoking the mutation harness', async () => {
+  const driver = new BrowserHarnessSalesNavigatorDriver({
+    allowMutations: true,
+    commandRunner({ args }) {
+      if (args?.[0] === '--help') {
+        return { status: 0, stdout: 'help', stderr: '' };
+      }
+      assert.fail('commandRunner must not run a mutation command when the candidate URL fails validation');
+    },
+  });
+
+  await driver.openSession({ runId: 'test', dryRun: false });
+
+  await assert.rejects(
+    () => driver.sendConnect(
+      {
+        fullName: 'Wrong URL',
+        salesNavigatorUrl: 'https://www.linkedin.com/search/results/people/foo',
+        profileUrl: 'https://www.linkedin.com/search/results/people/foo',
+      },
+      { dryRun: false },
+    ),
+    /does not point to a Sales Navigator lead URL/,
+  );
+});
+
 test('browser harness candidate collection has no implicit 8-result ceiling', async () => {
   class ManyCandidateHarnessDriver extends BrowserHarnessSalesNavigatorDriver {
     runHarnessJson() {

--- a/tests/fast-list-import.test.js
+++ b/tests/fast-list-import.test.js
@@ -49,6 +49,17 @@ test('parseMarkdownLeadRows extracts lead rows and LinkedIn URLs', () => {
   assert.equal(rows[0].publicLinkedInUrl, 'https://linkedin.com/in/thorsten');
 });
 
+test('parseMarkdownLeadRows classifies Sales Navigator lead URLs including query strings', () => {
+  const rows = parseMarkdownLeadRows(`
+| # | Name | LinkedIn |
+|---|---|---|
+| 1 | Lead One | [SN](https://www.linkedin.com/sales/lead/abc123?_ntb=1) |
+`);
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].salesNavigatorUrl, 'https://www.linkedin.com/sales/lead/abc123?_ntb=1');
+});
+
 test('resolveLeadsWithCoverage fills Sales Nav URLs by account and normalized name', () => {
   const coverageIndex = {
     byNameAndAccount: new Map([

--- a/tests/live-readiness.test.js
+++ b/tests/live-readiness.test.js
@@ -13,8 +13,19 @@ const {
 
 test('recognizes Sales Navigator lead URLs', () => {
   assert.equal(isSalesNavigatorLeadUrl('https://www.linkedin.com/sales/lead/ACwAAAZ123,NAME_SEARCH,abc'), true);
+  assert.equal(
+    isSalesNavigatorLeadUrl('https://www.linkedin.com/sales/lead/foo-bar?_ntb=1&trk=people-guest_'),
+    true,
+  );
+  assert.equal(isSalesNavigatorLeadUrl('https://de.linkedin.com/sales/lead/regional-lead'), true);
   assert.equal(isSalesNavigatorLeadUrl('https://www.linkedin.com/in/someone'), false);
+  assert.equal(isSalesNavigatorLeadUrl('https://www.linkedin.com/sales/search/people?keywords=a'), false);
+  assert.equal(isSalesNavigatorLeadUrl('https://www.linkedin.com/sales/company/12345'), false);
+  assert.equal(isSalesNavigatorLeadUrl('https://evil.example/phishing/www.linkedin.com/sales/lead/x'), false);
+  assert.equal(isSalesNavigatorLeadUrl('not a url'), false);
   assert.equal(isSalesNavigatorLeadUrl(''), false);
+  assert.equal(isSalesNavigatorLeadUrl(null), false);
+  assert.equal(isSalesNavigatorLeadUrl('http://www.linkedin.com/sales/lead/plain-http'), false);
 });
 
 test('flags file-based Salesforce secrets as blockers', () => {

--- a/tests/playwright-driver.test.js
+++ b/tests/playwright-driver.test.js
@@ -101,6 +101,45 @@ test('playwright driver defaults live connect pacing and spinner recovery guards
   assert.equal(driver.options.spinnerReloadWaitUntil, 'networkidle');
 });
 
+test('playwright saveCandidateToList rejects non-Sales-Navigator URLs before opening the candidate', async () => {
+  const driver = new PlaywrightSalesNavigatorDriver({ allowMutations: true });
+  driver.openCandidate = async () => {
+    assert.fail('openCandidate must not run when the candidate URL fails validation');
+  };
+
+  await assert.rejects(
+    () => driver.saveCandidateToList(
+      {
+        fullName: 'Wrong URL',
+        salesNavigatorUrl: 'https://www.linkedin.com/in/someone',
+        profileUrl: 'https://www.linkedin.com/in/someone',
+      },
+      { listName: 'Existing Test List' },
+      { dryRun: false },
+    ),
+    /does not point to a Sales Navigator lead URL/,
+  );
+});
+
+test('playwright sendConnect rejects non-Sales-Navigator URLs before opening the candidate', async () => {
+  const driver = new PlaywrightSalesNavigatorDriver({ allowMutations: true });
+  driver.openCandidate = async () => {
+    assert.fail('openCandidate must not run when the candidate URL fails validation');
+  };
+
+  await assert.rejects(
+    () => driver.sendConnect(
+      {
+        fullName: 'Wrong URL',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/search/people?keywords=wrong',
+        profileUrl: 'https://www.linkedin.com/sales/search/people?keywords=wrong',
+      },
+      { dryRun: false },
+    ),
+    /does not point to a Sales Navigator lead URL/,
+  );
+});
+
 test('checkSessionHealth reads login state without navigating away from the current page', async () => {
   const gotoCalls = [];
   const driver = new PlaywrightSalesNavigatorDriver({
@@ -406,6 +445,206 @@ test('playwright driver exports live-save helpers for current LinkedIn list flow
   assert.equal(typeof findSaveToListButton, 'function');
   assert.equal(typeof findListNameInput, 'function');
   assert.equal(typeof clickVisibleListRow, 'function');
+});
+
+function emptyLocator() {
+  return {
+    async count() {
+      return 0;
+    },
+    nth() {
+      return {
+        async isVisible() {
+          return false;
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Minimal page stub for save-panel list rows (aria-label match path in clickVisibleListRow).
+ * When alreadySelected is true, the row exposes aria-checked="true" like an active membership toggle.
+ */
+function createSavePanelListRowPage({ listName, alreadySelected }) {
+  const clicks = { listRow: 0 };
+  const ariaSelector = `button[aria-label*="${listName}"]`;
+
+  const rowNth = () => ({
+    async isVisible() {
+      return true;
+    },
+    async getAttribute(name) {
+      if (name === 'aria-label') {
+        return `${listName}`;
+      }
+      return '';
+    },
+    async innerText() {
+      return listName;
+    },
+    async click() {
+      clicks.listRow += 1;
+    },
+    async evaluate(fn) {
+      const el = {
+        tagName: 'BUTTON',
+        className: '',
+        getAttribute(name) {
+          if (alreadySelected && name === 'aria-checked') {
+            return 'true';
+          }
+          return '';
+        },
+        querySelectorAll: () => [],
+      };
+      return fn(el);
+    },
+  });
+
+  return {
+    clicks,
+    locator(selector) {
+      if (selector === ariaSelector) {
+        return {
+          async count() {
+            return 1;
+          },
+          nth: rowNth,
+        };
+      }
+      return emptyLocator();
+    },
+    getByRole() {
+      return emptyLocator();
+    },
+  };
+}
+
+/**
+ * Page stub that skips the aria-label button branch (count 0) so clickVisibleListRow uses
+ * getByRole('button', { name: /listName/i }) — matches LinkedIn rows labeled by visible text only.
+ */
+function createSavePanelListRowPageGetByRoleFallback({ listName, alreadySelected }) {
+  const clicks = { listRow: 0 };
+
+  const rowNth = () => ({
+    async isVisible() {
+      return true;
+    },
+    async getAttribute(name) {
+      if (name === 'aria-label') {
+        return '';
+      }
+      return '';
+    },
+    async innerText() {
+      return listName;
+    },
+    async click() {
+      clicks.listRow += 1;
+    },
+    async evaluate(fn) {
+      const el = {
+        tagName: 'BUTTON',
+        className: '',
+        getAttribute(name) {
+          if (alreadySelected && name === 'aria-checked') {
+            return 'true';
+          }
+          return '';
+        },
+        querySelectorAll: () => [],
+      };
+      return fn(el);
+    },
+  });
+
+  return {
+    clicks,
+    locator(selector) {
+      const ariaBranch = `button[aria-label*="${listName}"]`;
+      if (selector === ariaBranch) {
+        return emptyLocator();
+      }
+      return emptyLocator();
+    },
+    getByRole(role, options) {
+      assert.equal(role, 'button');
+      assert.ok(options?.name instanceof RegExp);
+      assert.ok(options.name.test(listName));
+      return {
+        async count() {
+          return 1;
+        },
+        nth: rowNth,
+      };
+    },
+  };
+}
+
+test('clickVisibleListRow does not click when list row is already selected (already_saved)', async () => {
+  const page = createSavePanelListRowPage({
+    listName: 'Enterprise Targets',
+    alreadySelected: true,
+  });
+
+  const result = await clickVisibleListRow(page, 'Enterprise Targets');
+
+  assert.deepEqual(result, {
+    outcome: 'already_saved',
+    listName: 'Enterprise Targets',
+    selectionMode: 'existing_list',
+  });
+  assert.equal(page.clicks.listRow, 0);
+});
+
+test('clickVisibleListRow clicks once when list row is not yet selected', async () => {
+  const page = createSavePanelListRowPage({
+    listName: 'Enterprise Targets',
+    alreadySelected: false,
+  });
+
+  const result = await clickVisibleListRow(page, 'Enterprise Targets');
+
+  assert.deepEqual(result, {
+    outcome: 'clicked',
+    listName: 'Enterprise Targets',
+    selectionMode: 'existing_list',
+  });
+  assert.equal(page.clicks.listRow, 1);
+});
+
+test('clickVisibleListRow getByRole fallback returns already_saved without clicking when row is selected', async () => {
+  const page = createSavePanelListRowPageGetByRoleFallback({
+    listName: 'Enterprise Targets',
+    alreadySelected: true,
+  });
+
+  const result = await clickVisibleListRow(page, 'Enterprise Targets');
+
+  assert.deepEqual(result, {
+    outcome: 'already_saved',
+    listName: 'Enterprise Targets',
+    selectionMode: 'existing_list',
+  });
+  assert.equal(page.clicks.listRow, 0);
+});
+
+test('clickVisibleListRow getByRole fallback clicks once and returns clicked when row is unselected', async () => {
+  const page = createSavePanelListRowPageGetByRoleFallback({
+    listName: 'Enterprise Targets',
+    alreadySelected: false,
+  });
+
+  const result = await clickVisibleListRow(page, 'Enterprise Targets');
+
+  assert.deepEqual(result, {
+    outcome: 'clicked',
+    listName: 'Enterprise Targets',
+    selectionMode: 'existing_list',
+  });
+  assert.equal(page.clicks.listRow, 1);
 });
 
 test('classifyLeadDetailSnapshot detects spinner-only lead shells', () => {


### PR DESCRIPTION
## Summary
- Adds a supervised multi-agent research-loop project plan for evolving the repo safely.
- Prevents Playwright Sales Navigator list-save flows from clicking already-selected list rows, avoiding accidental membership toggles/removals.
- Centralizes Sales Navigator lead URL validation across live mutation-adjacent paths.
- Adds regression coverage for already-saved list rows and invalid URL fail-closed behavior across Playwright, browser-harness, fast-list-import, and live-readiness.

## Safety / Guardrails
- Does not loosen `--live-save` or `--live-connect` requirements.
- Does not run live Sales Navigator save/connect commands.
- Keeps `runtime/`, `.env`, browser session/state, credentials, and local artifacts untouched.
- Invalid or non-lead LinkedIn URLs now fail closed before mutation paths proceed.

## Test Plan
- `node --test tests/live-readiness.test.js tests/browser-harness-driver.test.js tests/fast-list-import.test.js tests/playwright-driver.test.js`
- `npm run test:release-readiness`
- `npm test`

Final local result:
- `npm run test:release-readiness`: 28 pass / 0 fail
- `npm test`: 260 pass / 0 fail

## Notes
This PR covers Milestone 1 tasks M1-T1 and M1-T2 from `docs/plans/multi-agent-research-loop-project-plan.md`. Larger safety work such as company-scope fail-closed behavior should follow in separate scoped PRs.
