### PR TITLE
fix: block safe-save for manual-review identities

### DIFF
--- a/src/core/fast-list-import.js
+++ b/src/core/fast-list-import.js
@@ -373,7 +373,10 @@ function bucketFastResolveLead(lead, scoredCandidates = [], aliasTerms = []) {
   const sorted = [...scoredCandidates].sort((left, right) => right.score - left.score);
   const best = sorted[0] || null;
   const bestIsGuardedNameOnly = best?.queryPlanEntry?.guardedNameOnly || best?.guardedNameOnly;
+  const identityNeedsManualReview = Boolean(lead.identityResolution?.needsManualReview)
+    || (typeof lead.identityResolution?.confidence === 'number' && lead.identityResolution.confidence < 0.7);
   const safe = best
+    && !identityNeedsManualReview
     && best.exactName
     && (best.candidate.salesNavigatorUrl || best.candidate.profileUrl)
     && (
@@ -408,11 +411,13 @@ function bucketFastResolveLead(lead, scoredCandidates = [], aliasTerms = []) {
   const bucket = companyUnresolved || noCandidates || exactWrongCompany || hasOnlyOriginalAlias
     ? 'needs_company_alias_retry'
     : 'manual_review';
-  const evidence = companyUnresolved
-    ? 'company_unresolved'
-    : noCandidates && lead.identityResolution?.needsManualReview
-      ? 'identity_incomplete'
-      : bucket;
+  const evidence = identityNeedsManualReview
+    ? 'identity_manual_review'
+    : companyUnresolved
+      ? 'company_unresolved'
+      : noCandidates && lead.identityResolution?.needsManualReview
+        ? 'identity_incomplete'
+        : bucket;
   return {
     ...lead,
     salesNavigatorUrl: null,

--- a/tests/fast-list-import.test.js
+++ b/tests/fast-list-import.test.js
@@ -702,6 +702,35 @@ test('bucketFastResolveLead emits resolved_safe_to_save only for safe matches', 
   assert.equal(bucketed.resolutionStatus, 'resolved');
 });
 
+test('bucketFastResolveLead blocks manual-review identity from resolved_safe_to_save', () => {
+  const bucketed = bucketFastResolveLead({
+    fullName: 'T. Smith',
+    accountName: 'Example Account',
+    identityResolution: {
+      needsManualReview: true,
+      confidence: 0.35,
+      evidence: ['truncated_name_without_slug'],
+    },
+  }, [{
+    candidate: {
+      fullName: 'T. Smith',
+      company: 'Example Account',
+      salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/manual-identity',
+    },
+    score: 100,
+    exactName: true,
+    slugMatch: false,
+    companyMatch: true,
+    titleMatch: true,
+    additionalSignals: 3,
+  }], ['Example Account']);
+
+  assert.notEqual(bucketed.resolutionBucket, 'resolved_safe_to_save');
+  assert.equal(bucketed.resolutionStatus, 'unresolved');
+  assert.equal(bucketed.salesNavigatorUrl, null);
+  assert.equal(bucketed.resolutionEvidence, 'identity_manual_review');
+});
+
 test('bucketFastResolveLead sends same-name wrong-company matches to alias retry', () => {
   const bucketed = bucketFastResolveLead({
     fullName: 'Peter Cloud',


### PR DESCRIPTION
## Summary
- Blocks `resolved_safe_to_save` when lead identity is marked for manual review or has low identity confidence.
- Keeps identity-risk rows unresolved with `salesNavigatorUrl: null`, preventing accidental live-save eligibility.
- Adds regression coverage for manual-review identity inputs.

## Tests
- `node --test tests/fast-list-import.test.js`
- `npm run test:release-readiness`
- `npm test`

## Safety notes
- No live Sales Navigator actions were run.
- No credentials, runtime artifacts, or browser session data changed.
- Stacked on PR #4; merge order: #3 → #4 → this PR.
