### PR TITLE
feat: add dry-safe research loop planner

### DIFF
--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -11,6 +11,7 @@ const {
 const { summarizeCompanyResolutionArtifacts } = require('./company-resolution');
 const { summarizeCompanyResolutionRetryResults } = require('./company-resolution-retry');
 const { readLatestConnectEvidenceArtifact } = require('./connect-evidence');
+const { buildResearchLoopPlan } = require('./research-loop-planner');
 
 const FINAL_CONNECT_STATES = new Set([
   'sent',
@@ -397,8 +398,7 @@ function buildMvpAutoresearchArtifact({
   const connectEvidence = readLatestConnectEvidenceArtifact()?.artifact || null;
   const unresolvedAllSweepsFailures = getUnresolvedAllSweepsFailures({ background, companyResolutionRetries });
   const outcome = decideAutoresearchOutcome({ connect, background });
-
-  return {
+  const baseArtifact = {
     goal: 'supervised_mvp_release_candidate',
     generatedAt: now.toISOString(),
     hypothesis: 'Small dry-safe measurement loops harden release readiness without widening live LinkedIn mutation scope.',
@@ -432,6 +432,11 @@ function buildMvpAutoresearchArtifact({
       outcome,
       companyResolutionRetries,
     }),
+  };
+
+  return {
+    ...baseArtifact,
+    researchLoopPlan: buildResearchLoopPlan(baseArtifact, { generatedAt: now.toISOString() }),
   };
 }
 
@@ -565,6 +570,13 @@ function renderMvpAutoresearchMarkdown(artifact) {
   lines.push('## Safe Commands');
   for (const command of artifact.commands) {
     lines.push(`- \`${command}\``);
+  }
+  lines.push('');
+  lines.push('## Research Loop Plan');
+  lines.push(`- Version: \`${artifact.researchLoopPlan?.version || 'none'}\``);
+  lines.push(`- Dry safe: \`${artifact.researchLoopPlan?.drySafe ? 'yes' : 'no'}\``);
+  for (const step of artifact.researchLoopPlan?.steps || []) {
+    lines.push(`- \`${step.id}\` — ${escapeMarkdownCell(step.reason || '')}${step.command ? ` — \`${step.command}\`` : ' — manual gate only'}`);
   }
   lines.push('');
   lines.push('## Next Actions');

--- a/src/core/research-loop-planner.js
+++ b/src/core/research-loop-planner.js
@@ -1,0 +1,111 @@
+const PROHIBITED_MUTATION_FLAGS = /--live-save|--live-connect|allow-background-connects/i;
+
+function buildResearchLoopPlan(artifact = {}, { generatedAt = new Date().toISOString() } = {}) {
+  const steps = [];
+  const unresolvedFilterFailures = getUnresolvedAllSweepsFailures(artifact);
+  const environmentNextAction = artifact.background?.latestEnvironmentBlock?.environment?.nextAction || null;
+  const environmentCurrentlyBlocked = Boolean(environmentNextAction) && isEnvironmentBlockCurrent(artifact);
+
+  if (environmentCurrentlyBlocked) {
+    steps.push({
+      id: 'environment-check',
+      type: 'preflight',
+      command: 'npm run check-driver-session -- --driver=hybrid',
+      reason: environmentNextAction,
+      gate: 'operator_must_restore_browser_runtime_before_research',
+    });
+  }
+
+  if (unresolvedFilterFailures.length > 0) {
+    steps.push({
+      id: 'company-resolution-retry',
+      type: 'dry_cli',
+      command: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+      reason: 'unresolved_all_sweeps_failed_company_scope',
+      inputs: unresolvedFilterFailures.map((failure) => failure.accountName).filter(Boolean).slice(0, 10),
+      gate: 'review_retry_artifact_before_fast_resolve',
+    });
+  }
+
+  const remainingHealthyRuns = artifact.background?.runnerCoverageTarget?.healthyLiveAccountsRemaining || 0;
+  if (remainingHealthyRuns > 0 && !environmentCurrentlyBlocked) {
+    steps.push({
+      id: 'background-dry-run',
+      type: 'dry_cli',
+      command: 'node src/cli.js run-background-territory-loop --driver=hybrid --limit=1 --account-timeout-ms=180000',
+      reason: 'collect_more_healthy_background_runner_evidence',
+      targetRemaining: remainingHealthyRuns,
+      runnerTypeGaps: artifact.background?.runnerCoverageTarget?.notObservedTypes || [],
+      gate: 'inspect_background_runner_report_before_next_iteration',
+    });
+  }
+
+  const cooldownCandidates = artifact.background?.noisyCooldownCandidates || [];
+  if (cooldownCandidates.length > 0) {
+    steps.push({
+      id: 'operator-review',
+      type: 'manual_gate',
+      command: null,
+      reason: 'review_noisy_or_sparse_accounts_before_unattended_retry',
+      inputs: cooldownCandidates.map((candidate) => candidate.accountName).filter(Boolean).slice(0, 10),
+      gate: 'operator_marks_scope_or_cooldown_decision',
+    });
+  }
+
+  if (steps.length === 0) {
+    steps.push({
+      id: 'autoresearch-refresh',
+      type: 'dry_cli',
+      command: 'npm run autoresearch:mvp',
+      reason: 'refresh_dry_safe_autoresearch_evidence',
+      gate: 'inspect_autoresearch_report',
+    });
+  }
+
+  assertResearchLoopPlanDrySafe(steps);
+
+  return {
+    version: 1,
+    generatedAt,
+    sourceGeneratedAt: artifact.generatedAt || null,
+    drySafe: true,
+    prohibitedMutationFlags: ['--live-save', '--live-connect', '--allow-background-connects'],
+    steps,
+  };
+}
+
+function isEnvironmentBlockCurrent(artifact = {}) {
+  if (artifact.decision === 'blocked' || (artifact.background?.healthyLiveRuns || 0) <= 0) {
+    return true;
+  }
+  const blockedAt = Date.parse(artifact.background?.latestEnvironmentBlock?.processedAt || '');
+  const healthyAt = Date.parse(artifact.background?.latestHealthy?.processedAt || '');
+  if (Number.isFinite(blockedAt) && Number.isFinite(healthyAt)) {
+    return blockedAt > healthyAt;
+  }
+  return false;
+}
+
+function getUnresolvedAllSweepsFailures(artifact = {}) {
+  const recovered = new Set((artifact.companyResolutionRetries?.latestAccounts || [])
+    .filter((account) => account.resolutionRetryStatus === 'recovered')
+    .map((account) => String(account.accountName || '').toLowerCase()));
+  return (artifact.background?.accountLevelErrors || []).filter((error) => (
+    /all_sweeps_failed/i.test(error.coverageError || '')
+    && !recovered.has(String(error.accountName || '').toLowerCase())
+  ));
+}
+
+function assertResearchLoopPlanDrySafe(steps = []) {
+  const unsafe = steps
+    .map((step) => step.command || '')
+    .filter((command) => PROHIBITED_MUTATION_FLAGS.test(command));
+  if (unsafe.length > 0) {
+    throw new Error(`Research loop plan is not dry-safe: ${unsafe.join(', ')}`);
+  }
+}
+
+module.exports = {
+  assertResearchLoopPlanDrySafe,
+  buildResearchLoopPlan,
+};

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -14,6 +14,7 @@ const {
   renderMvpOperatorDashboard,
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
+const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
 
 function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
@@ -264,6 +265,141 @@ test('buildMvpAutoresearchArtifact surfaces repeated noisy accounts as cooldown 
   assert.equal(artifact.background.noisyCooldownCandidates[0].recommendedAction, 'cooldown_or_review_account_scope');
   assert.match(renderMvpOperatorDashboard(artifact), /Cooldown candidates: `1`/);
 });
+
+test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {
+  const artifact = {
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    decision: 'needs_followup',
+    nextActions: [
+      'continue_limit_1_or_2_background_dry_runs',
+      'resolve_company_targets_then_retry',
+      'do_not_run_live_save_or_live_connect_from_autoresearch',
+    ],
+    background: {
+      healthyLiveRuns: 4,
+      latestEnvironmentBlock: null,
+      runnerCoverageTarget: {
+        healthyLiveAccountsRemaining: 6,
+        notObservedTypes: ['mixed', 'sparse'],
+      },
+      accountLevelErrors: [
+        {
+          accountName: 'Filter Fail Co',
+          coverageError: 'all_sweeps_failed: Unable to scope people search',
+        },
+      ],
+      noisyCooldownCandidates: [
+        { accountName: 'Noisy Co', recommendedAction: 'cooldown_or_review_account_scope' },
+      ],
+    },
+    companyResolutionRetries: { latestAccounts: [] },
+  };
+
+  const plan = buildResearchLoopPlan(artifact, {
+    generatedAt: '2026-04-24T06:01:00.000Z',
+  });
+
+  assert.equal(plan.version, 1);
+  assert.equal(plan.drySafe, true);
+  assert.equal(plan.steps.length, 3);
+  assert.deepEqual(plan.steps.map((step) => step.id), [
+    'company-resolution-retry',
+    'background-dry-run',
+    'operator-review',
+  ]);
+  assert.match(plan.steps[0].command, /run-company-resolution-retries/);
+  assert.match(plan.steps[1].command, /run-background-territory-loop/);
+  assert.equal(plan.steps[2].command, null);
+  assert.doesNotMatch(plan.steps.map((step) => step.command || '').join(' '), /--live-save|--live-connect|allow-background-connects/i);
+});
+
+test('research loop planner ignores stale environment blocks after healthy evidence resumes', () => {
+  const plan = buildResearchLoopPlan({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    decision: 'needs_followup',
+    background: {
+      healthyLiveRuns: 2,
+      latestEnvironmentBlock: {
+        environment: { nextAction: 'allow_browser_runtime_then_retry' },
+      },
+      runnerCoverageTarget: {
+        healthyLiveAccountsRemaining: 8,
+        notObservedTypes: ['mixed'],
+      },
+      accountLevelErrors: [],
+      noisyCooldownCandidates: [],
+    },
+    companyResolutionRetries: { latestAccounts: [] },
+  }, {
+    generatedAt: '2026-04-24T06:01:00.000Z',
+  });
+
+  assert.equal(plan.steps.some((step) => step.id === 'environment-check'), false);
+  assert.equal(plan.steps.some((step) => step.id === 'background-dry-run'), true);
+});
+
+test('research loop planner prioritizes environment check when latest block is newer than healthy evidence', () => {
+  const plan = buildResearchLoopPlan({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    decision: 'needs_followup',
+    background: {
+      healthyLiveRuns: 2,
+      latestHealthy: { processedAt: '2026-04-24T05:00:00.000Z' },
+      latestEnvironmentBlock: {
+        processedAt: '2026-04-24T06:00:00.000Z',
+        environment: { nextAction: 'restart_browser_harness_then_retry' },
+      },
+      runnerCoverageTarget: {
+        healthyLiveAccountsRemaining: 8,
+        notObservedTypes: ['mixed'],
+      },
+      accountLevelErrors: [],
+      noisyCooldownCandidates: [],
+    },
+    companyResolutionRetries: { latestAccounts: [] },
+  }, {
+    generatedAt: '2026-04-24T06:01:00.000Z',
+  });
+
+  assert.equal(plan.steps[0].id, 'environment-check');
+  assert.equal(plan.steps.some((step) => step.id === 'background-dry-run'), false);
+});
+
+test('buildMvpAutoresearchArtifact includes a dry-safe research loop plan in JSON and Markdown', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mvp-autoresearch-plan-'));
+  const acceptancePath = path.join(tempDir, 'acceptance.json');
+  const backgroundDir = path.join(tempDir, 'background');
+  fs.mkdirSync(backgroundDir);
+  makeAcceptanceArtifact(acceptancePath);
+  makeBackgroundArtifact(path.join(backgroundDir, 'example-loop-1.json'), {
+    status: 'completed',
+    environment: { ok: true, state: 'healthy', sessionCheckSkipped: false },
+    metrics: { accountsAttempted: 1, productiveAccounts: 1 },
+    results: [
+      {
+        accountName: 'Filter Fail Co',
+        coverageStatus: 'live',
+        coverageError: 'all_sweeps_failed: Unable to scope people search',
+        candidateCount: 0,
+        listCandidateCount: 0,
+        productivity: { classification: 'noisy' },
+      },
+    ],
+  });
+
+  const artifact = buildMvpAutoresearchArtifact({
+    now: new Date('2026-04-24T06:00:00.000Z'),
+    acceptanceArtifactPath: acceptancePath,
+    backgroundArtifactsDir: backgroundDir,
+  });
+  const markdown = renderMvpAutoresearchMarkdown(artifact);
+
+  assert.equal(artifact.researchLoopPlan.drySafe, true);
+  assert.equal(artifact.researchLoopPlan.steps[0].id, 'company-resolution-retry');
+  assert.match(markdown, /## Research Loop Plan/);
+  assert.match(markdown, /company-resolution-retry/);
+});
+
 
 test('writeMvpAutoresearchRun writes JSON and Markdown reports', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mvp-autoresearch-write-'));


### PR DESCRIPTION
## Summary
- Adds a deterministic, dry-safe research-loop planner that turns autoresearch evidence into a CLI DAG.
- Includes `researchLoopPlan` in autoresearch JSON artifacts and Markdown reports.
- Handles unresolved company-scope failures, background dry-run evidence gaps, noisy cooldown review gates, and active environment blocks.
- Uses latest environment block vs latest healthy evidence recency so stale historical blocks do not suppress valid dry-runs.

## Tests
- `node --test tests/autoresearch-mvp.test.js`
- `npm run test:release-readiness`
- `npm test`
- `git diff --check`

## Safety notes
- Planner commands are dry-safe and reject `--live-save`, `--live-connect`, and `allow-background-connects`.
- No live Sales Navigator actions were run.
- No credentials, runtime artifacts, or browser session data changed.
- Stacked on PR #6; merge order: #3 → #4 → #5 → #6 → this PR.
