### PR TITLE
fix: fail closed on unverified browser-harness company scope

### DIFF
--- a/src/drivers/browser-harness-sales-nav.js
+++ b/src/drivers/browser-harness-sales-nav.js
@@ -83,22 +83,32 @@ wait_for_load()
   async openPeopleSearch(account) {
     const targetUrl = account.salesNav?.peopleSearchUrl || PEOPLE_SEARCH_URL;
     const filterTargets = buildCompanyFilterTargets(account);
+    if (filterTargets.length === 0) {
+      throw new Error(`No company filter targets available for people search scope verification for ${account.name || 'unknown account'}`);
+    }
     const targetList = pyStringArray(filterTargets);
 
-    this.runHarness(`
+    const scopeCheck = this.runHarnessJson(`
+import json
 new_tab(${pyString(targetUrl)})
 wait_for_load()
 targets = ${targetList}
+scoped = True
 if targets:
-    js(${pyString(`
+    scoped = bool(js(${pyString(`
 (() => {
   const normalize = (value) => (value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
   const targets = ${JSON.stringify(filterTargets)}.map(normalize).filter(Boolean);
   const text = normalize(document.body ? document.body.innerText : '');
   return targets.some((target) => text.includes(target));
 })()
-`)})
+`)}))
+print(json.dumps({"scoped": scoped, "targets": targets}))
 `);
+
+    if (!scopeCheck?.scoped) {
+      throw new Error(`Unable to scope people search to account filter for ${account.name || 'unknown account'}`);
+    }
   }
 
   async applySearchTemplate(template) {

--- a/tests/browser-harness-driver.test.js
+++ b/tests/browser-harness-driver.test.js
@@ -162,6 +162,54 @@ test('browser harness sendConnect rejects non-Sales-Navigator URLs before invoki
   );
 });
 
+test('browser harness openPeopleSearch fails closed when company scope cannot be verified', async () => {
+  const driver = new BrowserHarnessSalesNavigatorDriver({
+    allowMutations: false,
+    commandRunner({ args }) {
+      if (args?.[0] === '--help') {
+        return { status: 0, stdout: 'help', stderr: '' };
+      }
+      return {
+        status: 0,
+        stdout: `${JSON.stringify({ scoped: false, targets: ['Example Scoped Co'] })}\n`,
+        stderr: '',
+      };
+    },
+  });
+
+  await driver.openSession({ runId: 'test', dryRun: true });
+
+  await assert.rejects(
+    () => driver.openPeopleSearch({
+      name: 'Example Scoped Co',
+      salesNav: { peopleSearchUrl: 'https://www.linkedin.com/sales/search/people' },
+    }),
+    /Unable to scope people search to account filter for Example Scoped Co/,
+  );
+});
+
+test('browser harness openPeopleSearch fails closed when no company targets are available', async () => {
+  const driver = new BrowserHarnessSalesNavigatorDriver({
+    allowMutations: false,
+    commandRunner({ args }) {
+      if (args?.[0] === '--help') {
+        return { status: 0, stdout: 'help', stderr: '' };
+      }
+      assert.fail('commandRunner must not navigate an unscoped people search when no company targets exist');
+    },
+  });
+
+  await driver.openSession({ runId: 'test', dryRun: true });
+
+  await assert.rejects(
+    () => driver.openPeopleSearch({
+      name: '',
+      salesNav: { peopleSearchUrl: 'https://www.linkedin.com/sales/search/people' },
+    }),
+    /No company filter targets available for people search scope verification/,
+  );
+});
+
 test('browser harness candidate collection has no implicit 8-result ceiling', async () => {
   class ManyCandidateHarnessDriver extends BrowserHarnessSalesNavigatorDriver {
     runHarnessJson() {


### PR DESCRIPTION
## Summary
- Makes browser-harness people search fail closed when company scope cannot be verified.
- Rejects missing company filter targets before opening an unscoped Sales Navigator people search.
- Adds regression tests for unverified scope and no-target scope cases.

## Safety / Guardrails
- Does not loosen `--live-save` or `--live-connect` gates.
- Does not run live Sales Navigator save/connect commands.
- Prevents candidate collection from unverified/unscoped browser-harness people searches.
- Does not touch `runtime/`, `.env`, browser/session state, credentials, or local artifacts.

## Test Plan
- `node --test tests/browser-harness-driver.test.js`
- `npm run test:release-readiness`
- `npm test`

Final local result:
- Browser harness tests: 23 pass / 0 fail
- Release readiness: 28 pass / 0 fail
- Full suite: 262 pass / 0 fail

## Stacking note
This PR is stacked on #3 (`cursor/multi-agent-plan`) because it builds on the M1-T1/M1-T2 safety work. After #3 merges, this can be retargeted to `main` if needed.
