### PR TITLE
feat: add autoresearch gate report

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build-background-territory-queue": "node src/cli.js build-background-territory-queue",
     "run-background-territory-loop": "node src/cli.js run-background-territory-loop",
     "autoresearch:mvp": "node src/cli.js autoresearch-mvp",
+    "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/src/cli.js
+++ b/src/cli.js
@@ -100,6 +100,7 @@ const { normalizeCandidateLimit } = require('./core/candidate-limits');
 const {
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   writeMvpAutoresearchRun,
 } = require('./core/autoresearch-mvp');
 const {
@@ -253,6 +254,9 @@ async function main() {
         break;
       case 'autoresearch-mvp':
         await handleAutoresearchMvp(values, logger);
+        break;
+      case 'print-autoresearch-gate':
+        await handlePrintAutoresearchGate(values, logger);
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
@@ -2969,6 +2973,32 @@ async function handleAutoresearchMvp(values, logger) {
   }
 }
 
+async function handlePrintAutoresearchGate(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-background-connects')) {
+    throw new Error('print-autoresearch-gate is read-only and refuses live-save, live-connect, or background connects');
+  }
+
+  const explicitArtifactPath = getString(values, 'artifact');
+  const latest = explicitArtifactPath
+    ? {
+      artifactPath: path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath),
+      artifact: readJson(path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath)),
+    }
+    : readLatestAutoresearchArtifact();
+  if (!latest) {
+    logger.warn('No MVP autoresearch artifact found. Run npm run autoresearch:mvp first.');
+    console.log(renderMvpGateReport(null));
+    return;
+  }
+
+  const artifact = {
+    ...latest.artifact,
+    artifactPath: latest.artifact.artifactPath || latest.artifactPath,
+    reportPath: latest.artifact.reportPath || String(latest.artifactPath || '').replace(/\.json$/i, '.md'),
+  };
+  console.log(renderMvpGateReport(artifact));
+}
+
 async function handleRunAccountBatch(repository, values, logger) {
   const batchStartedAt = new Date().toISOString();
   const explicitNames = parseAccountNames(getString(values, 'account-names'));
@@ -3622,6 +3652,7 @@ Usage:
   node src/cli.js build-background-territory-queue [--owner-name="Example SDR"] [--stale-days=60] [--seed-dataset=project.dataset|--seed-file=runtime/seeds/accounts.json] [--budget-mode=assist] [--no-subsidiaries]
   node src/cli.js run-background-territory-loop [--queue-artifact=runtime/artifacts/background-runner/example-operator-territory-queue.json] [--driver=hybrid] [--limit=3] [--speed-profile=balanced] [--reuse-sweep-cache] [--live-save] [--account-timeout-ms=180000]
   node src/cli.js autoresearch-mvp [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
+  node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect

--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -641,6 +641,129 @@ function escapeMarkdownCell(value) {
   return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
+function renderMvpGateReport(artifact) {
+  const lines = [];
+  const gate = artifact?.executionGate || {};
+  const metrics = artifact?.evaluationMetrics || {};
+  const plan = artifact?.researchLoopPlan || {};
+  const decision = gate.decision || 'unknown';
+  const reasons = Array.isArray(gate.reasons) ? gate.reasons : [];
+  const checkpoints = Array.isArray(gate.checkpoints) ? gate.checkpoints : [];
+  const planSteps = Array.isArray(plan.steps) ? plan.steps : [];
+  const primaryCommand = sanitizeGateReportCommand(
+    gate.allowedCommandTemplate || getPrimarySafeCommand(artifact || {}),
+    { allowLiveSave: gate.decision === 'eligible_for_live_save', fallback: 'unsafe_command_suppressed_run_autoresearch_mvp' },
+  );
+  const stance = getGateOperatorStance(gate);
+
+  lines.push('# Autoresearch Execution Gate');
+  lines.push('');
+  if (!artifact) {
+    lines.push('- Decision: `unknown`');
+    lines.push('- Operator stance: `run_autoresearch_first`');
+    lines.push('- Primary command: `npm run autoresearch:mvp`');
+    lines.push('- Live save eligible: `no`');
+    lines.push('');
+    lines.push('## Evidence');
+    lines.push('- Latest autoresearch: `missing`');
+    return `${lines.join('\n').trim()}\n`;
+  }
+
+  lines.push(`- Generated at: \`${artifact.generatedAt || 'unknown'}\``);
+  lines.push(`- Decision: \`${decision}\``);
+  lines.push(`- Operator stance: \`${stance}\``);
+  lines.push(`- Live save eligible: \`${gate.liveSaveEligible ? 'yes' : 'no'}\``);
+  lines.push(`- Required approval: \`${gate.requiresOperatorApproval ? 'yes' : 'no'}\``);
+  lines.push(`- Risk level: \`${gate.riskLevel || metrics.overall?.riskLevel || 'unknown'}\``);
+  lines.push(`- Primary command: \`${primaryCommand}\``);
+  lines.push('');
+  lines.push('## Why Blocked or Gated');
+  if (reasons.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const reason of reasons) {
+      lines.push(`- \`${reason}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Metrics Snapshot');
+  lines.push(`- Overall indicators: \`${metrics.overall?.indicators?.join(', ') || 'none'}\``);
+  lines.push(`- Fast manual review rate: \`${metrics.fastResolve?.manualReviewRate ?? 0}\``);
+  lines.push(`- Fast duplicate rate: \`${metrics.fastResolve?.duplicateRate ?? 0}\``);
+  lines.push(`- Background noise rate: \`${metrics.background?.noiseRate ?? 0}\``);
+  lines.push(`- Company alias disagreement rate: \`${metrics.companyResolution?.aliasDisagreementRate ?? 0}\``);
+  lines.push('');
+  lines.push('## Required Checkpoints');
+  if (checkpoints.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const checkpoint of checkpoints) {
+      lines.push(`- \`${checkpoint}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Research Loop Steps');
+  if (planSteps.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const step of planSteps) {
+      const safeStepCommand = sanitizeGateReportCommand(step.command, {
+        allowLiveSave: false,
+        fallback: 'unsafe_command_suppressed',
+      });
+      const command = step.command ? ` — \`${safeStepCommand}\`` : ' — manual gate only';
+      const suffix = step.command && safeStepCommand === 'unsafe_command_suppressed'
+        ? ' (unsafe command suppressed)'
+        : '';
+      lines.push(`- \`${step.id}\`: ${escapeMarkdownCell(step.reason || step.type || 'no reason')}${command}${suffix}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Evidence');
+  lines.push(`- Latest autoresearch: \`${artifact.artifactPath || 'not recorded'}\``);
+  lines.push(`- Latest autoresearch report: \`${artifact.reportPath || 'not recorded'}\``);
+  lines.push(`- Gate dry-safe: \`${gate.drySafe ? 'yes' : 'no'}\``);
+  lines.push(`- Plan dry-safe: \`${plan.drySafe ? 'yes' : 'no'}\``);
+  lines.push('');
+  lines.push('## Operator Rule');
+  if (gate.liveSaveEligible) {
+    lines.push('- Live-save is still supervised: review the mutation artifact, confirm the exact source/list, then run only the rendered reviewed command.');
+  } else {
+    lines.push('- Do not run live-save, live-connect, or background connect modes until this gate is eligible and human-approved.');
+  }
+  return `${lines.join('\n').trim()}\n`;
+}
+
+function getGateOperatorStance(gate = {}) {
+  if (gate.decision === 'eligible_for_live_save') {
+    return 'supervised_live_save_possible_after_human_approval';
+  }
+  if (gate.decision === 'requires_operator_review') {
+    return 'operator_review_required';
+  }
+  if (gate.decision === 'blocked_until_company_resolution') {
+    return 'dry_run_only';
+  }
+  return 'dry_run_only';
+}
+
+function sanitizeGateReportCommand(command, { allowLiveSave = false, fallback = 'unsafe_command_suppressed' } = {}) {
+  const raw = String(command || '').trim();
+  if (!raw) {
+    return fallback;
+  }
+  if (/--live-connect|allow-background-connects/i.test(raw)) {
+    return fallback;
+  }
+  if (!allowLiveSave && /--live-save/i.test(raw)) {
+    return fallback;
+  }
+  if (/\b(?:pilot-live-save-batch|test-list-save|remove-lead-list-members)\b/i.test(raw)) {
+    return fallback;
+  }
+  return raw;
+}
+
 function renderMvpOperatorDashboard(artifact) {
   const lines = [];
   lines.push('# MVP Control Center');
@@ -813,6 +936,7 @@ module.exports = {
   findLatestAutoresearchArtifact,
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   buildRunnerCoverageTarget,
   buildRunnerCoverageByType,
   summarizeBackgroundEvidence,

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -12,6 +12,7 @@ const {
   buildMvpAutoresearchArtifact,
   renderMvpAutoresearchMarkdown,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
@@ -446,6 +447,115 @@ test('buildMvpAutoresearchArtifact includes execution gate in JSON and Markdown'
   assert.equal(artifact.executionGate.liveSaveEligible, false);
   assert.match(markdown, /## Execution Gate/);
   assert.match(markdown, /Decision:/);
+});
+
+test('renderMvpGateReport gives an operator-facing read-only gate summary', () => {
+  const report = renderMvpGateReport({
+    artifactPath: '/tmp/mvp-autoresearch.json',
+    reportPath: '/tmp/mvp-autoresearch.md',
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'blocked_until_company_resolution',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'medium',
+      reasons: ['company_resolution_retry_pending', 'mutation_review_artifact_missing'],
+      allowedCommandTemplate: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+      checkpoints: ['do_not_run_live_save_until_gate_is_eligible'],
+    },
+    evaluationMetrics: {
+      overall: { riskLevel: 'medium', indicators: ['company_resolution_failure_rate'] },
+      fastResolve: { manualReviewRate: 0.25, duplicateRate: 0.1 },
+      background: { noiseRate: 0.2 },
+      companyResolution: { aliasDisagreementRate: 0.1 },
+    },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        {
+          id: 'company-resolution-retry',
+          type: 'cli_command',
+          command: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+          reason: 'retry failed scoped company resolution',
+        },
+        { id: 'operator-review', type: 'manual_gate', command: null, reason: 'review blockers' },
+      ],
+    },
+  });
+
+  assert.match(report, /# Autoresearch Execution Gate/);
+  assert.match(report, /Decision: `blocked_until_company_resolution`/);
+  assert.match(report, /Live save eligible: `no`/);
+  assert.match(report, /Primary command: `node src\/cli\.js run-company-resolution-retries/);
+  assert.match(report, /Operator stance: `dry_run_only`/);
+  assert.match(report, /company_resolution_retry_pending/);
+  assert.match(report, /## Why Blocked or Gated/);
+  assert.match(report, /## Evidence/);
+  assert.doesNotMatch(report, /--live-save/);
+  assert.doesNotMatch(report, /--live-connect/);
+});
+
+test('renderMvpGateReport makes eligible live-save explicit but supervised', () => {
+  const report = renderMvpGateReport({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'eligible_for_live_save',
+      liveSaveEligible: true,
+      requiresOperatorApproval: true,
+      riskLevel: 'low',
+      reasons: [],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save',
+      checkpoints: ['operator_confirms_mutation_review_before_live_save'],
+    },
+    evaluationMetrics: {
+      overall: { riskLevel: 'low', indicators: [] },
+      fastResolve: { manualReviewRate: 0, duplicateRate: 0 },
+      background: { noiseRate: 0 },
+      companyResolution: { aliasDisagreementRate: 0 },
+    },
+    researchLoopPlan: { drySafe: true, steps: [] },
+  });
+
+  assert.match(report, /Decision: `eligible_for_live_save`/);
+  assert.match(report, /Operator stance: `supervised_live_save_possible_after_human_approval`/);
+  assert.match(report, /Primary command: `node src\/cli\.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save`/);
+  assert.match(report, /Required approval: `yes`/);
+});
+
+test('renderMvpGateReport suppresses unsafe commands in stale or malformed non-live artifacts', () => {
+  const report = renderMvpGateReport({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'allow_dry_run_only',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'low',
+      reasons: [],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=/tmp/leads.md --live-save',
+      checkpoints: [],
+    },
+    evaluationMetrics: { overall: { riskLevel: 'low', indicators: [] } },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        {
+          id: 'unsafe-connect',
+          type: 'cli_command',
+          command: 'node src/cli.js run-background-territory-loop --allow-background-connects --live-connect',
+          reason: 'malformed stale artifact',
+        },
+      ],
+    },
+  });
+
+  assert.match(report, /unsafe_command_suppressed/);
+  assert.match(report, /unsafe command suppressed/);
+  assert.doesNotMatch(report, /--live-save/);
+  assert.doesNotMatch(report, /--live-connect/);
+  assert.doesNotMatch(report, /allow-background-connects/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {


### PR DESCRIPTION
## Summary

Adds a read-only, operator-facing Autoresearch Execution Gate report so operators can understand the latest gate decision without reading raw JSON.

- Adds `renderMvpGateReport(...)` to summarize the latest execution gate, risk metrics, required checkpoints, research-loop steps, and evidence paths.
- Adds `print-autoresearch-gate` CLI command and `npm run autoresearch:gate` script.
- Keeps the command read-only and rejects `--live-save`, `--live-connect`, and background-connect flags at CLI entry.
- Suppresses unsafe commands from stale/malformed artifacts before rendering them to operators.

## Safety notes

- No live Sales Navigator commands were run.
- No live-save/live-connect defaults were loosened.
- Non-eligible reports do not render `--live-save`, `--live-connect`, or `allow-background-connects` from stale/malformed artifacts.
- Unsafe commands are replaced with `unsafe_command_suppressed` / `unsafe_command_suppressed_run_autoresearch_mvp`.
- Eligible live-save remains explicitly supervised and human-approved.

## Tests / verification

- `node --test tests/autoresearch-mvp.test.js`
- `npm run test:release-readiness`
- `npm test` → 283/283 passing
- `git diff --check`
- Manual CLI smoke: `node src/cli.js print-autoresearch-gate`
- Manual live flag rejection: `node src/cli.js print-autoresearch-gate --live-save` rejects as expected
- Manual malformed artifact regression: unsafe artifact commands are suppressed
- Secret scan: no added secret assignments found
- Risky scan: no newly added risky execution patterns found
- Independent re-review: APPROVE

## Merge context

Earlier stack has landed/closed into `main`; this PR is now retargeted directly to `main` and contains only M6 on top of current `main`.