### PR TITLE
feat: add dry-safe research evaluation metrics

### DIFF
--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -3,8 +3,8 @@ const path = require('node:path');
 const { readJson, writeJson } = require('../lib/json');
 const {
   AUTORESEARCH_ARTIFACTS_DIR,
-  BACKGROUND_RUNNER_ARTIFACTS_DIR,
   ACCOUNT_BATCH_ARTIFACTS_DIR,
+  BACKGROUND_RUNNER_ARTIFACTS_DIR,
   ensureDir,
   resolveProjectPath,
 } = require('../lib/paths');
@@ -12,6 +12,7 @@ const { summarizeCompanyResolutionArtifacts } = require('./company-resolution');
 const { summarizeCompanyResolutionRetryResults } = require('./company-resolution-retry');
 const { readLatestConnectEvidenceArtifact } = require('./connect-evidence');
 const { buildResearchLoopPlan } = require('./research-loop-planner');
+const { buildResearchEvaluationMetrics } = require('./research-evaluation-metrics');
 
 const FINAL_CONNECT_STATES = new Set([
   'sent',
@@ -103,6 +104,23 @@ function readJsonIfExists(filePath) {
     return null;
   }
   return readJson(filePath);
+}
+
+function readLatestFastResolveArtifacts(artifactsDir = ACCOUNT_BATCH_ARTIFACTS_DIR, limit = 5) {
+  if (!artifactsDir || !fs.existsSync(artifactsDir)) {
+    return [];
+  }
+  return fs.readdirSync(artifactsDir)
+    .filter((fileName) => /fast-resolve.+\.json$/i.test(fileName))
+    .map((fileName) => {
+      const filePath = path.join(artifactsDir, fileName);
+      const stat = fs.statSync(filePath);
+      return { filePath, mtimeMs: stat.mtimeMs };
+    })
+    .sort((left, right) => right.mtimeMs - left.mtimeMs)
+    .slice(0, limit)
+    .map((entry) => readJsonIfExists(entry.filePath))
+    .filter(Boolean);
 }
 
 function summarizeConnectShapes(acceptanceArtifact, evidencePath = DEFAULT_ACCEPTANCE_ARTIFACT) {
@@ -388,6 +406,7 @@ function buildMvpAutoresearchArtifact({
   now = new Date(),
   acceptanceArtifactPath = DEFAULT_ACCEPTANCE_ARTIFACT,
   backgroundArtifactsDir = BACKGROUND_RUNNER_ARTIFACTS_DIR,
+  fastResolveArtifactsDir = ACCOUNT_BATCH_ARTIFACTS_DIR,
 } = {}) {
   assertDrySafeCommands(SAFE_EVAL_COMMANDS);
   const acceptanceArtifact = readJsonIfExists(acceptanceArtifactPath);
@@ -398,6 +417,11 @@ function buildMvpAutoresearchArtifact({
   const connectEvidence = readLatestConnectEvidenceArtifact()?.artifact || null;
   const unresolvedAllSweepsFailures = getUnresolvedAllSweepsFailures({ background, companyResolutionRetries });
   const outcome = decideAutoresearchOutcome({ connect, background });
+  const evaluationMetrics = buildResearchEvaluationMetrics({
+    fastResolveArtifacts: readLatestFastResolveArtifacts(fastResolveArtifactsDir),
+    background,
+    companyResolution,
+  });
   const baseArtifact = {
     goal: 'supervised_mvp_release_candidate',
     generatedAt: now.toISOString(),
@@ -426,6 +450,7 @@ function buildMvpAutoresearchArtifact({
       ].filter((value, index, all) => all.indexOf(value) === index),
     },
     companyResolutionRetries,
+    evaluationMetrics,
     nextActions: buildAutoresearchNextActions({
       connect,
       background,
@@ -571,6 +596,14 @@ function renderMvpAutoresearchMarkdown(artifact) {
   for (const command of artifact.commands) {
     lines.push(`- \`${command}\``);
   }
+  lines.push('');
+  lines.push('## Evaluation Metrics');
+  lines.push(`- Risk level: \`${artifact.evaluationMetrics?.overall?.riskLevel || 'unknown'}\``);
+  lines.push(`- Fast manual review rate: \`${artifact.evaluationMetrics?.fastResolve?.manualReviewRate ?? 0}\``);
+  lines.push(`- Fast duplicate rate: \`${artifact.evaluationMetrics?.fastResolve?.duplicateRate ?? 0}\``);
+  lines.push(`- Background noise rate: \`${artifact.evaluationMetrics?.background?.noiseRate ?? 0}\``);
+  lines.push(`- Company alias disagreement rate: \`${artifact.evaluationMetrics?.companyResolution?.aliasDisagreementRate ?? 0}\``);
+  lines.push(`- Indicators: \`${artifact.evaluationMetrics?.overall?.indicators?.join(', ') || 'none'}\``);
   lines.push('');
   lines.push('## Research Loop Plan');
   lines.push(`- Version: \`${artifact.researchLoopPlan?.version || 'none'}\``);

--- a/src/core/research-evaluation-metrics.js
+++ b/src/core/research-evaluation-metrics.js
@@ -1,0 +1,178 @@
+function buildResearchEvaluationMetrics({
+  fastResolveArtifacts = [],
+  background = {},
+  companyResolution = {},
+} = {}) {
+  const fastResolve = summarizeFastResolveMetrics(fastResolveArtifacts);
+  const backgroundMetrics = summarizeBackgroundMetrics(background);
+  const companyResolutionMetrics = summarizeCompanyResolutionMetrics(companyResolution);
+  const riskLevel = classifyResearchRisk({
+    fastResolve,
+    background: backgroundMetrics,
+    companyResolution: companyResolutionMetrics,
+  });
+
+  return {
+    drySafe: true,
+    version: 1,
+    fastResolve,
+    background: backgroundMetrics,
+    companyResolution: companyResolutionMetrics,
+    overall: {
+      riskLevel,
+      indicators: buildRiskIndicators({
+        fastResolve,
+        background: backgroundMetrics,
+        companyResolution: companyResolutionMetrics,
+      }),
+    },
+  };
+}
+
+function summarizeFastResolveMetrics(artifacts = []) {
+  const leads = artifacts.flatMap((artifact) => Array.isArray(artifact?.leads) ? artifact.leads : []);
+  const totalLeads = leads.length;
+  const manualReview = countBucket(leads, 'manual_review') || sumBucketCounts(artifacts, 'manual_review');
+  const companyAliasRetry = countBucket(leads, 'needs_company_alias_retry') || sumBucketCounts(artifacts, 'needs_company_alias_retry');
+  const resolvedSafeToSave = countBucket(leads, 'resolved_safe_to_save') || sumBucketCounts(artifacts, 'resolved_safe_to_save');
+  const resolvedViaAliasResearch = countBucket(leads, 'resolved_via_alias_research') || sumBucketCounts(artifacts, 'resolved_via_alias_research');
+  const duplicateUrls = countDuplicateUrls(leads);
+
+  return {
+    totalArtifacts: artifacts.length,
+    totalLeads,
+    resolvedSafeToSave,
+    resolvedViaAliasResearch,
+    manualReview,
+    companyAliasRetry,
+    duplicateUrls,
+    manualReviewRate: ratio(manualReview, totalLeads),
+    companyAliasRetryRate: ratio(companyAliasRetry, totalLeads),
+    duplicateRate: ratio(duplicateUrls, totalLeads),
+  };
+}
+
+function summarizeBackgroundMetrics(background = {}) {
+  const buckets = background.runnerCoverageByType || {};
+  const productive = countRunnerBucket(buckets, 'productive');
+  const mixed = countRunnerBucket(buckets, 'mixed');
+  const sparse = countRunnerBucket(buckets, 'sparse');
+  const noisy = countRunnerBucket(buckets, 'noisy');
+  const allSweepsFailed = countRunnerBucket(buckets, 'all_sweeps_failed');
+  const timedOut = countRunnerBucket(buckets, 'timed_out');
+  const totalClassified = productive + mixed + sparse + noisy;
+  const noisyOrSparse = noisy + sparse;
+
+  return {
+    productive,
+    mixed,
+    sparse,
+    noisy,
+    allSweepsFailed,
+    timedOut,
+    totalClassified,
+    noisyOrSparse,
+    noiseRate: ratio(noisyOrSparse, totalClassified),
+    allSweepsFailedRate: ratio(allSweepsFailed, Math.max(1, totalClassified + allSweepsFailed)),
+  };
+}
+
+function summarizeCompanyResolutionMetrics(companyResolution = {}) {
+  const total = Number(companyResolution.total || 0);
+  const needsManualReview = Number(companyResolution.needsManualReview || 0);
+  const failed = Number(companyResolution.failed || 0);
+  const multiTarget = Number(companyResolution.multiTarget || 0);
+  const aliasDisagreements = needsManualReview + failed + multiTarget;
+  return {
+    total,
+    needsManualReview,
+    failed,
+    multiTarget,
+    aliasDisagreements,
+    aliasDisagreementRate: ratio(aliasDisagreements, total),
+  };
+}
+
+function countBucket(leads, bucket) {
+  return leads.filter((lead) => lead.resolutionBucket === bucket).length;
+}
+
+function sumBucketCounts(artifacts, bucket) {
+  return artifacts.reduce((sum, artifact) => sum + Number(artifact?.bucketCounts?.[bucket] || 0), 0);
+}
+
+function countDuplicateUrls(leads) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const lead of leads) {
+    const url = normalizeUrl(lead.salesNavigatorUrl || lead.profileUrl || '');
+    if (!url) {
+      continue;
+    }
+    if (seen.has(url)) {
+      duplicates.add(url);
+      continue;
+    }
+    seen.add(url);
+  }
+  return duplicates.size;
+}
+
+function countRunnerBucket(buckets, key) {
+  return Number(buckets?.[key]?.count || 0);
+}
+
+function normalizeUrl(value) {
+  return String(value || '').trim().replace(/\?.*$/, '').replace(/\/$/, '').toLowerCase();
+}
+
+function ratio(numerator, denominator) {
+  if (!denominator) {
+    return 0;
+  }
+  return Number((numerator / denominator).toFixed(4));
+}
+
+function classifyResearchRisk({ fastResolve, background, companyResolution }) {
+  const high = fastResolve.manualReviewRate >= 0.4
+    || fastResolve.duplicateRate >= 0.4
+    || companyResolution.aliasDisagreementRate >= 0.75
+    || background.noiseRate >= 0.75;
+  if (high) {
+    return 'high';
+  }
+  const medium = fastResolve.manualReviewRate >= 0.2
+    || fastResolve.duplicateRate > 0
+    || fastResolve.companyAliasRetryRate >= 0.2
+    || companyResolution.aliasDisagreementRate >= 0.3
+    || background.noiseRate >= 0.3
+    || background.allSweepsFailed > 0;
+  return medium ? 'medium' : 'low';
+}
+
+function buildRiskIndicators({ fastResolve, background, companyResolution }) {
+  const indicators = [];
+  if (fastResolve.manualReviewRate >= 0.2) {
+    indicators.push('fast_resolve_manual_review_rate');
+  }
+  if (fastResolve.duplicateRate > 0) {
+    indicators.push('duplicate_sales_nav_urls');
+  }
+  if (fastResolve.companyAliasRetryRate >= 0.2) {
+    indicators.push('company_alias_retry_rate');
+  }
+  if (companyResolution.aliasDisagreementRate >= 0.3) {
+    indicators.push('company_alias_disagreement_rate');
+  }
+  if (background.noiseRate >= 0.3) {
+    indicators.push('background_noise_rate');
+  }
+  if (background.allSweepsFailed > 0) {
+    indicators.push('all_sweeps_failed_present');
+  }
+  return indicators;
+}
+
+module.exports = {
+  buildResearchEvaluationMetrics,
+};

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -15,6 +15,7 @@ const {
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
+const { buildResearchEvaluationMetrics } = require('../src/core/research-evaluation-metrics');
 
 function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
@@ -264,6 +265,90 @@ test('buildMvpAutoresearchArtifact surfaces repeated noisy accounts as cooldown 
   assert.equal(artifact.background.noisyCooldownCandidates[0].noisyRuns, 2);
   assert.equal(artifact.background.noisyCooldownCandidates[0].recommendedAction, 'cooldown_or_review_account_scope');
   assert.match(renderMvpOperatorDashboard(artifact), /Cooldown candidates: `1`/);
+});
+
+test('research evaluation metrics compute manual review, duplicate, alias disagreement, and noise rates', () => {
+  const metrics = buildResearchEvaluationMetrics({
+    fastResolveArtifacts: [{
+      leads: [
+        { fullName: 'Ada', salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/ada', resolutionBucket: 'resolved_safe_to_save' },
+        { fullName: 'Ada Duplicate', salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/ada', resolutionBucket: 'resolved_safe_to_save' },
+        { fullName: 'Manual', resolutionBucket: 'manual_review' },
+        { fullName: 'Alias', resolutionBucket: 'needs_company_alias_retry' },
+      ],
+      bucketCounts: {
+        resolved_safe_to_save: 2,
+        manual_review: 1,
+        needs_company_alias_retry: 1,
+      },
+    }],
+    background: {
+      runnerCoverageByType: {
+        productive: { count: 2 },
+        noisy: { count: 1 },
+        sparse: { count: 1 },
+        all_sweeps_failed: { count: 1 },
+      },
+    },
+    companyResolution: {
+      total: 5,
+      needsManualReview: 1,
+      failed: 1,
+      multiTarget: 1,
+    },
+  });
+
+  assert.equal(metrics.fastResolve.totalLeads, 4);
+  assert.equal(metrics.fastResolve.manualReviewRate, 0.25);
+  assert.equal(metrics.fastResolve.duplicateRate, 0.25);
+  assert.equal(metrics.fastResolve.companyAliasRetryRate, 0.25);
+  assert.equal(metrics.companyResolution.aliasDisagreementRate, 0.6);
+  assert.equal(metrics.background.noiseRate, 0.5);
+  assert.equal(metrics.overall.riskLevel, 'medium');
+});
+
+test('buildMvpAutoresearchArtifact includes evaluation metrics in JSON and Markdown', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mvp-autoresearch-metrics-'));
+  const acceptancePath = path.join(tempDir, 'acceptance.json');
+  const backgroundDir = path.join(tempDir, 'background');
+  const fastResolveDir = path.join(tempDir, 'account-batches');
+  fs.mkdirSync(backgroundDir);
+  fs.mkdirSync(fastResolveDir);
+  writeJson(path.join(fastResolveDir, 'example-fast-resolve-2026.json'), {
+    leads: [
+      { fullName: 'Manual', resolutionBucket: 'manual_review' },
+      { fullName: 'Safe', salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/safe', resolutionBucket: 'resolved_safe_to_save' },
+    ],
+  });
+  makeAcceptanceArtifact(acceptancePath);
+  makeBackgroundArtifact(path.join(backgroundDir, 'example-loop-1.json'), {
+    status: 'completed',
+    environment: { ok: true, state: 'healthy', sessionCheckSkipped: false },
+    metrics: { accountsAttempted: 1, productiveAccounts: 1 },
+    results: [
+      {
+        accountName: 'Noisy Co',
+        coverageStatus: 'live',
+        candidateCount: 2,
+        listCandidateCount: 0,
+        productivity: { classification: 'noisy' },
+      },
+    ],
+  });
+
+  const artifact = buildMvpAutoresearchArtifact({
+    now: new Date('2026-04-24T06:00:00.000Z'),
+    acceptanceArtifactPath: acceptancePath,
+    backgroundArtifactsDir: backgroundDir,
+    fastResolveArtifactsDir: fastResolveDir,
+  });
+  const markdown = renderMvpAutoresearchMarkdown(artifact);
+
+  assert.equal(artifact.evaluationMetrics.drySafe, true);
+  assert.equal(artifact.evaluationMetrics.fastResolve.manualReviewRate, 0.5);
+  assert.equal(typeof artifact.evaluationMetrics.background.noiseRate, 'number');
+  assert.match(markdown, /## Evaluation Metrics/);
+  assert.match(markdown, /Risk level:/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {


### PR DESCRIPTION
## Summary
- Adds dry-safe research evaluation metrics for fast-resolve, background runner, and company-resolution quality.
- Reports manual-review rate, duplicate Sales Nav URL rate, company-alias retry/disagreement rates, background noise/all-sweeps rates, and overall risk indicators.
- Integrates `evaluationMetrics` into autoresearch JSON artifacts and Markdown reports.
- Reads recent fast-resolve artifacts from account-batch artifacts so integrated metrics are not always zero.

## Tests
- `node --test tests/autoresearch-mvp.test.js`
- `npm run test:release-readiness`
- `npm test`
- `git diff --check`

## Safety notes
- Metrics are read-only and dry-safe.
- No live Sales Navigator actions were run.
- No credentials, runtime artifacts, or browser session data changed.
- Stacked on PR #7; merge order: #3 → #4 → #5 → #6 → #7 → this PR.
