### PR TITLE
feat: add research execution gate

### DIFF
--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -13,6 +13,7 @@ const { summarizeCompanyResolutionRetryResults } = require('./company-resolution
 const { readLatestConnectEvidenceArtifact } = require('./connect-evidence');
 const { buildResearchLoopPlan } = require('./research-loop-planner');
 const { buildResearchEvaluationMetrics } = require('./research-evaluation-metrics');
+const { buildResearchExecutionGate } = require('./research-execution-gate');
 
 const FINAL_CONNECT_STATES = new Set([
   'sent',
@@ -459,9 +460,18 @@ function buildMvpAutoresearchArtifact({
     }),
   };
 
+  const researchLoopPlan = buildResearchLoopPlan(baseArtifact, { generatedAt: now.toISOString() });
+  const executionGate = buildResearchExecutionGate({
+    researchLoopPlan,
+    evaluationMetrics,
+    mutationReview: null,
+    generatedAt: now.toISOString(),
+  });
+
   return {
     ...baseArtifact,
-    researchLoopPlan: buildResearchLoopPlan(baseArtifact, { generatedAt: now.toISOString() }),
+    researchLoopPlan,
+    executionGate,
   };
 }
 
@@ -604,6 +614,13 @@ function renderMvpAutoresearchMarkdown(artifact) {
   lines.push(`- Background noise rate: \`${artifact.evaluationMetrics?.background?.noiseRate ?? 0}\``);
   lines.push(`- Company alias disagreement rate: \`${artifact.evaluationMetrics?.companyResolution?.aliasDisagreementRate ?? 0}\``);
   lines.push(`- Indicators: \`${artifact.evaluationMetrics?.overall?.indicators?.join(', ') || 'none'}\``);
+  lines.push('');
+  lines.push('## Execution Gate');
+  lines.push(`- Decision: \`${artifact.executionGate?.decision || 'unknown'}\``);
+  lines.push(`- Live save eligible: \`${artifact.executionGate?.liveSaveEligible ? 'yes' : 'no'}\``);
+  lines.push(`- Risk level: \`${artifact.executionGate?.riskLevel || 'unknown'}\``);
+  lines.push(`- Reasons: \`${artifact.executionGate?.reasons?.join(', ') || 'none'}\``);
+  lines.push(`- Allowed command template: \`${artifact.executionGate?.allowedCommandTemplate || 'none'}\``);
   lines.push('');
   lines.push('## Research Loop Plan');
   lines.push(`- Version: \`${artifact.researchLoopPlan?.version || 'none'}\``);

--- a/src/core/research-execution-gate.js
+++ b/src/core/research-execution-gate.js
@@ -1,0 +1,162 @@
+const PROHIBITED_BACKGROUND_FLAGS = /--live-connect|allow-background-connects/i;
+const IMPLICIT_LIVE_MUTATION_COMMANDS = /\b(?:pilot-live-save-batch|test-list-save|remove-lead-list-members)\b/i;
+
+function buildResearchExecutionGate({
+  researchLoopPlan = null,
+  evaluationMetrics = null,
+  mutationReview = null,
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const reasons = [];
+  const planSteps = Array.isArray(researchLoopPlan?.steps) ? researchLoopPlan.steps : [];
+  const riskLevel = evaluationMetrics?.overall?.riskLevel || 'unknown';
+  const reviewSummary = mutationReview?.summary || null;
+
+  if (researchLoopPlan?.drySafe !== true) {
+    reasons.push('research_loop_plan_missing_or_not_dry_safe');
+  }
+  if (evaluationMetrics?.drySafe !== true) {
+    reasons.push('evaluation_metrics_missing_or_not_dry_safe');
+  }
+  if (!mutationReview) {
+    reasons.push('mutation_review_artifact_missing');
+  } else if (mutationReview.drySafe !== true) {
+    reasons.push('mutation_review_artifact_not_dry_safe');
+  }
+
+  const hasCompanyResolutionBlocker = planSteps.some((step) => step.id === 'company-resolution-retry');
+  if (hasCompanyResolutionBlocker) {
+    reasons.push('company_resolution_retry_pending');
+  }
+
+  const hasEnvironmentBlocker = planSteps.some((step) => step.id === 'environment-check');
+  if (hasEnvironmentBlocker) {
+    reasons.push('environment_check_pending');
+  }
+
+  if (riskLevel === 'high') {
+    reasons.push('high_research_risk');
+  } else if (riskLevel === 'medium') {
+    reasons.push('medium_research_risk_requires_operator_review');
+  } else if (riskLevel === 'unknown') {
+    reasons.push('research_risk_unknown');
+  }
+
+  if (reviewSummary) {
+    if ((reviewSummary.intendedAdds || 0) <= 0) {
+      reasons.push('no_intended_adds_to_save');
+    }
+    if ((reviewSummary.exclusions || 0) > 0) {
+      reasons.push('mutation_review_has_exclusions');
+    }
+    if ((reviewSummary.duplicateWarnings || 0) > 0) {
+      reasons.push('mutation_review_has_duplicate_warnings');
+    }
+  }
+
+  const decision = chooseGateDecision({
+    reasons,
+    hasCompanyResolutionBlocker,
+    hasEnvironmentBlocker,
+    riskLevel,
+    reviewSummary,
+    mutationReview,
+  });
+
+  const allowedCommandTemplate = decision === 'eligible_for_live_save'
+    ? 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save'
+    : getDrySafeCommandTemplate(planSteps);
+
+  assertGatePlanCommandsSafe(decision, planSteps);
+  assertGateCommandSafe(decision, allowedCommandTemplate);
+
+  return {
+    version: 1,
+    generatedAt,
+    drySafe: true,
+    decision,
+    liveSaveEligible: decision === 'eligible_for_live_save',
+    requiresOperatorApproval: ['requires_operator_review', 'eligible_for_live_save'].includes(decision),
+    riskLevel,
+    reasons,
+    allowedCommandTemplate,
+    checkpoints: buildGateCheckpoints({ decision, reviewSummary, riskLevel }),
+  };
+}
+
+function chooseGateDecision({
+  reasons,
+  hasCompanyResolutionBlocker,
+  hasEnvironmentBlocker,
+  riskLevel,
+  reviewSummary,
+  mutationReview,
+}) {
+  if (hasCompanyResolutionBlocker) {
+    return 'blocked_until_company_resolution';
+  }
+  if (hasEnvironmentBlocker || riskLevel === 'high' || !mutationReview) {
+    return 'allow_dry_run_only';
+  }
+  if (
+    riskLevel !== 'low'
+    || mutationReview.drySafe !== true
+    || !reviewSummary
+    || (reviewSummary.intendedAdds || 0) <= 0
+    || (reviewSummary.exclusions || 0) > 0
+    || (reviewSummary.duplicateWarnings || 0) > 0
+    || reasons.includes('research_loop_plan_missing_or_not_dry_safe')
+    || reasons.includes('evaluation_metrics_missing_or_not_dry_safe')
+  ) {
+    return 'requires_operator_review';
+  }
+  return 'eligible_for_live_save';
+}
+
+function getDrySafeCommandTemplate(planSteps = []) {
+  const firstDryStep = planSteps.find((step) => step.command && step.type !== 'manual_gate');
+  return firstDryStep?.command || 'npm run autoresearch:mvp';
+}
+
+function buildGateCheckpoints({ decision, reviewSummary, riskLevel }) {
+  const checkpoints = [
+    'confirm_no_live_connect_or_background_connect_flags',
+    'confirm_sales_navigator_urls_are_valid_lead_urls',
+    'confirm_company_scope_and_identity_evidence_are_current',
+  ];
+  if (decision !== 'eligible_for_live_save') {
+    checkpoints.push('do_not_run_live_save_until_gate_is_eligible');
+  } else {
+    checkpoints.push('operator_confirms_mutation_review_before_live_save');
+  }
+  if (riskLevel !== 'low') {
+    checkpoints.push('resolve_or_accept_metric_risk_before_live_save');
+  }
+  if ((reviewSummary?.exclusions || 0) > 0 || (reviewSummary?.duplicateWarnings || 0) > 0) {
+    checkpoints.push('review_exclusions_and_duplicate_warnings');
+  }
+  return checkpoints;
+}
+
+function assertGatePlanCommandsSafe(decision, planSteps = []) {
+  for (const step of planSteps) {
+    const command = step.command || '';
+    if (IMPLICIT_LIVE_MUTATION_COMMANDS.test(command)) {
+      throw new Error(`Execution gate plan contains implicit live mutation command: ${command}`);
+    }
+    assertGateCommandSafe(decision, command);
+  }
+}
+
+function assertGateCommandSafe(decision, command = '') {
+  if (PROHIBITED_BACKGROUND_FLAGS.test(command)) {
+    throw new Error(`Execution gate command contains prohibited background/connect flags: ${command}`);
+  }
+  if (decision !== 'eligible_for_live_save' && /--live-save/i.test(command)) {
+    throw new Error(`Execution gate non-live decision contains live-save command: ${command}`);
+  }
+}
+
+module.exports = {
+  buildResearchExecutionGate,
+};

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -16,6 +16,7 @@ const {
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
 const { buildResearchEvaluationMetrics } = require('../src/core/research-evaluation-metrics');
+const { buildResearchExecutionGate } = require('../src/core/research-execution-gate');
 
 function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
@@ -349,6 +350,102 @@ test('buildMvpAutoresearchArtifact includes evaluation metrics in JSON and Markd
   assert.equal(typeof artifact.evaluationMetrics.background.noiseRate, 'number');
   assert.match(markdown, /## Evaluation Metrics/);
   assert.match(markdown, /Risk level:/);
+});
+
+test('research execution gate blocks live save until company resolution blockers clear', () => {
+  const gate = buildResearchExecutionGate({
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        { id: 'company-resolution-retry', gate: 'review_retry_artifact_before_fast_resolve' },
+      ],
+    },
+    evaluationMetrics: {
+      drySafe: true,
+      overall: { riskLevel: 'low', indicators: [] },
+    },
+    mutationReview: {
+      drySafe: true,
+      summary: { intendedAdds: 3, alreadySavedSkips: 0, exclusions: 0, duplicateWarnings: 0 },
+    },
+  });
+
+  assert.equal(gate.drySafe, true);
+  assert.equal(gate.decision, 'blocked_until_company_resolution');
+  assert.equal(gate.liveSaveEligible, false);
+  assert.ok(gate.reasons.includes('company_resolution_retry_pending'));
+});
+
+test('research execution gate requires operator review for review warnings and only allows clean low-risk artifacts', () => {
+  const needsReview = buildResearchExecutionGate({
+    researchLoopPlan: { drySafe: true, steps: [{ id: 'autoresearch-refresh' }] },
+    evaluationMetrics: {
+      drySafe: true,
+      overall: { riskLevel: 'medium', indicators: ['duplicate_sales_nav_urls'] },
+    },
+    mutationReview: {
+      drySafe: true,
+      summary: { intendedAdds: 2, alreadySavedSkips: 1, exclusions: 0, duplicateWarnings: 1 },
+    },
+  });
+  const clean = buildResearchExecutionGate({
+    researchLoopPlan: { drySafe: true, steps: [{ id: 'autoresearch-refresh' }] },
+    evaluationMetrics: {
+      drySafe: true,
+      overall: { riskLevel: 'low', indicators: [] },
+    },
+    mutationReview: {
+      drySafe: true,
+      summary: { intendedAdds: 2, alreadySavedSkips: 0, exclusions: 0, duplicateWarnings: 0 },
+    },
+  });
+
+  assert.equal(needsReview.decision, 'requires_operator_review');
+  assert.equal(needsReview.liveSaveEligible, false);
+  assert.equal(clean.decision, 'eligible_for_live_save');
+  assert.equal(clean.liveSaveEligible, true);
+  assert.doesNotMatch(clean.allowedCommandTemplate, /--live-connect|allow-background-connects/i);
+});
+
+test('research execution gate rejects implicit live mutation commands for non-live decisions', () => {
+  assert.throws(
+    () => buildResearchExecutionGate({
+      researchLoopPlan: {
+        drySafe: true,
+        steps: [
+          { id: 'unsafe-live-command', command: 'node src/cli.js pilot-live-save-batch --account-names=Example' },
+        ],
+      },
+      evaluationMetrics: {
+        drySafe: true,
+        overall: { riskLevel: 'high', indicators: ['background_noise_rate'] },
+      },
+      mutationReview: null,
+    }),
+    /implicit live mutation command/i,
+  );
+});
+
+test('buildMvpAutoresearchArtifact includes execution gate in JSON and Markdown', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mvp-autoresearch-gate-'));
+  const acceptancePath = path.join(tempDir, 'acceptance.json');
+  const backgroundDir = path.join(tempDir, 'background');
+  fs.mkdirSync(backgroundDir);
+  makeAcceptanceArtifact(acceptancePath);
+
+  const artifact = buildMvpAutoresearchArtifact({
+    now: new Date('2026-04-24T06:00:00.000Z'),
+    acceptanceArtifactPath: acceptancePath,
+    backgroundArtifactsDir: backgroundDir,
+    fastResolveArtifactsDir: tempDir,
+  });
+  const markdown = renderMvpAutoresearchMarkdown(artifact);
+
+  assert.equal(artifact.executionGate.drySafe, true);
+  assert.equal(artifact.executionGate.decision, 'allow_dry_run_only');
+  assert.equal(artifact.executionGate.liveSaveEligible, false);
+  assert.match(markdown, /## Execution Gate/);
+  assert.match(markdown, /Decision:/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {


### PR DESCRIPTION
## Summary
- add a dry-safe research execution gate combining research loop plan, evaluation metrics, and optional mutation review artifacts
- surface execution gate decisions in autoresearch JSON/Markdown
- support decisions: `allow_dry_run_only`, `blocked_until_company_resolution`, `requires_operator_review`, `eligible_for_live_save`
- reject implicit live mutation commands such as `pilot-live-save-batch`, `test-list-save`, and `remove-lead-list-members` from gate plan commands

## Tests
- `node --test tests/autoresearch-mvp.test.js`
- `npm run test:release-readiness`
- `npm test`
- `git diff --check`

## Review
- Independent review initially requested stronger command safety for implicit live mutation commands.
- Fixed with command denylist + regression test.
- Final independent review verdict: APPROVE.

## Safety notes
- Autoresearch remains dry-safe and defaults to `allow_dry_run_only` when no mutation review artifact is provided.
- `eligible_for_live_save` requires low risk, a dry-safe mutation review, intended adds, no exclusions, and no duplicate warnings.
- Non-eligible decisions cannot expose `--live-save` command templates.
- Live-connect/background-connect flags remain prohibited.

## Stack / merge order
1. #3
2. #4
3. #5
4. #6
5. #7
6. #8
7. #9
8. this PR
