### PR TITLE
feat: add autoresearch supervisor runbook

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build-background-territory-queue": "node src/cli.js build-background-territory-queue",
     "run-background-territory-loop": "node src/cli.js run-background-territory-loop",
     "autoresearch:mvp": "node src/cli.js autoresearch-mvp",
+    "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "run-background-territory-loop": "node src/cli.js run-background-territory-loop",
     "autoresearch:mvp": "node src/cli.js autoresearch-mvp",
     "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
+    "autoresearch:supervisor": "node src/cli.js print-autoresearch-supervisor",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/src/cli.js
+++ b/src/cli.js
@@ -100,6 +100,7 @@ const { normalizeCandidateLimit } = require('./core/candidate-limits');
 const {
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   writeMvpAutoresearchRun,
 } = require('./core/autoresearch-mvp');
 const {
@@ -253,6 +254,9 @@ async function main() {
         break;
       case 'autoresearch-mvp':
         await handleAutoresearchMvp(values, logger);
+        break;
+      case 'print-autoresearch-gate':
+        await handlePrintAutoresearchGate(values, logger);
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
@@ -2969,6 +2973,32 @@ async function handleAutoresearchMvp(values, logger) {
   }
 }
 
+async function handlePrintAutoresearchGate(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-background-connects')) {
+    throw new Error('print-autoresearch-gate is read-only and refuses live-save, live-connect, or background connects');
+  }
+
+  const explicitArtifactPath = getString(values, 'artifact');
+  const latest = explicitArtifactPath
+    ? {
+      artifactPath: path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath),
+      artifact: readJson(path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath)),
+    }
+    : readLatestAutoresearchArtifact();
+  if (!latest) {
+    logger.warn('No MVP autoresearch artifact found. Run npm run autoresearch:mvp first.');
+    console.log(renderMvpGateReport(null));
+    return;
+  }
+
+  const artifact = {
+    ...latest.artifact,
+    artifactPath: latest.artifact.artifactPath || latest.artifactPath,
+    reportPath: latest.artifact.reportPath || String(latest.artifactPath || '').replace(/\.json$/i, '.md'),
+  };
+  console.log(renderMvpGateReport(artifact));
+}
+
 async function handleRunAccountBatch(repository, values, logger) {
   const batchStartedAt = new Date().toISOString();
   const explicitNames = parseAccountNames(getString(values, 'account-names'));
@@ -3622,6 +3652,7 @@ Usage:
   node src/cli.js build-background-territory-queue [--owner-name="Example SDR"] [--stale-days=60] [--seed-dataset=project.dataset|--seed-file=runtime/seeds/accounts.json] [--budget-mode=assist] [--no-subsidiaries]
   node src/cli.js run-background-territory-loop [--queue-artifact=runtime/artifacts/background-runner/example-operator-territory-queue.json] [--driver=hybrid] [--limit=3] [--speed-profile=balanced] [--reuse-sweep-cache] [--live-save] [--account-timeout-ms=180000]
   node src/cli.js autoresearch-mvp [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
+  node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect

--- a/src/cli.js
+++ b/src/cli.js
@@ -101,6 +101,8 @@ const {
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
   renderMvpGateReport,
+  buildMvpSupervisorRunbook,
+  renderMvpSupervisorRunbook,
   writeMvpAutoresearchRun,
 } = require('./core/autoresearch-mvp');
 const {
@@ -257,6 +259,9 @@ async function main() {
         break;
       case 'print-autoresearch-gate':
         await handlePrintAutoresearchGate(values, logger);
+        break;
+      case 'print-autoresearch-supervisor':
+        await handlePrintAutoresearchSupervisor(values, logger);
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
@@ -2978,25 +2983,51 @@ async function handlePrintAutoresearchGate(values, logger) {
     throw new Error('print-autoresearch-gate is read-only and refuses live-save, live-connect, or background connects');
   }
 
-  const explicitArtifactPath = getString(values, 'artifact');
-  const latest = explicitArtifactPath
-    ? {
-      artifactPath: path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath),
-      artifact: readJson(path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath)),
-    }
-    : readLatestAutoresearchArtifact();
+  const latest = loadAutoresearchArtifactForReadOnlyReport(values);
   if (!latest) {
     logger.warn('No MVP autoresearch artifact found. Run npm run autoresearch:mvp first.');
     console.log(renderMvpGateReport(null));
     return;
   }
 
-  const artifact = {
+  const artifact = buildReportArtifact(latest);
+  console.log(renderMvpGateReport(artifact));
+}
+
+async function handlePrintAutoresearchSupervisor(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-background-connects')) {
+    throw new Error('print-autoresearch-supervisor is read-only and refuses live-save, live-connect, or background connects');
+  }
+
+  const latest = loadAutoresearchArtifactForReadOnlyReport(values);
+  if (!latest) {
+    logger.warn('No MVP autoresearch artifact found. Run npm run autoresearch:mvp first.');
+    console.log(renderMvpSupervisorRunbook(buildMvpSupervisorRunbook(null)));
+    return;
+  }
+
+  const artifact = buildReportArtifact(latest);
+  console.log(renderMvpSupervisorRunbook(buildMvpSupervisorRunbook(artifact)));
+}
+
+function loadAutoresearchArtifactForReadOnlyReport(values) {
+  const explicitArtifactPath = getString(values, 'artifact');
+  if (!explicitArtifactPath) {
+    return readLatestAutoresearchArtifact();
+  }
+  const artifactPath = path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath);
+  return {
+    artifactPath,
+    artifact: readJson(artifactPath),
+  };
+}
+
+function buildReportArtifact(latest) {
+  return {
     ...latest.artifact,
     artifactPath: latest.artifact.artifactPath || latest.artifactPath,
     reportPath: latest.artifact.reportPath || String(latest.artifactPath || '').replace(/\.json$/i, '.md'),
   };
-  console.log(renderMvpGateReport(artifact));
 }
 
 async function handleRunAccountBatch(repository, values, logger) {
@@ -3653,6 +3684,7 @@ Usage:
   node src/cli.js run-background-territory-loop [--queue-artifact=runtime/artifacts/background-runner/example-operator-territory-queue.json] [--driver=hybrid] [--limit=3] [--speed-profile=balanced] [--reuse-sweep-cache] [--live-save] [--account-timeout-ms=180000]
   node src/cli.js autoresearch-mvp [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
+  node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect

--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -641,6 +641,129 @@ function escapeMarkdownCell(value) {
   return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
+function renderMvpGateReport(artifact) {
+  const lines = [];
+  const gate = artifact?.executionGate || {};
+  const metrics = artifact?.evaluationMetrics || {};
+  const plan = artifact?.researchLoopPlan || {};
+  const decision = gate.decision || 'unknown';
+  const reasons = Array.isArray(gate.reasons) ? gate.reasons : [];
+  const checkpoints = Array.isArray(gate.checkpoints) ? gate.checkpoints : [];
+  const planSteps = Array.isArray(plan.steps) ? plan.steps : [];
+  const primaryCommand = sanitizeGateReportCommand(
+    gate.allowedCommandTemplate || getPrimarySafeCommand(artifact || {}),
+    { allowLiveSave: gate.decision === 'eligible_for_live_save', fallback: 'unsafe_command_suppressed_run_autoresearch_mvp' },
+  );
+  const stance = getGateOperatorStance(gate);
+
+  lines.push('# Autoresearch Execution Gate');
+  lines.push('');
+  if (!artifact) {
+    lines.push('- Decision: `unknown`');
+    lines.push('- Operator stance: `run_autoresearch_first`');
+    lines.push('- Primary command: `npm run autoresearch:mvp`');
+    lines.push('- Live save eligible: `no`');
+    lines.push('');
+    lines.push('## Evidence');
+    lines.push('- Latest autoresearch: `missing`');
+    return `${lines.join('\n').trim()}\n`;
+  }
+
+  lines.push(`- Generated at: \`${artifact.generatedAt || 'unknown'}\``);
+  lines.push(`- Decision: \`${decision}\``);
+  lines.push(`- Operator stance: \`${stance}\``);
+  lines.push(`- Live save eligible: \`${gate.liveSaveEligible ? 'yes' : 'no'}\``);
+  lines.push(`- Required approval: \`${gate.requiresOperatorApproval ? 'yes' : 'no'}\``);
+  lines.push(`- Risk level: \`${gate.riskLevel || metrics.overall?.riskLevel || 'unknown'}\``);
+  lines.push(`- Primary command: \`${primaryCommand}\``);
+  lines.push('');
+  lines.push('## Why Blocked or Gated');
+  if (reasons.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const reason of reasons) {
+      lines.push(`- \`${reason}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Metrics Snapshot');
+  lines.push(`- Overall indicators: \`${metrics.overall?.indicators?.join(', ') || 'none'}\``);
+  lines.push(`- Fast manual review rate: \`${metrics.fastResolve?.manualReviewRate ?? 0}\``);
+  lines.push(`- Fast duplicate rate: \`${metrics.fastResolve?.duplicateRate ?? 0}\``);
+  lines.push(`- Background noise rate: \`${metrics.background?.noiseRate ?? 0}\``);
+  lines.push(`- Company alias disagreement rate: \`${metrics.companyResolution?.aliasDisagreementRate ?? 0}\``);
+  lines.push('');
+  lines.push('## Required Checkpoints');
+  if (checkpoints.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const checkpoint of checkpoints) {
+      lines.push(`- \`${checkpoint}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Research Loop Steps');
+  if (planSteps.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const step of planSteps) {
+      const safeStepCommand = sanitizeGateReportCommand(step.command, {
+        allowLiveSave: false,
+        fallback: 'unsafe_command_suppressed',
+      });
+      const command = step.command ? ` — \`${safeStepCommand}\`` : ' — manual gate only';
+      const suffix = step.command && safeStepCommand === 'unsafe_command_suppressed'
+        ? ' (unsafe command suppressed)'
+        : '';
+      lines.push(`- \`${step.id}\`: ${escapeMarkdownCell(step.reason || step.type || 'no reason')}${command}${suffix}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Evidence');
+  lines.push(`- Latest autoresearch: \`${artifact.artifactPath || 'not recorded'}\``);
+  lines.push(`- Latest autoresearch report: \`${artifact.reportPath || 'not recorded'}\``);
+  lines.push(`- Gate dry-safe: \`${gate.drySafe ? 'yes' : 'no'}\``);
+  lines.push(`- Plan dry-safe: \`${plan.drySafe ? 'yes' : 'no'}\``);
+  lines.push('');
+  lines.push('## Operator Rule');
+  if (gate.liveSaveEligible) {
+    lines.push('- Live-save is still supervised: review the mutation artifact, confirm the exact source/list, then run only the rendered reviewed command.');
+  } else {
+    lines.push('- Do not run live-save, live-connect, or background connect modes until this gate is eligible and human-approved.');
+  }
+  return `${lines.join('\n').trim()}\n`;
+}
+
+function getGateOperatorStance(gate = {}) {
+  if (gate.decision === 'eligible_for_live_save') {
+    return 'supervised_live_save_possible_after_human_approval';
+  }
+  if (gate.decision === 'requires_operator_review') {
+    return 'operator_review_required';
+  }
+  if (gate.decision === 'blocked_until_company_resolution') {
+    return 'dry_run_only';
+  }
+  return 'dry_run_only';
+}
+
+function sanitizeGateReportCommand(command, { allowLiveSave = false, fallback = 'unsafe_command_suppressed' } = {}) {
+  const raw = String(command || '').trim();
+  if (!raw) {
+    return fallback;
+  }
+  if (/--live-connect|allow-background-connects/i.test(raw)) {
+    return fallback;
+  }
+  if (!allowLiveSave && /--live-save/i.test(raw)) {
+    return fallback;
+  }
+  if (/\b(?:pilot-live-save-batch|test-list-save|remove-lead-list-members)\b/i.test(raw)) {
+    return fallback;
+  }
+  return raw;
+}
+
 function renderMvpOperatorDashboard(artifact) {
   const lines = [];
   lines.push('# MVP Control Center');
@@ -813,6 +936,7 @@ module.exports = {
   findLatestAutoresearchArtifact,
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   buildRunnerCoverageTarget,
   buildRunnerCoverageByType,
   summarizeBackgroundEvidence,

--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -764,6 +764,155 @@ function sanitizeGateReportCommand(command, { allowLiveSave = false, fallback = 
   return raw;
 }
 
+function buildMvpSupervisorRunbook(artifact) {
+  if (!artifact) {
+    return {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      executionMode: 'read_only_supervisor',
+      autoExecute: false,
+      gateDecision: 'unknown',
+      nextAction: 'run_autoresearch_first',
+      primaryCommand: 'npm run autoresearch:mvp',
+      requiresHumanApproval: false,
+      reasons: ['autoresearch_artifact_missing'],
+      checkpoints: ['generate_autoresearch_artifact_before_supervisor_loop'],
+      planSteps: [],
+      evidence: { artifactPath: null, reportPath: null },
+    };
+  }
+
+  const gate = artifact.executionGate || {};
+  const decision = gate.decision || 'unknown';
+  const planSteps = Array.isArray(artifact.researchLoopPlan?.steps) ? artifact.researchLoopPlan.steps : [];
+  const primaryCommand = chooseSupervisorPrimaryCommand({ decision, gate, planSteps });
+  const nextAction = chooseSupervisorNextAction(decision);
+  const requiresHumanApproval = decision === 'eligible_for_live_save'
+    || decision === 'requires_operator_review'
+    || gate.requiresOperatorApproval === true;
+
+  return {
+    version: 1,
+    generatedAt: artifact.generatedAt || new Date().toISOString(),
+    executionMode: 'read_only_supervisor',
+    autoExecute: false,
+    gateDecision: decision,
+    nextAction,
+    primaryCommand,
+    requiresHumanApproval,
+    liveSaveEligible: gate.liveSaveEligible === true,
+    riskLevel: gate.riskLevel || artifact.evaluationMetrics?.overall?.riskLevel || 'unknown',
+    reasons: Array.isArray(gate.reasons) ? gate.reasons : [],
+    checkpoints: Array.isArray(gate.checkpoints) ? gate.checkpoints : [],
+    planSteps: planSteps.map((step) => ({
+      id: step.id,
+      reason: step.reason || step.type || 'no reason',
+      command: step.command ? sanitizeGateReportCommand(step.command, {
+        allowLiveSave: false,
+        fallback: 'unsafe_command_suppressed',
+      }) : null,
+    })),
+    evidence: {
+      artifactPath: artifact.artifactPath || null,
+      reportPath: artifact.reportPath || null,
+    },
+  };
+}
+
+function chooseSupervisorPrimaryCommand({ decision, gate, planSteps }) {
+  if (decision === 'blocked_until_company_resolution') {
+    const retryStep = planSteps.find((step) => step.id === 'company-resolution-retry' && step.command);
+    return sanitizeGateReportCommand(
+      retryStep?.command || gate.allowedCommandTemplate || 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+      { allowLiveSave: false, fallback: 'unsafe_command_suppressed_run_autoresearch_gate' },
+    );
+  }
+  if (decision === 'requires_operator_review') {
+    return 'npm run autoresearch:gate';
+  }
+  if (decision === 'eligible_for_live_save') {
+    return sanitizeGateReportCommand(
+      gate.allowedCommandTemplate || 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save',
+      { allowLiveSave: true, fallback: 'unsafe_command_suppressed_run_autoresearch_gate' },
+    );
+  }
+  if (decision === 'allow_dry_run_only') {
+    return sanitizeGateReportCommand(
+      gate.allowedCommandTemplate || 'npm run autoresearch:mvp',
+      { allowLiveSave: false, fallback: 'unsafe_command_suppressed_run_autoresearch_mvp' },
+    );
+  }
+  return 'npm run autoresearch:mvp';
+}
+
+function chooseSupervisorNextAction(decision) {
+  switch (decision) {
+    case 'blocked_until_company_resolution':
+      return 'run_company_resolution_retries';
+    case 'requires_operator_review':
+      return 'review_gate_and_mutation_artifacts';
+    case 'eligible_for_live_save':
+      return 'prepare_supervised_live_save';
+    case 'allow_dry_run_only':
+      return 'continue_dry_research';
+    default:
+      return 'run_autoresearch_first';
+  }
+}
+
+function renderMvpSupervisorRunbook(runbook) {
+  const lines = [];
+  const safeRunbook = runbook || buildMvpSupervisorRunbook(null);
+  lines.push('# Autoresearch Supervisor Runbook');
+  lines.push('');
+  lines.push(`- Generated at: \`${safeRunbook.generatedAt || 'unknown'}\``);
+  lines.push(`- Execution mode: \`${safeRunbook.executionMode}\``);
+  lines.push(`- Auto execute: \`${safeRunbook.autoExecute ? 'yes' : 'no'}\``);
+  lines.push(`- Gate decision: \`${safeRunbook.gateDecision}\``);
+  lines.push(`- Next action: \`${safeRunbook.nextAction}\``);
+  lines.push(`- Primary command: \`${safeRunbook.primaryCommand}\``);
+  lines.push(`- Requires human approval: \`${safeRunbook.requiresHumanApproval ? 'yes' : 'no'}\``);
+  lines.push(`- Live save eligible: \`${safeRunbook.liveSaveEligible ? 'yes' : 'no'}\``);
+  lines.push(`- Risk level: \`${safeRunbook.riskLevel || 'unknown'}\``);
+  lines.push('');
+  lines.push('## Reasons');
+  if ((safeRunbook.reasons || []).length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const reason of safeRunbook.reasons) {
+      lines.push(`- \`${reason}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Required Checkpoints');
+  if ((safeRunbook.checkpoints || []).length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const checkpoint of safeRunbook.checkpoints) {
+      lines.push(`- \`${checkpoint}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Plan Steps');
+  if ((safeRunbook.planSteps || []).length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const step of safeRunbook.planSteps) {
+      lines.push(`- \`${step.id}\`: ${escapeMarkdownCell(step.reason || '')}${step.command ? ` — \`${step.command}\`` : ' — manual gate only'}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Evidence');
+  lines.push(`- Latest autoresearch: \`${safeRunbook.evidence?.artifactPath || 'missing'}\``);
+  lines.push(`- Latest autoresearch report: \`${safeRunbook.evidence?.reportPath || 'missing'}\``);
+  lines.push('');
+  lines.push('## Safety Contract');
+  lines.push('- This runbook is advisory and read-only; it never executes the primary command.');
+  lines.push('- Live-save remains supervised and requires human approval plus reviewed mutation artifacts.');
+  lines.push('- Live-connect and background-connect modes are never part of the supervisor runbook.');
+  return `${lines.join('\n').trim()}\n`;
+}
+
 function renderMvpOperatorDashboard(artifact) {
   const lines = [];
   lines.push('# MVP Control Center');
@@ -937,6 +1086,8 @@ module.exports = {
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
   renderMvpGateReport,
+  buildMvpSupervisorRunbook,
+  renderMvpSupervisorRunbook,
   buildRunnerCoverageTarget,
   buildRunnerCoverageByType,
   summarizeBackgroundEvidence,

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -13,6 +13,8 @@ const {
   renderMvpAutoresearchMarkdown,
   renderMvpOperatorDashboard,
   renderMvpGateReport,
+  buildMvpSupervisorRunbook,
+  renderMvpSupervisorRunbook,
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
@@ -556,6 +558,95 @@ test('renderMvpGateReport suppresses unsafe commands in stale or malformed non-l
   assert.doesNotMatch(report, /--live-save/);
   assert.doesNotMatch(report, /--live-connect/);
   assert.doesNotMatch(report, /allow-background-connects/);
+});
+
+test('buildMvpSupervisorRunbook maps execution gate decisions to read-only next steps', () => {
+  const cases = [
+    {
+      decision: 'allow_dry_run_only',
+      expectedAction: 'continue_dry_research',
+      command: 'npm run autoresearch:mvp',
+    },
+    {
+      decision: 'blocked_until_company_resolution',
+      expectedAction: 'run_company_resolution_retries',
+      command: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+    },
+    {
+      decision: 'requires_operator_review',
+      expectedAction: 'review_gate_and_mutation_artifacts',
+      command: 'npm run autoresearch:gate',
+    },
+    {
+      decision: 'eligible_for_live_save',
+      expectedAction: 'prepare_supervised_live_save',
+      command: 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save',
+      requiresHumanApproval: true,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const runbook = buildMvpSupervisorRunbook({
+      generatedAt: '2026-04-24T06:00:00.000Z',
+      executionGate: {
+        drySafe: true,
+        decision: testCase.decision,
+        liveSaveEligible: testCase.decision === 'eligible_for_live_save',
+        requiresOperatorApproval: testCase.requiresHumanApproval || testCase.decision === 'requires_operator_review',
+        riskLevel: testCase.decision === 'eligible_for_live_save' ? 'low' : 'medium',
+        reasons: testCase.decision === 'blocked_until_company_resolution' ? ['company_resolution_retry_pending'] : [],
+        allowedCommandTemplate: testCase.command,
+        checkpoints: ['confirm_no_live_connect_or_background_connect_flags'],
+      },
+      researchLoopPlan: {
+        drySafe: true,
+        steps: testCase.decision === 'blocked_until_company_resolution'
+          ? [{ id: 'company-resolution-retry', command: testCase.command, reason: 'retry company resolution' }]
+          : [],
+      },
+      evaluationMetrics: { overall: { riskLevel: 'medium', indicators: [] } },
+    });
+
+    assert.equal(runbook.executionMode, 'read_only_supervisor');
+    assert.equal(runbook.autoExecute, false);
+    assert.equal(runbook.nextAction, testCase.expectedAction);
+    assert.equal(runbook.primaryCommand, testCase.command);
+    assert.equal(runbook.requiresHumanApproval, Boolean(testCase.requiresHumanApproval || testCase.decision === 'requires_operator_review'));
+  }
+});
+
+test('renderMvpSupervisorRunbook is operator-facing and suppresses unsafe commands for non-live decisions', () => {
+  const runbook = buildMvpSupervisorRunbook({
+    artifactPath: '/tmp/mvp-autoresearch.json',
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'allow_dry_run_only',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'low',
+      reasons: ['mutation_review_artifact_missing'],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=/tmp/leads.md --live-save',
+      checkpoints: [],
+    },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        { id: 'unsafe-connect', command: 'node src/cli.js run-background-territory-loop --live-connect', reason: 'malformed stale artifact' },
+      ],
+    },
+    evaluationMetrics: { overall: { riskLevel: 'low', indicators: [] } },
+  });
+  const markdown = renderMvpSupervisorRunbook(runbook);
+
+  assert.match(markdown, /# Autoresearch Supervisor Runbook/);
+  assert.match(markdown, /Execution mode: `read_only_supervisor`/);
+  assert.match(markdown, /Auto execute: `no`/);
+  assert.match(markdown, /Next action: `continue_dry_research`/);
+  assert.match(markdown, /unsafe_command_suppressed/);
+  assert.doesNotMatch(markdown, /--live-save/);
+  assert.doesNotMatch(markdown, /--live-connect/);
+  assert.match(markdown, /Latest autoresearch: `\/tmp\/mvp-autoresearch.json`/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -12,6 +12,7 @@ const {
   buildMvpAutoresearchArtifact,
   renderMvpAutoresearchMarkdown,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
@@ -446,6 +447,115 @@ test('buildMvpAutoresearchArtifact includes execution gate in JSON and Markdown'
   assert.equal(artifact.executionGate.liveSaveEligible, false);
   assert.match(markdown, /## Execution Gate/);
   assert.match(markdown, /Decision:/);
+});
+
+test('renderMvpGateReport gives an operator-facing read-only gate summary', () => {
+  const report = renderMvpGateReport({
+    artifactPath: '/tmp/mvp-autoresearch.json',
+    reportPath: '/tmp/mvp-autoresearch.md',
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'blocked_until_company_resolution',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'medium',
+      reasons: ['company_resolution_retry_pending', 'mutation_review_artifact_missing'],
+      allowedCommandTemplate: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+      checkpoints: ['do_not_run_live_save_until_gate_is_eligible'],
+    },
+    evaluationMetrics: {
+      overall: { riskLevel: 'medium', indicators: ['company_resolution_failure_rate'] },
+      fastResolve: { manualReviewRate: 0.25, duplicateRate: 0.1 },
+      background: { noiseRate: 0.2 },
+      companyResolution: { aliasDisagreementRate: 0.1 },
+    },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        {
+          id: 'company-resolution-retry',
+          type: 'cli_command',
+          command: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+          reason: 'retry failed scoped company resolution',
+        },
+        { id: 'operator-review', type: 'manual_gate', command: null, reason: 'review blockers' },
+      ],
+    },
+  });
+
+  assert.match(report, /# Autoresearch Execution Gate/);
+  assert.match(report, /Decision: `blocked_until_company_resolution`/);
+  assert.match(report, /Live save eligible: `no`/);
+  assert.match(report, /Primary command: `node src\/cli\.js run-company-resolution-retries/);
+  assert.match(report, /Operator stance: `dry_run_only`/);
+  assert.match(report, /company_resolution_retry_pending/);
+  assert.match(report, /## Why Blocked or Gated/);
+  assert.match(report, /## Evidence/);
+  assert.doesNotMatch(report, /--live-save/);
+  assert.doesNotMatch(report, /--live-connect/);
+});
+
+test('renderMvpGateReport makes eligible live-save explicit but supervised', () => {
+  const report = renderMvpGateReport({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'eligible_for_live_save',
+      liveSaveEligible: true,
+      requiresOperatorApproval: true,
+      riskLevel: 'low',
+      reasons: [],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save',
+      checkpoints: ['operator_confirms_mutation_review_before_live_save'],
+    },
+    evaluationMetrics: {
+      overall: { riskLevel: 'low', indicators: [] },
+      fastResolve: { manualReviewRate: 0, duplicateRate: 0 },
+      background: { noiseRate: 0 },
+      companyResolution: { aliasDisagreementRate: 0 },
+    },
+    researchLoopPlan: { drySafe: true, steps: [] },
+  });
+
+  assert.match(report, /Decision: `eligible_for_live_save`/);
+  assert.match(report, /Operator stance: `supervised_live_save_possible_after_human_approval`/);
+  assert.match(report, /Primary command: `node src\/cli\.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save`/);
+  assert.match(report, /Required approval: `yes`/);
+});
+
+test('renderMvpGateReport suppresses unsafe commands in stale or malformed non-live artifacts', () => {
+  const report = renderMvpGateReport({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'allow_dry_run_only',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'low',
+      reasons: [],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=/tmp/leads.md --live-save',
+      checkpoints: [],
+    },
+    evaluationMetrics: { overall: { riskLevel: 'low', indicators: [] } },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        {
+          id: 'unsafe-connect',
+          type: 'cli_command',
+          command: 'node src/cli.js run-background-territory-loop --allow-background-connects --live-connect',
+          reason: 'malformed stale artifact',
+        },
+      ],
+    },
+  });
+
+  assert.match(report, /unsafe_command_suppressed/);
+  assert.match(report, /unsafe command suppressed/);
+  assert.doesNotMatch(report, /--live-save/);
+  assert.doesNotMatch(report, /--live-connect/);
+  assert.doesNotMatch(report, /allow-background-connects/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {


### PR DESCRIPTION
## Summary
- Adds a read-only autoresearch supervisor runbook that maps execution-gate decisions to the safest next operator step.
- Adds `print-autoresearch-supervisor` plus `npm run autoresearch:supervisor` for operator-facing guidance from the latest or explicit autoresearch artifact.
- Reuses gate-report command sanitization so malformed/stale non-live artifacts cannot expose copyable unsafe live commands.

## Safety notes
- Read-only only: no Sales Navigator mutation is executed.
- CLI refuses `--live-save`, `--live-connect`, and `--allow-background-connects`.
- Non-live decisions suppress unsafe live commands.
- `eligible_for_live_save` still requires human approval and only renders a supervised command when the execution gate is eligible.

## Tests / verification
- `node --test tests/autoresearch-mvp.test.js --test-name-pattern='Supervisor Runbook|supervisor'`
- `node src/cli.js print-autoresearch-supervisor --live-save` rejected as expected
- `node src/cli.js print-autoresearch-supervisor` smoke-tested
- `node --test tests/autoresearch-mvp.test.js`
- `npm run test:release-readiness`
- `npm test` → 285/285 passing
- `git diff --check`
- Secret scan: no added secret assignments found
- Risky scan: no newly added risky execution patterns found
- Independent review: APPROVE
