### PR TITLE
fix: make grouped fast-resolve row keys collision safe

### DIFF
--- a/src/core/fast-list-import.js
+++ b/src/core/fast-list-import.js
@@ -741,6 +741,24 @@ function dedupeMergedImportLeads(leads = []) {
   return output;
 }
 
+function buildFastResolveLeadKey(lead = {}) {
+  const row = lead.row || lead.importSourceRow || '';
+  const url = normalizeLeadUrl(lead.salesNavigatorUrl || lead.profileUrl || lead.publicLinkedInUrl || '');
+  const fallback = [
+    normalizeLookupValue(lead.accountName || lead.company),
+    normalizeLookupValue(lead.fullName || lead.name),
+    normalizeLookupValue(lead.title || lead.titel),
+    normalizeLookupValue(lead.location || lead.standort),
+  ].filter(Boolean).join('::');
+  const parts = [
+    lead.importSourcePath || lead.sourcePath || '',
+    row ? `row:${row}` : '',
+    url ? `url:${url}` : '',
+    fallback ? `lead:${fallback}` : '',
+  ].filter(Boolean);
+  return parts.length ? parts.join('::') : null;
+}
+
 function loadFastListImportSource(sourcePath, options = {}) {
   const absolutePath = path.isAbsolute(sourcePath) ? sourcePath : path.resolve(sourcePath);
   const raw = fs.readFileSync(absolutePath, 'utf8');
@@ -1175,7 +1193,11 @@ async function fastResolveLeads({
         }));
         const bucketed = bucketFastResolveLead(prepared.leadForResolution, scored, prepared.aliasTerms);
         if (bucketed.resolutionBucket === 'resolved_safe_to_save') {
-          resolvedRows.set(prepared.lead.row || `${groupKey}:${prepared.lead.fullName}`, {
+          const leadKey = buildFastResolveLeadKey(prepared.lead);
+          if (!leadKey) {
+            continue;
+          }
+          resolvedRows.set(leadKey, {
             ...bucketed,
             resolutionPath: 'grouped_company_pool',
             resolutionEvidence: 'grouped_company_pool',
@@ -1228,7 +1250,7 @@ async function fastResolveLeads({
       continue;
     }
 
-    const groupedRow = groupedRows.get(lead.row || `${normalizeLookupValue(lead.accountName)}:${lead.fullName}`);
+    const groupedRow = groupedRows.get(buildFastResolveLeadKey(lead));
     if (groupedRow) {
       leads.push(groupedRow);
       if (typeof onProgress === 'function') {

--- a/tests/fast-list-import.test.js
+++ b/tests/fast-list-import.test.js
@@ -924,6 +924,71 @@ test('fastResolveLeads resolves multiple same-company leads from one grouped com
   assert.equal(artifact.leads.every((lead) => lead.resolutionPath === 'grouped_company_pool'), true);
 });
 
+test('fastResolveLeads keeps grouped rows collision-safe when source row ids repeat', async () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const sourcePath = path.join(os.tmpdir(), `fast-resolve-collision-${Date.now()}.json`);
+  fs.writeFileSync(sourcePath, JSON.stringify({
+    listName: 'Collision Test',
+    leads: [
+      {
+        row: 1,
+        accountName: 'Example Observability Co',
+        fullName: 'Alex Platform',
+        title: 'Platform Engineer',
+        publicLinkedInUrl: 'https://www.linkedin.com/in/alex-platform',
+      },
+      {
+        row: 1,
+        accountName: 'Example Observability Co',
+        fullName: 'Riley SRE',
+        title: 'SRE Manager',
+        publicLinkedInUrl: 'https://www.linkedin.com/in/riley-sre',
+      },
+    ],
+  }));
+  const driver = {
+    async openPeopleSearch() {},
+    async applySearchTemplate() {},
+    async scrollAndCollectCandidates(account, template) {
+      if (template.id !== 'fast-resolve-company-pool') {
+        return [];
+      }
+      return [
+        {
+          fullName: 'Alex Platform',
+          title: 'Platform Engineer',
+          company: 'Example Observability Co',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/alex-platform',
+        },
+        {
+          fullName: 'Riley SRE',
+          title: 'SRE Manager',
+          company: 'Example Observability Co',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/riley-sre',
+        },
+      ];
+    },
+  };
+
+  const artifact = await fastResolveLeads({
+    driver,
+    sourcePath,
+    searchTimeoutMs: 8000,
+  });
+
+  assert.equal(artifact.bucketCounts.resolved_safe_to_save, 2);
+  assert.equal(artifact.leads.filter((lead) => ['Alex Platform', 'Riley SRE'].includes(lead.fullName)).length, 2);
+  assert.deepEqual(
+    artifact.leads.map((lead) => lead.salesNavigatorUrl).sort(),
+    [
+      'https://www.linkedin.com/sales/lead/alex-platform',
+      'https://www.linkedin.com/sales/lead/riley-sre',
+    ],
+  );
+});
+
 test('fastResolveLeads uses slug name fallback and guarded name-only company retry', async () => {
   const calls = [];
   const driver = {


### PR DESCRIPTION
## Summary
- Makes grouped fast-resolve row keys collision-safe instead of relying on row id alone.
- Incorporates URL/identity signals so repeated source row ids cannot overwrite distinct grouped rows.
- Adds regression coverage for duplicate source row ids resolving through grouped company pool.

## Tests
- `node --test tests/fast-list-import.test.js`
- `npm run test:release-readiness`
- `npm test`

## Safety notes
- No live Sales Navigator actions were run.
- No credentials, runtime artifacts, or browser session data changed.
- Stacked on PR #5; merge order: #3 → #4 → #5 → this PR.
