### PR TITLE
perf: dedupe fast resolve queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build-background-territory-queue": "node src/cli.js build-background-territory-queue",
     "run-background-territory-loop": "node src/cli.js run-background-territory-loop",
     "autoresearch:mvp": "node src/cli.js autoresearch-mvp",
+    "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "autoresearch:mvp": "node src/cli.js autoresearch-mvp",
     "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
     "autoresearch:supervisor": "node src/cli.js print-autoresearch-supervisor",
+    "autoresearch:speed": "node src/cli.js autoresearch-speed-eval",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "run-background-territory-loop": "node src/cli.js run-background-territory-loop",
     "autoresearch:mvp": "node src/cli.js autoresearch-mvp",
     "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
+    "autoresearch:supervisor": "node src/cli.js print-autoresearch-supervisor",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1855,6 +1855,7 @@ async function handleAccountCoverage(values, logger) {
   const maxCandidates = parseOptionalCandidateLimit(getString(values, 'max-candidates'));
   const speedProfile = getString(values, 'speed-profile') || 'balanced';
   const reuseSweepCache = getBoolean(values, 'reuse-sweep-cache');
+  const adaptiveSweepPruning = getBoolean(values, 'adaptive-sweep-pruning');
   const interSweepDelayMs = Number(getString(values, 'inter-sweep-delay-ms') || 0);
   const coverageConfig = loadAccountCoverageConfig(getString(values, 'coverage-config') || null);
   const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
@@ -1885,6 +1886,7 @@ async function handleAccountCoverage(values, logger) {
       priorityModel,
       maxCandidates,
       speedProfile,
+      adaptiveSweepPruning,
       reuseSweepCache,
       interSweepDelayMs,
       runId: 'account-coverage',
@@ -1902,8 +1904,10 @@ async function handleAccountCoverage(values, logger) {
     logger.info(`Driver: ${driverName}`);
     logger.info(`Account target: ${accountName}`);
     const failedSweepIds = (result.sweepErrors || []).map((error) => error.templateId).filter(Boolean);
-    const succeededSweeps = Math.max(0, templates.length - failedSweepIds.length);
-    logger.info(`Sweeps: ${succeededSweeps}/${templates.length} succeeded${failedSweepIds.length ? `, ${failedSweepIds.length} failed (${failedSweepIds.join(', ')})` : ''}`);
+    const skippedPrunedCount = result.adaptivePruning?.skippedTemplates?.length || 0;
+    const attemptedSweepCount = Math.max(0, templates.length - skippedPrunedCount);
+    const succeededSweeps = Math.max(0, attemptedSweepCount - failedSweepIds.length);
+    logger.info(`Sweeps: ${succeededSweeps}/${attemptedSweepCount} attempted succeeded${failedSweepIds.length ? `, ${failedSweepIds.length} failed (${failedSweepIds.join(', ')})` : ''}${skippedPrunedCount ? `, ${skippedPrunedCount} pruned (${result.adaptivePruning.skippedTemplates.join(', ')})` : ''}`);
     logger.info(`Speed profile: ${result.speedProfile}`);
     if (interSweepDelayMs > 0) {
       logger.info(`Inter-sweep delay: ${interSweepDelayMs}ms`);
@@ -3088,6 +3092,7 @@ async function handleRunAccountBatch(repository, values, logger) {
   const maxCandidates = parseOptionalCandidateLimit(getString(values, 'max-candidates'));
   const speedProfile = getString(values, 'speed-profile') || 'balanced';
   const reuseSweepCache = getBoolean(values, 'reuse-sweep-cache');
+  const adaptiveSweepPruning = getBoolean(values, 'adaptive-sweep-pruning');
   const researchConcurrency = Number(getString(values, 'research-concurrency') || 1);
   if ((liveSave || liveConnect) && researchConcurrency > 1) {
     throw new Error('research-concurrency > 1 is only allowed for read-only research; live-save/live-connect stay serial');
@@ -3142,6 +3147,7 @@ async function handleRunAccountBatch(repository, values, logger) {
         priorityModel,
         maxCandidates,
         speedProfile,
+        adaptiveSweepPruning,
         reuseSweepCache,
         runId: 'run-account-batch',
         logger: {
@@ -3682,7 +3688,7 @@ Usage:
   node src/cli.js check-driver-session [--driver=playwright|browser-harness|hybrid] [--session-mode=storage-state|persistent]
   node src/cli.js bootstrap-session [--driver=playwright] [--wait-minutes=10]
   node src/cli.js test-account-search --driver=playwright|browser-harness|hybrid --account-name="Acme" [--account-list="Territory List"] [--keywords="site reliability,observability"]
-  node src/cli.js account-coverage --driver=hybrid --account-name="Acme" [--speed-profile=balanced] [--reuse-sweep-cache] [--inter-sweep-delay-ms=2000]
+  node src/cli.js account-coverage --driver=hybrid --account-name="Acme" [--speed-profile=balanced] [--reuse-sweep-cache] [--adaptive-sweep-pruning] [--inter-sweep-delay-ms=2000]
   node src/cli.js resolve-company --account-name="Acme"
   node src/cli.js print-company-resolution [--account-name="Acme"]
   node src/cli.js retry-company-resolution-failures [--limit=3]
@@ -3716,7 +3722,7 @@ Usage:
   node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js autoresearch-speed-eval --baseline=runtime/artifacts/autoresearch/baseline.json --candidate=runtime/artifacts/autoresearch/candidate.json [--min-speedup-percent=25]
-  node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--live-save] [--live-connect]
+  node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--adaptive-sweep-pruning] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect
 `);

--- a/src/cli.js
+++ b/src/cli.js
@@ -100,6 +100,7 @@ const { normalizeCandidateLimit } = require('./core/candidate-limits');
 const {
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   writeMvpAutoresearchRun,
 } = require('./core/autoresearch-mvp');
 const {
@@ -253,6 +254,9 @@ async function main() {
         break;
       case 'autoresearch-mvp':
         await handleAutoresearchMvp(values, logger);
+        break;
+      case 'print-autoresearch-gate':
+        await handlePrintAutoresearchGate(values, logger);
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
@@ -2969,6 +2973,32 @@ async function handleAutoresearchMvp(values, logger) {
   }
 }
 
+async function handlePrintAutoresearchGate(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-background-connects')) {
+    throw new Error('print-autoresearch-gate is read-only and refuses live-save, live-connect, or background connects');
+  }
+
+  const explicitArtifactPath = getString(values, 'artifact');
+  const latest = explicitArtifactPath
+    ? {
+      artifactPath: path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath),
+      artifact: readJson(path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath)),
+    }
+    : readLatestAutoresearchArtifact();
+  if (!latest) {
+    logger.warn('No MVP autoresearch artifact found. Run npm run autoresearch:mvp first.');
+    console.log(renderMvpGateReport(null));
+    return;
+  }
+
+  const artifact = {
+    ...latest.artifact,
+    artifactPath: latest.artifact.artifactPath || latest.artifactPath,
+    reportPath: latest.artifact.reportPath || String(latest.artifactPath || '').replace(/\.json$/i, '.md'),
+  };
+  console.log(renderMvpGateReport(artifact));
+}
+
 async function handleRunAccountBatch(repository, values, logger) {
   const batchStartedAt = new Date().toISOString();
   const explicitNames = parseAccountNames(getString(values, 'account-names'));
@@ -3622,6 +3652,7 @@ Usage:
   node src/cli.js build-background-territory-queue [--owner-name="Example SDR"] [--stale-days=60] [--seed-dataset=project.dataset|--seed-file=runtime/seeds/accounts.json] [--budget-mode=assist] [--no-subsidiaries]
   node src/cli.js run-background-territory-loop [--queue-artifact=runtime/artifacts/background-runner/example-operator-territory-queue.json] [--driver=hybrid] [--limit=3] [--speed-profile=balanced] [--reuse-sweep-cache] [--live-save] [--account-timeout-ms=180000]
   node src/cli.js autoresearch-mvp [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
+  node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect

--- a/src/cli.js
+++ b/src/cli.js
@@ -101,6 +101,8 @@ const {
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
   renderMvpGateReport,
+  buildMvpSupervisorRunbook,
+  renderMvpSupervisorRunbook,
   writeMvpAutoresearchRun,
 } = require('./core/autoresearch-mvp');
 const {
@@ -257,6 +259,9 @@ async function main() {
         break;
       case 'print-autoresearch-gate':
         await handlePrintAutoresearchGate(values, logger);
+        break;
+      case 'print-autoresearch-supervisor':
+        await handlePrintAutoresearchSupervisor(values, logger);
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
@@ -2978,25 +2983,51 @@ async function handlePrintAutoresearchGate(values, logger) {
     throw new Error('print-autoresearch-gate is read-only and refuses live-save, live-connect, or background connects');
   }
 
-  const explicitArtifactPath = getString(values, 'artifact');
-  const latest = explicitArtifactPath
-    ? {
-      artifactPath: path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath),
-      artifact: readJson(path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath)),
-    }
-    : readLatestAutoresearchArtifact();
+  const latest = loadAutoresearchArtifactForReadOnlyReport(values);
   if (!latest) {
     logger.warn('No MVP autoresearch artifact found. Run npm run autoresearch:mvp first.');
     console.log(renderMvpGateReport(null));
     return;
   }
 
-  const artifact = {
+  const artifact = buildReportArtifact(latest);
+  console.log(renderMvpGateReport(artifact));
+}
+
+async function handlePrintAutoresearchSupervisor(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-background-connects')) {
+    throw new Error('print-autoresearch-supervisor is read-only and refuses live-save, live-connect, or background connects');
+  }
+
+  const latest = loadAutoresearchArtifactForReadOnlyReport(values);
+  if (!latest) {
+    logger.warn('No MVP autoresearch artifact found. Run npm run autoresearch:mvp first.');
+    console.log(renderMvpSupervisorRunbook(buildMvpSupervisorRunbook(null)));
+    return;
+  }
+
+  const artifact = buildReportArtifact(latest);
+  console.log(renderMvpSupervisorRunbook(buildMvpSupervisorRunbook(artifact)));
+}
+
+function loadAutoresearchArtifactForReadOnlyReport(values) {
+  const explicitArtifactPath = getString(values, 'artifact');
+  if (!explicitArtifactPath) {
+    return readLatestAutoresearchArtifact();
+  }
+  const artifactPath = path.isAbsolute(explicitArtifactPath) ? explicitArtifactPath : resolveProjectPath(explicitArtifactPath);
+  return {
+    artifactPath,
+    artifact: readJson(artifactPath),
+  };
+}
+
+function buildReportArtifact(latest) {
+  return {
     ...latest.artifact,
     artifactPath: latest.artifact.artifactPath || latest.artifactPath,
     reportPath: latest.artifact.reportPath || String(latest.artifactPath || '').replace(/\.json$/i, '.md'),
   };
-  console.log(renderMvpGateReport(artifact));
 }
 
 async function handleRunAccountBatch(repository, values, logger) {
@@ -3653,6 +3684,7 @@ Usage:
   node src/cli.js run-background-territory-loop [--queue-artifact=runtime/artifacts/background-runner/example-operator-territory-queue.json] [--driver=hybrid] [--limit=3] [--speed-profile=balanced] [--reuse-sweep-cache] [--live-save] [--account-timeout-ms=180000]
   node src/cli.js autoresearch-mvp [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
+  node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect

--- a/src/cli.js
+++ b/src/cli.js
@@ -103,6 +103,8 @@ const {
   renderMvpGateReport,
   buildMvpSupervisorRunbook,
   renderMvpSupervisorRunbook,
+  buildAutoresearchSpeedEvaluation,
+  renderAutoresearchSpeedEvaluationMarkdown,
   writeMvpAutoresearchRun,
 } = require('./core/autoresearch-mvp');
 const {
@@ -262,6 +264,9 @@ async function main() {
         break;
       case 'print-autoresearch-supervisor':
         await handlePrintAutoresearchSupervisor(values, logger);
+        break;
+      case 'autoresearch-speed-eval':
+        await handleAutoresearchSpeedEval(values, logger);
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
@@ -3010,6 +3015,31 @@ async function handlePrintAutoresearchSupervisor(values, logger) {
   console.log(renderMvpSupervisorRunbook(buildMvpSupervisorRunbook(artifact)));
 }
 
+async function handleAutoresearchSpeedEval(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-background-connects')) {
+    throw new Error('autoresearch-speed-eval is read-only and refuses live-save, live-connect, or background connects');
+  }
+  const baselinePath = getString(values, 'baseline');
+  const candidatePath = getString(values, 'candidate');
+  if (!baselinePath || !candidatePath) {
+    throw new Error('autoresearch-speed-eval requires --baseline=path/to/baseline.json and --candidate=path/to/candidate.json');
+  }
+  const minSpeedupPercent = Number(getString(values, 'min-speedup-percent') || 25);
+  const baselineArtifactPath = path.isAbsolute(baselinePath) ? baselinePath : resolveProjectPath(baselinePath);
+  const candidateArtifactPath = path.isAbsolute(candidatePath) ? candidatePath : resolveProjectPath(candidatePath);
+  const baseline = {
+    ...readJson(baselineArtifactPath),
+    artifactPath: baselineArtifactPath,
+  };
+  const candidate = {
+    ...readJson(candidateArtifactPath),
+    artifactPath: candidateArtifactPath,
+  };
+  const evaluation = buildAutoresearchSpeedEvaluation({ baseline, candidate, minSpeedupPercent });
+  logger.info(`Speed evaluation decision: ${evaluation.decision}`);
+  console.log(renderAutoresearchSpeedEvaluationMarkdown(evaluation));
+}
+
 function loadAutoresearchArtifactForReadOnlyReport(values) {
   const explicitArtifactPath = getString(values, 'artifact');
   if (!explicitArtifactPath) {
@@ -3685,6 +3715,7 @@ Usage:
   node src/cli.js autoresearch-mvp [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
+  node src/cli.js autoresearch-speed-eval --baseline=runtime/artifacts/autoresearch/baseline.json --candidate=runtime/artifacts/autoresearch/candidate.json [--min-speedup-percent=25]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect

--- a/src/core/account-coverage.js
+++ b/src/core/account-coverage.js
@@ -131,7 +131,7 @@ function isPrioritySweep(template) {
   return PRIORITY_SWEEP_HINTS.some((hint) => haystack.includes(hint));
 }
 
-function applySpeedProfileToTemplates(templates, speedProfile = 'balanced') {
+function applySpeedProfileToTemplates(templates, speedProfile = 'balanced', profileOptions = {}) {
   const profile = normalizeSpeedProfile(speedProfile);
   if (profile === 'exhaustive') {
     return templates;
@@ -141,10 +141,59 @@ function applySpeedProfileToTemplates(templates, speedProfile = 'balanced') {
   const priority = templates.filter((template) => template.id !== 'broad-crawl' && isPrioritySweep(template));
   const rest = templates.filter((template) => template.id !== 'broad-crawl' && !isPrioritySweep(template));
 
+  const expandFastRestForAdaptivePruning = Boolean(profileOptions.adaptiveSweepPruning);
+
   if (profile === 'fast') {
+    if (expandFastRestForAdaptivePruning) {
+      return [...broad, ...priority, ...rest];
+    }
     return [...broad, ...priority];
   }
   return [...broad, ...priority, ...rest];
+}
+
+function isRestSweepTemplate(template) {
+  return template.id !== 'broad-crawl' && !isPrioritySweep(template);
+}
+
+function getAdaptivePruningThresholds(speedProfile) {
+  const profile = normalizeSpeedProfile(speedProfile);
+  if (profile === 'exhaustive') {
+    return null;
+  }
+  if (profile === 'fast') {
+    return { windowSize: 2, maxNewUniquesPerSweep: 0 };
+  }
+  return { windowSize: 3, maxNewUniquesPerSweep: 0 };
+}
+
+function broadCrawlFinishedBeforeIndex(templates, templateIndex) {
+  const broadIdx = templates.findIndex((template) => template.id === 'broad-crawl');
+  if (broadIdx === -1) {
+    return true;
+  }
+  return templateIndex > broadIdx;
+}
+
+function shouldAdaptiveSkipRestSweep({
+  template,
+  thresholds,
+  adaptiveEnabled,
+  executedUniqueAdds,
+  templates,
+  templateIndex,
+}) {
+  if (!adaptiveEnabled || !thresholds || !isRestSweepTemplate(template)) {
+    return false;
+  }
+  if (!broadCrawlFinishedBeforeIndex(templates, templateIndex)) {
+    return false;
+  }
+  if (executedUniqueAdds.length < thresholds.windowSize) {
+    return false;
+  }
+  const tail = executedUniqueAdds.slice(-thresholds.windowSize);
+  return tail.every((count) => count <= thresholds.maxNewUniquesPerSweep);
 }
 
 function buildSweepTemplates(config, maxCandidatesOverride = null, options = {}) {
@@ -179,7 +228,9 @@ function buildSweepTemplates(config, maxCandidatesOverride = null, options = {})
     templates.push(template);
   }
 
-  return applySpeedProfileToTemplates(templates, options.speedProfile || 'balanced');
+  return applySpeedProfileToTemplates(templates, options.speedProfile || 'balanced', {
+    adaptiveSweepPruning: options.adaptiveSweepPruning,
+  });
 }
 
 function classifySweepErrorCategory(error) {
@@ -494,6 +545,7 @@ async function runAccountCoverageWorkflow({
   priorityModel,
   maxCandidates = null,
   speedProfile = 'balanced',
+  adaptiveSweepPruning = false,
   reuseSweepCache = false,
   sweepCacheDir = DEFAULT_SWEEP_CACHE_DIR,
   runId = 'account-coverage',
@@ -504,7 +556,13 @@ async function runAccountCoverageWorkflow({
 }) {
   const normalizedSpeedProfile = normalizeSpeedProfile(speedProfile);
   const timings = createRunTimings(now);
-  const templates = buildSweepTemplates(coverageConfig, maxCandidates, { speedProfile: normalizedSpeedProfile });
+  const adaptivePruningRequested = Boolean(adaptiveSweepPruning);
+  const adaptivePruningActive = adaptivePruningRequested && normalizedSpeedProfile !== 'exhaustive';
+  const pruningThresholds = adaptivePruningActive ? getAdaptivePruningThresholds(normalizedSpeedProfile) : null;
+  const templates = buildSweepTemplates(coverageConfig, maxCandidates, {
+    speedProfile: normalizedSpeedProfile,
+    adaptiveSweepPruning: adaptivePruningRequested && normalizedSpeedProfile === 'fast',
+  });
   const aliasConfig = loadAccountAliasConfig();
   const aliasEntry = findAccountAliasEntry(aliasConfig, accountName);
   const priorCoverage = loadExistingAccountCoverageArtifact(accountName);
@@ -544,11 +602,48 @@ async function runAccountCoverageWorkflow({
   }, { now });
 
   let stopSweeps = false;
+  const adaptivePruningTelemetry = {
+    enabled: adaptivePruningActive,
+    triggered: false,
+    reason: null,
+    skippedTemplates: [],
+    executedTemplates: [],
+    uniqueCandidatesAddedByTemplate: {},
+    thresholds: pruningThresholds
+      ? { ...pruningThresholds, profile: normalizedSpeedProfile }
+      : null,
+    profile: normalizedSpeedProfile,
+  };
+  const executedUniqueAdds = [];
+
+  function registerSweepAdds(uniqueNew, templateId) {
+    adaptivePruningTelemetry.executedTemplates.push(templateId);
+    adaptivePruningTelemetry.uniqueCandidatesAddedByTemplate[templateId] = uniqueNew;
+    executedUniqueAdds.push(uniqueNew);
+  }
+
   for (let templateIndex = 0; templateIndex < templates.length; templateIndex += 1) {
     if (stopSweeps) {
       break;
     }
     const template = templates[templateIndex];
+
+    if (
+      shouldAdaptiveSkipRestSweep({
+        template,
+        thresholds: pruningThresholds,
+        adaptiveEnabled: adaptivePruningActive,
+        executedUniqueAdds,
+        templates,
+        templateIndex,
+      })
+    ) {
+      adaptivePruningTelemetry.skippedTemplates.push(template.id);
+      adaptivePruningTelemetry.triggered = true;
+      adaptivePruningTelemetry.reason = adaptivePruningTelemetry.reason || 'low_yield_recent_window';
+      continue;
+    }
+
     const cacheKey = buildSweepCacheKey({
       account: activeAccount,
       accountName,
@@ -559,6 +654,7 @@ async function runAccountCoverageWorkflow({
     if (cacheHit && Array.isArray(cacheHit.candidates)) {
       cacheHits += 1;
       await timePhase(timings, `sweep:${template.id}`, async () => {
+        let uniqueNew = 0;
         rawResults.push({
           templateId: template.id,
           keywords: template.keywords || [],
@@ -566,8 +662,13 @@ async function runAccountCoverageWorkflow({
           cacheHit: true,
         });
         for (const candidate of cacheHit.candidates) {
-          seenCandidateKeys.add(normalizeCandidateKey(candidate));
+          const key = normalizeCandidateKey(candidate);
+          if (!seenCandidateKeys.has(key)) {
+            uniqueNew += 1;
+          }
+          seenCandidateKeys.add(key);
         }
+        registerSweepAdds(uniqueNew, template.id);
       }, {
         now,
         meta: {
@@ -595,6 +696,7 @@ async function runAccountCoverageWorkflow({
           rateLimitEvents,
           duplicateShortCircuitThreshold: coverageConfig.duplicateShortCircuitThreshold ?? 0.8,
         });
+        let uniqueNew = 0;
         rawResults.push({
           templateId: template.id,
           keywords: template.keywords || [],
@@ -602,8 +704,13 @@ async function runAccountCoverageWorkflow({
           cacheHit: false,
         });
         for (const candidate of candidates) {
-          seenCandidateKeys.add(normalizeCandidateKey(candidate));
+          const key = normalizeCandidateKey(candidate);
+          if (!seenCandidateKeys.has(key)) {
+            uniqueNew += 1;
+          }
+          seenCandidateKeys.add(key);
         }
+        registerSweepAdds(uniqueNew, template.id);
         if (reuseSweepCache) {
           writeSweepCache(sweepCacheDir, cacheKey, {
             accountName,
@@ -703,6 +810,7 @@ async function runAccountCoverageWorkflow({
   finalResult.cacheHits = cacheHits;
   finalResult.cacheMisses = cacheMisses;
   finalResult.speedProfile = normalizedSpeedProfile;
+  finalResult.adaptivePruning = adaptivePruningTelemetry;
   const bucketSummary = summarizeCoverageBuckets(finalResult.candidates);
 
   return {

--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -641,6 +641,129 @@ function escapeMarkdownCell(value) {
   return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
+function renderMvpGateReport(artifact) {
+  const lines = [];
+  const gate = artifact?.executionGate || {};
+  const metrics = artifact?.evaluationMetrics || {};
+  const plan = artifact?.researchLoopPlan || {};
+  const decision = gate.decision || 'unknown';
+  const reasons = Array.isArray(gate.reasons) ? gate.reasons : [];
+  const checkpoints = Array.isArray(gate.checkpoints) ? gate.checkpoints : [];
+  const planSteps = Array.isArray(plan.steps) ? plan.steps : [];
+  const primaryCommand = sanitizeGateReportCommand(
+    gate.allowedCommandTemplate || getPrimarySafeCommand(artifact || {}),
+    { allowLiveSave: gate.decision === 'eligible_for_live_save', fallback: 'unsafe_command_suppressed_run_autoresearch_mvp' },
+  );
+  const stance = getGateOperatorStance(gate);
+
+  lines.push('# Autoresearch Execution Gate');
+  lines.push('');
+  if (!artifact) {
+    lines.push('- Decision: `unknown`');
+    lines.push('- Operator stance: `run_autoresearch_first`');
+    lines.push('- Primary command: `npm run autoresearch:mvp`');
+    lines.push('- Live save eligible: `no`');
+    lines.push('');
+    lines.push('## Evidence');
+    lines.push('- Latest autoresearch: `missing`');
+    return `${lines.join('\n').trim()}\n`;
+  }
+
+  lines.push(`- Generated at: \`${artifact.generatedAt || 'unknown'}\``);
+  lines.push(`- Decision: \`${decision}\``);
+  lines.push(`- Operator stance: \`${stance}\``);
+  lines.push(`- Live save eligible: \`${gate.liveSaveEligible ? 'yes' : 'no'}\``);
+  lines.push(`- Required approval: \`${gate.requiresOperatorApproval ? 'yes' : 'no'}\``);
+  lines.push(`- Risk level: \`${gate.riskLevel || metrics.overall?.riskLevel || 'unknown'}\``);
+  lines.push(`- Primary command: \`${primaryCommand}\``);
+  lines.push('');
+  lines.push('## Why Blocked or Gated');
+  if (reasons.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const reason of reasons) {
+      lines.push(`- \`${reason}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Metrics Snapshot');
+  lines.push(`- Overall indicators: \`${metrics.overall?.indicators?.join(', ') || 'none'}\``);
+  lines.push(`- Fast manual review rate: \`${metrics.fastResolve?.manualReviewRate ?? 0}\``);
+  lines.push(`- Fast duplicate rate: \`${metrics.fastResolve?.duplicateRate ?? 0}\``);
+  lines.push(`- Background noise rate: \`${metrics.background?.noiseRate ?? 0}\``);
+  lines.push(`- Company alias disagreement rate: \`${metrics.companyResolution?.aliasDisagreementRate ?? 0}\``);
+  lines.push('');
+  lines.push('## Required Checkpoints');
+  if (checkpoints.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const checkpoint of checkpoints) {
+      lines.push(`- \`${checkpoint}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Research Loop Steps');
+  if (planSteps.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const step of planSteps) {
+      const safeStepCommand = sanitizeGateReportCommand(step.command, {
+        allowLiveSave: false,
+        fallback: 'unsafe_command_suppressed',
+      });
+      const command = step.command ? ` — \`${safeStepCommand}\`` : ' — manual gate only';
+      const suffix = step.command && safeStepCommand === 'unsafe_command_suppressed'
+        ? ' (unsafe command suppressed)'
+        : '';
+      lines.push(`- \`${step.id}\`: ${escapeMarkdownCell(step.reason || step.type || 'no reason')}${command}${suffix}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Evidence');
+  lines.push(`- Latest autoresearch: \`${artifact.artifactPath || 'not recorded'}\``);
+  lines.push(`- Latest autoresearch report: \`${artifact.reportPath || 'not recorded'}\``);
+  lines.push(`- Gate dry-safe: \`${gate.drySafe ? 'yes' : 'no'}\``);
+  lines.push(`- Plan dry-safe: \`${plan.drySafe ? 'yes' : 'no'}\``);
+  lines.push('');
+  lines.push('## Operator Rule');
+  if (gate.liveSaveEligible) {
+    lines.push('- Live-save is still supervised: review the mutation artifact, confirm the exact source/list, then run only the rendered reviewed command.');
+  } else {
+    lines.push('- Do not run live-save, live-connect, or background connect modes until this gate is eligible and human-approved.');
+  }
+  return `${lines.join('\n').trim()}\n`;
+}
+
+function getGateOperatorStance(gate = {}) {
+  if (gate.decision === 'eligible_for_live_save') {
+    return 'supervised_live_save_possible_after_human_approval';
+  }
+  if (gate.decision === 'requires_operator_review') {
+    return 'operator_review_required';
+  }
+  if (gate.decision === 'blocked_until_company_resolution') {
+    return 'dry_run_only';
+  }
+  return 'dry_run_only';
+}
+
+function sanitizeGateReportCommand(command, { allowLiveSave = false, fallback = 'unsafe_command_suppressed' } = {}) {
+  const raw = String(command || '').trim();
+  if (!raw) {
+    return fallback;
+  }
+  if (/--live-connect|allow-background-connects/i.test(raw)) {
+    return fallback;
+  }
+  if (!allowLiveSave && /--live-save/i.test(raw)) {
+    return fallback;
+  }
+  if (/\b(?:pilot-live-save-batch|test-list-save|remove-lead-list-members)\b/i.test(raw)) {
+    return fallback;
+  }
+  return raw;
+}
+
 function renderMvpOperatorDashboard(artifact) {
   const lines = [];
   lines.push('# MVP Control Center');
@@ -813,6 +936,7 @@ module.exports = {
   findLatestAutoresearchArtifact,
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   buildRunnerCoverageTarget,
   buildRunnerCoverageByType,
   summarizeBackgroundEvidence,

--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -764,6 +764,155 @@ function sanitizeGateReportCommand(command, { allowLiveSave = false, fallback = 
   return raw;
 }
 
+function buildMvpSupervisorRunbook(artifact) {
+  if (!artifact) {
+    return {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      executionMode: 'read_only_supervisor',
+      autoExecute: false,
+      gateDecision: 'unknown',
+      nextAction: 'run_autoresearch_first',
+      primaryCommand: 'npm run autoresearch:mvp',
+      requiresHumanApproval: false,
+      reasons: ['autoresearch_artifact_missing'],
+      checkpoints: ['generate_autoresearch_artifact_before_supervisor_loop'],
+      planSteps: [],
+      evidence: { artifactPath: null, reportPath: null },
+    };
+  }
+
+  const gate = artifact.executionGate || {};
+  const decision = gate.decision || 'unknown';
+  const planSteps = Array.isArray(artifact.researchLoopPlan?.steps) ? artifact.researchLoopPlan.steps : [];
+  const primaryCommand = chooseSupervisorPrimaryCommand({ decision, gate, planSteps });
+  const nextAction = chooseSupervisorNextAction(decision);
+  const requiresHumanApproval = decision === 'eligible_for_live_save'
+    || decision === 'requires_operator_review'
+    || gate.requiresOperatorApproval === true;
+
+  return {
+    version: 1,
+    generatedAt: artifact.generatedAt || new Date().toISOString(),
+    executionMode: 'read_only_supervisor',
+    autoExecute: false,
+    gateDecision: decision,
+    nextAction,
+    primaryCommand,
+    requiresHumanApproval,
+    liveSaveEligible: gate.liveSaveEligible === true,
+    riskLevel: gate.riskLevel || artifact.evaluationMetrics?.overall?.riskLevel || 'unknown',
+    reasons: Array.isArray(gate.reasons) ? gate.reasons : [],
+    checkpoints: Array.isArray(gate.checkpoints) ? gate.checkpoints : [],
+    planSteps: planSteps.map((step) => ({
+      id: step.id,
+      reason: step.reason || step.type || 'no reason',
+      command: step.command ? sanitizeGateReportCommand(step.command, {
+        allowLiveSave: false,
+        fallback: 'unsafe_command_suppressed',
+      }) : null,
+    })),
+    evidence: {
+      artifactPath: artifact.artifactPath || null,
+      reportPath: artifact.reportPath || null,
+    },
+  };
+}
+
+function chooseSupervisorPrimaryCommand({ decision, gate, planSteps }) {
+  if (decision === 'blocked_until_company_resolution') {
+    const retryStep = planSteps.find((step) => step.id === 'company-resolution-retry' && step.command);
+    return sanitizeGateReportCommand(
+      retryStep?.command || gate.allowedCommandTemplate || 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+      { allowLiveSave: false, fallback: 'unsafe_command_suppressed_run_autoresearch_gate' },
+    );
+  }
+  if (decision === 'requires_operator_review') {
+    return 'npm run autoresearch:gate';
+  }
+  if (decision === 'eligible_for_live_save') {
+    return sanitizeGateReportCommand(
+      gate.allowedCommandTemplate || 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save',
+      { allowLiveSave: true, fallback: 'unsafe_command_suppressed_run_autoresearch_gate' },
+    );
+  }
+  if (decision === 'allow_dry_run_only') {
+    return sanitizeGateReportCommand(
+      gate.allowedCommandTemplate || 'npm run autoresearch:mvp',
+      { allowLiveSave: false, fallback: 'unsafe_command_suppressed_run_autoresearch_mvp' },
+    );
+  }
+  return 'npm run autoresearch:mvp';
+}
+
+function chooseSupervisorNextAction(decision) {
+  switch (decision) {
+    case 'blocked_until_company_resolution':
+      return 'run_company_resolution_retries';
+    case 'requires_operator_review':
+      return 'review_gate_and_mutation_artifacts';
+    case 'eligible_for_live_save':
+      return 'prepare_supervised_live_save';
+    case 'allow_dry_run_only':
+      return 'continue_dry_research';
+    default:
+      return 'run_autoresearch_first';
+  }
+}
+
+function renderMvpSupervisorRunbook(runbook) {
+  const lines = [];
+  const safeRunbook = runbook || buildMvpSupervisorRunbook(null);
+  lines.push('# Autoresearch Supervisor Runbook');
+  lines.push('');
+  lines.push(`- Generated at: \`${safeRunbook.generatedAt || 'unknown'}\``);
+  lines.push(`- Execution mode: \`${safeRunbook.executionMode}\``);
+  lines.push(`- Auto execute: \`${safeRunbook.autoExecute ? 'yes' : 'no'}\``);
+  lines.push(`- Gate decision: \`${safeRunbook.gateDecision}\``);
+  lines.push(`- Next action: \`${safeRunbook.nextAction}\``);
+  lines.push(`- Primary command: \`${safeRunbook.primaryCommand}\``);
+  lines.push(`- Requires human approval: \`${safeRunbook.requiresHumanApproval ? 'yes' : 'no'}\``);
+  lines.push(`- Live save eligible: \`${safeRunbook.liveSaveEligible ? 'yes' : 'no'}\``);
+  lines.push(`- Risk level: \`${safeRunbook.riskLevel || 'unknown'}\``);
+  lines.push('');
+  lines.push('## Reasons');
+  if ((safeRunbook.reasons || []).length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const reason of safeRunbook.reasons) {
+      lines.push(`- \`${reason}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Required Checkpoints');
+  if ((safeRunbook.checkpoints || []).length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const checkpoint of safeRunbook.checkpoints) {
+      lines.push(`- \`${checkpoint}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Plan Steps');
+  if ((safeRunbook.planSteps || []).length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const step of safeRunbook.planSteps) {
+      lines.push(`- \`${step.id}\`: ${escapeMarkdownCell(step.reason || '')}${step.command ? ` — \`${step.command}\`` : ' — manual gate only'}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Evidence');
+  lines.push(`- Latest autoresearch: \`${safeRunbook.evidence?.artifactPath || 'missing'}\``);
+  lines.push(`- Latest autoresearch report: \`${safeRunbook.evidence?.reportPath || 'missing'}\``);
+  lines.push('');
+  lines.push('## Safety Contract');
+  lines.push('- This runbook is advisory and read-only; it never executes the primary command.');
+  lines.push('- Live-save remains supervised and requires human approval plus reviewed mutation artifacts.');
+  lines.push('- Live-connect and background-connect modes are never part of the supervisor runbook.');
+  return `${lines.join('\n').trim()}\n`;
+}
+
 function renderMvpOperatorDashboard(artifact) {
   const lines = [];
   lines.push('# MVP Control Center');
@@ -937,6 +1086,8 @@ module.exports = {
   readLatestAutoresearchArtifact,
   renderMvpOperatorDashboard,
   renderMvpGateReport,
+  buildMvpSupervisorRunbook,
+  renderMvpSupervisorRunbook,
   buildRunnerCoverageTarget,
   buildRunnerCoverageByType,
   summarizeBackgroundEvidence,

--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -1045,6 +1045,170 @@ function getPrimarySafeCommand(artifact) {
   }
 }
 
+function numberOrZero(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function extractSpeedEvaluationMetrics(artifact = {}) {
+  const fastResolve = artifact.evaluationMetrics?.fastResolve || {};
+  const companyResolution = artifact.evaluationMetrics?.companyResolution || {};
+  return {
+    totalMs: numberOrZero(artifact.timings?.totalMs || artifact.totalMs || artifact.durationMs),
+    resolvedSafeToSave: numberOrZero(
+      fastResolve.resolvedSafeToSave
+      ?? fastResolve.bucketCounts?.resolved_safe_to_save
+      ?? artifact.bucketCounts?.resolved_safe_to_save
+      ?? artifact.resolvedSafeToSave
+      ?? artifact.resolvedLeads,
+    ),
+    manualReviewRate: numberOrZero(
+      fastResolve.manualReviewRate
+      ?? artifact.manualReviewRate,
+    ),
+    duplicateWarningRate: numberOrZero(
+      fastResolve.duplicateWarningRate
+      ?? fastResolve.duplicateRate
+      ?? artifact.duplicateWarningRate
+      ?? artifact.duplicateRate,
+    ),
+    companyResolutionBlockers: numberOrZero(
+      companyResolution.blockerCount
+      ?? companyResolution.aliasDisagreements
+      ?? companyResolution.failed
+      ?? companyResolution.needsManualReview
+      ?? companyResolution.blocked
+      ?? artifact.companyResolutionBlockers,
+    ),
+    overallRisk: artifact.evaluationMetrics?.overallRisk || artifact.overallRisk || 'unknown',
+  };
+}
+
+function buildAutoresearchSpeedEvaluation({
+  baseline = null,
+  candidate = null,
+  minSpeedupPercent = 25,
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const baselineMetrics = extractSpeedEvaluationMetrics(baseline || {});
+  const candidateMetrics = extractSpeedEvaluationMetrics(candidate || {});
+  const baselineMs = baselineMetrics.totalMs;
+  const candidateMs = candidateMetrics.totalMs;
+  const speedupPercent = baselineMs > 0 && candidateMs > 0
+    ? Math.round(((baselineMs - candidateMs) / baselineMs) * 1000) / 10
+    : 0;
+  const failedGates = [];
+
+  if (speedupPercent < Number(minSpeedupPercent || 0)) {
+    failedGates.push('speedup_below_threshold');
+  }
+  if (candidateMetrics.resolvedSafeToSave < baselineMetrics.resolvedSafeToSave) {
+    failedGates.push('resolved_safe_to_save_regressed');
+  }
+  if (candidateMetrics.manualReviewRate > baselineMetrics.manualReviewRate) {
+    failedGates.push('manual_review_rate_regressed');
+  }
+  if (candidateMetrics.duplicateWarningRate > baselineMetrics.duplicateWarningRate) {
+    failedGates.push('duplicate_warning_rate_regressed');
+  }
+  if (candidateMetrics.companyResolutionBlockers > baselineMetrics.companyResolutionBlockers) {
+    failedGates.push('company_resolution_blockers_regressed');
+  }
+
+  const qualityRegression = failedGates.some((gate) => gate !== 'speedup_below_threshold');
+  const decision = failedGates.length === 0
+    ? 'keep_candidate'
+    : (qualityRegression ? 'revert_candidate' : 'needs_more_evidence');
+
+  return {
+    generatedAt,
+    mode: 'read_only_speed_evaluation',
+    decision,
+    minSpeedupPercent: Number(minSpeedupPercent || 0),
+    failedGates,
+    speed: {
+      baselineMs,
+      candidateMs,
+      speedupPercent,
+    },
+    quality: {
+      baseline: baselineMetrics,
+      candidate: candidateMetrics,
+      qualityRegression,
+    },
+    safety: {
+      drySafe: true,
+      readOnly: true,
+      liveMutationAllowed: false,
+      autoExecute: false,
+    },
+    evidence: {
+      baselineArtifactPath: baseline?.artifactPath || null,
+      candidateArtifactPath: candidate?.artifactPath || null,
+    },
+  };
+}
+
+function formatPercent(value) {
+  return `${Math.round(numberOrZero(value) * 1000) / 10}%`;
+}
+
+function renderAutoresearchSpeedEvaluationMarkdown(evaluation = {}) {
+  const baseline = evaluation.quality?.baseline || {};
+  const candidate = evaluation.quality?.candidate || {};
+  const lines = [];
+  lines.push('# Autoresearch Speed Evaluation');
+  lines.push('');
+  lines.push(`- Generated at: \`${evaluation.generatedAt || new Date().toISOString()}\``);
+  lines.push(`- Execution mode: \`${evaluation.mode || 'read_only_speed_evaluation'}\``);
+  lines.push(`- Decision: \`${evaluation.decision || 'needs_more_evidence'}\``);
+  lines.push(`- Minimum speedup: \`${evaluation.minSpeedupPercent ?? 25}%\``);
+  lines.push(`- Actual speedup: \`${evaluation.speed?.speedupPercent ?? 0}%\``);
+  lines.push(`- Auto execute: \`${evaluation.safety?.autoExecute ? 'yes' : 'no'}\``);
+  lines.push('');
+  lines.push('## Speed');
+  lines.push(`- Baseline total: \`${evaluation.speed?.baselineMs || 0}ms\``);
+  lines.push(`- Candidate total: \`${evaluation.speed?.candidateMs || 0}ms\``);
+  lines.push('');
+  lines.push('## Quality Gate');
+  lines.push(`- Baseline resolved safe-to-save: \`${baseline.resolvedSafeToSave || 0}\``);
+  lines.push(`- Candidate resolved safe-to-save: \`${candidate.resolvedSafeToSave || 0}\``);
+  lines.push(`- Baseline manual review rate: \`${formatPercent(baseline.manualReviewRate)}\``);
+  lines.push(`- Candidate manual review rate: \`${formatPercent(candidate.manualReviewRate)}\``);
+  lines.push(`- Baseline duplicate warning rate: \`${formatPercent(baseline.duplicateWarningRate)}\``);
+  lines.push(`- Candidate duplicate warning rate: \`${formatPercent(candidate.duplicateWarningRate)}\``);
+  lines.push(`- Baseline company blockers: \`${baseline.companyResolutionBlockers || 0}\``);
+  lines.push(`- Candidate company blockers: \`${candidate.companyResolutionBlockers || 0}\``);
+  lines.push(`- Quality regression: \`${evaluation.quality?.qualityRegression ? 'yes' : 'no'}\``);
+  lines.push('');
+  lines.push('## Failed Gates');
+  const failed = evaluation.failedGates || [];
+  if (failed.length === 0) {
+    lines.push('- `none`');
+  } else {
+    for (const gate of failed) {
+      lines.push(`- \`${gate}\``);
+    }
+  }
+  lines.push('');
+  lines.push('## Safety Contract');
+  lines.push('- No Sales Navigator mutation is executed by this evaluation.');
+  lines.push('- This report only compares dry artifacts and quality metrics.');
+  lines.push('- Keep/revert decisions are advisory until reviewed by an operator.');
+  lines.push('');
+  lines.push('## Evidence');
+  if (evaluation.evidence?.baselineArtifactPath) {
+    lines.push(`- Baseline artifact: \`${evaluation.evidence.baselineArtifactPath}\``);
+  }
+  if (evaluation.evidence?.candidateArtifactPath) {
+    lines.push(`- Candidate artifact: \`${evaluation.evidence.candidateArtifactPath}\``);
+  }
+  if (!evaluation.evidence?.baselineArtifactPath && !evaluation.evidence?.candidateArtifactPath) {
+    lines.push('- `no artifact paths provided`');
+  }
+  return `${lines.join('\n').trim()}\n`;
+}
+
 function writeMvpAutoresearchRun(options = {}) {
   const artifact = buildMvpAutoresearchArtifact(options);
   const artifactPath = options.artifactPath || buildAutoresearchArtifactPath(new Date(artifact.generatedAt));
@@ -1088,6 +1252,8 @@ module.exports = {
   renderMvpGateReport,
   buildMvpSupervisorRunbook,
   renderMvpSupervisorRunbook,
+  buildAutoresearchSpeedEvaluation,
+  renderAutoresearchSpeedEvaluationMarkdown,
   buildRunnerCoverageTarget,
   buildRunnerCoverageByType,
   summarizeBackgroundEvidence,

--- a/src/core/fast-list-import.js
+++ b/src/core/fast-list-import.js
@@ -1,5 +1,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const crypto = require('node:crypto');
 const { readJson, writeJson } = require('../lib/json');
 const {
   ACCOUNT_BATCH_ARTIFACTS_DIR,
@@ -154,6 +155,16 @@ function buildFastResolveQueryPlan({ lead, identityResolution, companyResolution
     seen.add(key);
     return true;
   });
+}
+
+function buildFastResolveQueryCacheKey({ query, maxCandidates } = {}) {
+  const normalizedQuery = normalizeLookupValue(String(query || '').trim());
+  const cap = Number.isFinite(Number(maxCandidates)) ? Number(maxCandidates) : 0;
+  return `${normalizedQuery}::mc:${cap}`;
+}
+
+function fingerprintFastResolveCacheKey(cacheKey = '') {
+  return crypto.createHash('sha256').update(String(cacheKey)).digest('hex').slice(0, 16);
 }
 
 function dedupeStrings(values = []) {
@@ -925,6 +936,13 @@ async function fastResolveLeads({
   const safeSearchTimeout = Math.max(2000, Number(searchTimeoutMs || 8000));
   const selectorTimeout = Math.max(1000, Math.floor(safeSearchTimeout / 2));
   const aliasResearchCache = new Map();
+  const fastResolveSearchCache = new Map();
+  const queryCacheState = {
+    hits: 0,
+    misses: 0,
+    avoidedSearches: 0,
+    keyFingerprints: new Set(),
+  };
 
   async function collectScoredCandidates(leadForResolution, queryPlan, aliasTerms) {
     const scored = [];
@@ -950,31 +968,45 @@ async function fastResolveLeads({
         titleIncludes: [],
       };
 
+      const cacheLookupKey = buildFastResolveQueryCacheKey({ query, maxCandidates });
+      queryCacheState.keyFingerprints.add(fingerprintFastResolveCacheKey(cacheLookupKey));
+
       let candidates = [];
-      try {
-        await driver.openPeopleSearch(account, { runId, accountKey: 'fast-resolve-unscoped' });
-        await driver.applySearchTemplate(template, { runId, accountKey: 'fast-resolve-unscoped' });
-        candidates = await driver.scrollAndCollectCandidates(account, template, {
-          runId,
-          accountKey: 'fast-resolve-unscoped',
-          resultTimeoutMs: selectorTimeout,
-          hydrateTimeoutMs: selectorTimeout,
-        });
-      } catch (error) {
-        scored.push({
-          candidate: {
-            fullName: null,
-            title: null,
-            company: null,
-            salesNavigatorUrl: null,
-          },
-          score: 0,
-          exactName: false,
-          slugMatch: false,
-          companyMatch: false,
-          titleMatch: false,
-          error: error.message,
-        });
+      if (fastResolveSearchCache.has(cacheLookupKey)) {
+        candidates = fastResolveSearchCache.get(cacheLookupKey).slice();
+        queryCacheState.hits += 1;
+        queryCacheState.avoidedSearches += 1;
+      } else {
+        queryCacheState.misses += 1;
+        try {
+          await driver.openPeopleSearch(account, { runId, accountKey: 'fast-resolve-unscoped' });
+          await driver.applySearchTemplate(template, { runId, accountKey: 'fast-resolve-unscoped' });
+          candidates = await driver.scrollAndCollectCandidates(account, template, {
+            runId,
+            accountKey: 'fast-resolve-unscoped',
+            resultTimeoutMs: selectorTimeout,
+            hydrateTimeoutMs: selectorTimeout,
+          });
+          fastResolveSearchCache.set(
+            cacheLookupKey,
+            Array.isArray(candidates) ? candidates.slice() : [],
+          );
+        } catch (error) {
+          scored.push({
+            candidate: {
+              fullName: null,
+              title: null,
+              company: null,
+              salesNavigatorUrl: null,
+            },
+            score: 0,
+            exactName: false,
+            slugMatch: false,
+            companyMatch: false,
+            titleMatch: false,
+            error: error.message,
+          });
+        }
       }
 
       for (const candidate of candidates) {
@@ -1306,6 +1338,13 @@ async function fastResolveLeads({
     maxCandidates,
     groupedCompanyPool,
     timings: finishRunTimings(timings, now),
+    queryCache: {
+      enabled: true,
+      hits: queryCacheState.hits,
+      misses: queryCacheState.misses,
+      avoidedSearches: queryCacheState.avoidedSearches,
+      keyFingerprints: Array.from(queryCacheState.keyFingerprints).sort(),
+    },
     leads,
   });
 }
@@ -2004,6 +2043,7 @@ module.exports = {
   buildFastListImportArtifactPath,
   buildFastResolveArtifact,
   buildFastResolveArtifactPath,
+  buildFastResolveQueryCacheKey,
   buildMutationReviewArtifact,
   buildMutationReviewArtifactPath,
   bucketFastResolveLead,

--- a/src/lib/args.js
+++ b/src/lib/args.js
@@ -56,6 +56,7 @@ function parseCliArgs(argv) {
       'speed-profile': { type: 'string' },
       'research-concurrency': { type: 'string' },
       'reuse-sweep-cache': { type: 'boolean' },
+      'adaptive-sweep-pruning': { type: 'boolean' },
       'max-age-hours': { type: 'string' },
       'skip-session-check': { type: 'boolean' },
       checklist: { type: 'boolean' },

--- a/tests/account-coverage.test.js
+++ b/tests/account-coverage.test.js
@@ -51,9 +51,20 @@ test('buildSweepTemplates applies speed profiles without adding hidden candidate
   };
 
   const fast = buildSweepTemplates(config, null, { speedProfile: 'fast' });
+  const fastAdaptive = buildSweepTemplates(config, null, {
+    speedProfile: 'fast',
+    adaptiveSweepPruning: true,
+  });
   const balanced = buildSweepTemplates(config, null, { speedProfile: 'balanced' });
 
   assert.deepEqual(fast.map((template) => template.id), ['broad-crawl', 'sweep-platform']);
+  assert.deepEqual(fastAdaptive.map((template) => template.id), [
+    'broad-crawl',
+    'sweep-platform',
+    'sweep-security',
+    'sweep-data',
+  ]);
+  assert.equal(fastAdaptive.some((template) => Object.hasOwn(template, 'maxCandidates')), false);
   assert.equal(fast.some((template) => Object.hasOwn(template, 'maxCandidates')), false);
   assert.deepEqual(balanced.map((template) => template.id), [
     'broad-crawl',
@@ -853,4 +864,169 @@ test('findAccountAliasEntry tolerates legal suffix and punctuation variants', ()
     findAccountAliasEntry(config, 'Example Broadcast Studio').companyFilterAliases[0],
     'Example Broadcaster',
   );
+});
+
+test('runAccountCoverageWorkflow keeps adaptiveSweepPruning off unless explicitly opted in', async () => {
+  const coverageConfig = {
+    version: 'adaptive-default-off',
+    broadCrawl: { enabled: true, maxCandidates: 3 },
+    sweeps: [
+      { id: 'platform', keywords: ['platform engineering'], maxCandidates: 3 },
+    ],
+  };
+  const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
+
+  const driver = {
+    async openAccountSearch() {},
+    async enumerateAccounts(accounts) {
+      return accounts;
+    },
+    async openPeopleSearch() {},
+    async applySearchTemplate() {},
+    async scrollAndCollectCandidates() {
+      return [];
+    },
+  };
+
+  const run = await runAccountCoverageWorkflow({
+    driver,
+    accountName: 'Adaptive Default Off Account',
+    coverageConfig,
+    icpConfig,
+    priorityModel: null,
+    maxCandidates: 3,
+    speedProfile: 'fast',
+  });
+
+  assert.equal(run.result.adaptivePruning.enabled, false);
+  assert.equal(run.result.adaptivePruning.triggered, false);
+});
+
+test('adaptive pruning (fast): skips remaining low-yield rest sweep after broad + priority', async () => {
+  const coverageConfig = {
+    version: 'adaptive-prune-fast',
+    broadCrawl: { enabled: true, maxCandidates: 3 },
+    sweeps: [
+      { id: 'platform', keywords: ['platform engineering'], maxCandidates: 3 },
+      { id: 'security-noisy-rest', keywords: ['zzz-nonpriority-keyword'], maxCandidates: 3 },
+    ],
+  };
+  const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
+  const applyCalls = [];
+
+  const driver = {
+    async openAccountSearch() {},
+    async enumerateAccounts(accounts) {
+      return accounts;
+    },
+    async openPeopleSearch() {},
+    async applySearchTemplate(template) {
+      applyCalls.push(template.id);
+    },
+    async scrollAndCollectCandidates() {
+      return [];
+    },
+  };
+
+  const run = await runAccountCoverageWorkflow({
+    driver,
+    accountName: 'Adaptive Prune Fast Account',
+    coverageConfig,
+    icpConfig,
+    priorityModel: null,
+    maxCandidates: 3,
+    speedProfile: 'fast',
+    adaptiveSweepPruning: true,
+  });
+
+  assert.deepEqual(applyCalls, ['broad-crawl', 'sweep-platform']);
+  assert.equal(run.result.adaptivePruning.enabled, true);
+  assert.equal(run.result.adaptivePruning.triggered, true);
+  assert.ok(run.result.adaptivePruning.reason.includes('low_yield'));
+  assert.deepEqual(run.result.adaptivePruning.skippedTemplates, ['sweep-security-noisy-rest']);
+  assert.deepEqual(run.result.adaptivePruning.executedTemplates, ['broad-crawl', 'sweep-platform']);
+  assert.equal(run.result.sweepErrors?.length || 0, 0);
+  assert.notEqual(run.result.resolutionStatus, 'needs_company_resolution');
+});
+
+test('adaptive pruning (exhaustive): runs every sweep and does not prune', async () => {
+  const coverageConfig = {
+    version: 'adaptive-prune-exhaustive',
+    broadCrawl: { enabled: true, maxCandidates: 3 },
+    sweeps: [
+      { id: 'platform', keywords: ['platform'], maxCandidates: 3 },
+      { id: 'data-rest', keywords: ['analytics_only_rest'], maxCandidates: 3 },
+    ],
+  };
+  const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
+  const applyCalls = [];
+
+  const driver = {
+    async openAccountSearch() {},
+    async enumerateAccounts(accounts) {
+      return accounts;
+    },
+    async openPeopleSearch() {},
+    async applySearchTemplate(template) {
+      applyCalls.push(template.id);
+    },
+    async scrollAndCollectCandidates() {
+      return [];
+    },
+  };
+
+  const run = await runAccountCoverageWorkflow({
+    driver,
+    accountName: 'Adaptive Prune Exhaustive Account',
+    coverageConfig,
+    icpConfig,
+    priorityModel: null,
+    maxCandidates: 3,
+    speedProfile: 'exhaustive',
+    adaptiveSweepPruning: true,
+  });
+
+  assert.deepEqual(applyCalls, ['broad-crawl', 'sweep-platform', 'sweep-data-rest']);
+  assert.equal(run.result.adaptivePruning.enabled, false);
+  assert.equal(run.result.adaptivePruning.triggered, false);
+  assert.deepEqual(run.result.adaptivePruning.skippedTemplates || [], []);
+});
+
+test('adaptive pruning: skipped sweeps are not sweepErrors and do not force company-resolution summary', async () => {
+  const coverageConfig = {
+    version: 'adaptive-prune-clean',
+    broadCrawl: { enabled: true, maxCandidates: 3 },
+    sweeps: [
+      { id: 'architecture', keywords: ['architecture'], maxCandidates: 3 },
+      { id: 'noise-rest', keywords: ['zzz-rest-only'], maxCandidates: 3 },
+    ],
+  };
+  const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
+
+  const driver = {
+    async openAccountSearch() {},
+    async enumerateAccounts(accounts) {
+      return accounts;
+    },
+    async openPeopleSearch() {},
+    async applySearchTemplate() {},
+    async scrollAndCollectCandidates() {
+      return [];
+    },
+  };
+
+  const run = await runAccountCoverageWorkflow({
+    driver,
+    accountName: 'Adaptive Prune Clean Account',
+    coverageConfig,
+    icpConfig,
+    priorityModel: null,
+    maxCandidates: 3,
+    speedProfile: 'fast',
+    adaptiveSweepPruning: true,
+  });
+
+  assert.equal(run.sweepErrors.length, 0);
+  assert.equal(run.result.sweepErrors?.length || 0, 0);
+  assert.notEqual(run.result.resolutionStatus, 'needs_company_resolution');
 });

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -15,6 +15,8 @@ const {
   renderMvpGateReport,
   buildMvpSupervisorRunbook,
   renderMvpSupervisorRunbook,
+  buildAutoresearchSpeedEvaluation,
+  renderAutoresearchSpeedEvaluationMarkdown,
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
@@ -647,6 +649,143 @@ test('renderMvpSupervisorRunbook is operator-facing and suppresses unsafe comman
   assert.doesNotMatch(markdown, /--live-save/);
   assert.doesNotMatch(markdown, /--live-connect/);
   assert.match(markdown, /Latest autoresearch: `\/tmp\/mvp-autoresearch.json`/);
+});
+
+test('buildAutoresearchSpeedEvaluation keeps faster candidates only when quality does not regress', () => {
+  const baseline = {
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    timings: { totalMs: 120000 },
+    evaluationMetrics: {
+      fastResolve: {
+        resolvedSafeToSave: 40,
+        manualReviewRate: 0.12,
+        duplicateWarningRate: 0.03,
+      },
+      companyResolution: { blockerCount: 1 },
+      overallRisk: 'medium',
+    },
+  };
+  const candidate = {
+    generatedAt: '2026-04-24T07:00:00.000Z',
+    timings: { totalMs: 78000 },
+    evaluationMetrics: {
+      fastResolve: {
+        resolvedSafeToSave: 41,
+        manualReviewRate: 0.11,
+        duplicateWarningRate: 0.02,
+      },
+      companyResolution: { blockerCount: 1 },
+      overallRisk: 'low',
+    },
+  };
+
+  const evaluation = buildAutoresearchSpeedEvaluation({ baseline, candidate, minSpeedupPercent: 25 });
+
+  assert.equal(evaluation.mode, 'read_only_speed_evaluation');
+  assert.equal(evaluation.decision, 'keep_candidate');
+  assert.equal(evaluation.speed.speedupPercent, 35);
+  assert.equal(evaluation.quality.qualityRegression, false);
+  assert.equal(evaluation.safety.liveMutationAllowed, false);
+  assert.deepEqual(evaluation.failedGates, []);
+});
+
+test('buildAutoresearchSpeedEvaluation rejects faster candidates with lead-quality regressions', () => {
+  const baseline = {
+    timings: { totalMs: 100000 },
+    evaluationMetrics: {
+      fastResolve: {
+        resolvedSafeToSave: 20,
+        manualReviewRate: 0.1,
+        duplicateWarningRate: 0.02,
+      },
+      companyResolution: { blockerCount: 0 },
+    },
+  };
+  const candidate = {
+    timings: { totalMs: 50000 },
+    evaluationMetrics: {
+      fastResolve: {
+        resolvedSafeToSave: 18,
+        manualReviewRate: 0.2,
+        duplicateWarningRate: 0.05,
+      },
+      companyResolution: { blockerCount: 1 },
+    },
+  };
+
+  const evaluation = buildAutoresearchSpeedEvaluation({ baseline, candidate, minSpeedupPercent: 25 });
+
+  assert.equal(evaluation.decision, 'revert_candidate');
+  assert.equal(evaluation.quality.qualityRegression, true);
+  assert.match(evaluation.failedGates.join(' '), /resolved_safe_to_save_regressed/);
+  assert.match(evaluation.failedGates.join(' '), /manual_review_rate_regressed/);
+  assert.match(evaluation.failedGates.join(' '), /company_resolution_blockers_regressed/);
+});
+
+test('buildAutoresearchSpeedEvaluation rejects real evaluation metric duplicate and company regressions', () => {
+  const evaluation = buildAutoresearchSpeedEvaluation({
+    baseline: {
+      timings: { totalMs: 100000 },
+      evaluationMetrics: {
+        fastResolve: {
+          resolvedSafeToSave: 10,
+          manualReviewRate: 0,
+          duplicateRate: 0,
+        },
+        companyResolution: {
+          aliasDisagreements: 0,
+          aliasDisagreementRate: 0,
+        },
+      },
+    },
+    candidate: {
+      timings: { totalMs: 50000 },
+      evaluationMetrics: {
+        fastResolve: {
+          resolvedSafeToSave: 10,
+          manualReviewRate: 0,
+          duplicateRate: 0.5,
+        },
+        companyResolution: {
+          aliasDisagreements: 2,
+          aliasDisagreementRate: 0.5,
+        },
+      },
+    },
+    minSpeedupPercent: 25,
+  });
+
+  assert.equal(evaluation.decision, 'revert_candidate');
+  assert.match(evaluation.failedGates.join(' '), /duplicate_warning_rate_regressed/);
+  assert.match(evaluation.failedGates.join(' '), /company_resolution_blockers_regressed/);
+});
+
+test('renderAutoresearchSpeedEvaluationMarkdown is operator-facing and read-only', () => {
+  const markdown = renderAutoresearchSpeedEvaluationMarkdown(buildAutoresearchSpeedEvaluation({
+    baseline: {
+      artifactPath: 'runtime/artifacts/autoresearch/baseline.json',
+      timings: { totalMs: 90000 },
+      evaluationMetrics: {
+        fastResolve: { resolvedSafeToSave: 12, manualReviewRate: 0.1, duplicateWarningRate: 0 },
+        companyResolution: { blockerCount: 0 },
+      },
+    },
+    candidate: {
+      artifactPath: 'runtime/artifacts/autoresearch/candidate.json',
+      timings: { totalMs: 60000 },
+      evaluationMetrics: {
+        fastResolve: { resolvedSafeToSave: 12, manualReviewRate: 0.1, duplicateWarningRate: 0 },
+        companyResolution: { blockerCount: 0 },
+      },
+    },
+    minSpeedupPercent: 20,
+  }));
+
+  assert.match(markdown, /# Autoresearch Speed Evaluation/);
+  assert.match(markdown, /Decision: `keep_candidate`/);
+  assert.match(markdown, /Execution mode: `read_only_speed_evaluation`/);
+  assert.doesNotMatch(markdown, /--live-save|--live-connect|allow-background-connects/);
+  assert.match(markdown, /No Sales Navigator mutation is executed/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -13,6 +13,8 @@ const {
   renderMvpAutoresearchMarkdown,
   renderMvpOperatorDashboard,
   renderMvpGateReport,
+  buildMvpSupervisorRunbook,
+  renderMvpSupervisorRunbook,
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
@@ -556,6 +558,95 @@ test('renderMvpGateReport suppresses unsafe commands in stale or malformed non-l
   assert.doesNotMatch(report, /--live-save/);
   assert.doesNotMatch(report, /--live-connect/);
   assert.doesNotMatch(report, /allow-background-connects/);
+});
+
+test('buildMvpSupervisorRunbook maps execution gate decisions to read-only next steps', () => {
+  const cases = [
+    {
+      decision: 'allow_dry_run_only',
+      expectedAction: 'continue_dry_research',
+      command: 'npm run autoresearch:mvp',
+    },
+    {
+      decision: 'blocked_until_company_resolution',
+      expectedAction: 'run_company_resolution_retries',
+      command: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+    },
+    {
+      decision: 'requires_operator_review',
+      expectedAction: 'review_gate_and_mutation_artifacts',
+      command: 'npm run autoresearch:gate',
+    },
+    {
+      decision: 'eligible_for_live_save',
+      expectedAction: 'prepare_supervised_live_save',
+      command: 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save',
+      requiresHumanApproval: true,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const runbook = buildMvpSupervisorRunbook({
+      generatedAt: '2026-04-24T06:00:00.000Z',
+      executionGate: {
+        drySafe: true,
+        decision: testCase.decision,
+        liveSaveEligible: testCase.decision === 'eligible_for_live_save',
+        requiresOperatorApproval: testCase.requiresHumanApproval || testCase.decision === 'requires_operator_review',
+        riskLevel: testCase.decision === 'eligible_for_live_save' ? 'low' : 'medium',
+        reasons: testCase.decision === 'blocked_until_company_resolution' ? ['company_resolution_retry_pending'] : [],
+        allowedCommandTemplate: testCase.command,
+        checkpoints: ['confirm_no_live_connect_or_background_connect_flags'],
+      },
+      researchLoopPlan: {
+        drySafe: true,
+        steps: testCase.decision === 'blocked_until_company_resolution'
+          ? [{ id: 'company-resolution-retry', command: testCase.command, reason: 'retry company resolution' }]
+          : [],
+      },
+      evaluationMetrics: { overall: { riskLevel: 'medium', indicators: [] } },
+    });
+
+    assert.equal(runbook.executionMode, 'read_only_supervisor');
+    assert.equal(runbook.autoExecute, false);
+    assert.equal(runbook.nextAction, testCase.expectedAction);
+    assert.equal(runbook.primaryCommand, testCase.command);
+    assert.equal(runbook.requiresHumanApproval, Boolean(testCase.requiresHumanApproval || testCase.decision === 'requires_operator_review'));
+  }
+});
+
+test('renderMvpSupervisorRunbook is operator-facing and suppresses unsafe commands for non-live decisions', () => {
+  const runbook = buildMvpSupervisorRunbook({
+    artifactPath: '/tmp/mvp-autoresearch.json',
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'allow_dry_run_only',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'low',
+      reasons: ['mutation_review_artifact_missing'],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=/tmp/leads.md --live-save',
+      checkpoints: [],
+    },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        { id: 'unsafe-connect', command: 'node src/cli.js run-background-territory-loop --live-connect', reason: 'malformed stale artifact' },
+      ],
+    },
+    evaluationMetrics: { overall: { riskLevel: 'low', indicators: [] } },
+  });
+  const markdown = renderMvpSupervisorRunbook(runbook);
+
+  assert.match(markdown, /# Autoresearch Supervisor Runbook/);
+  assert.match(markdown, /Execution mode: `read_only_supervisor`/);
+  assert.match(markdown, /Auto execute: `no`/);
+  assert.match(markdown, /Next action: `continue_dry_research`/);
+  assert.match(markdown, /unsafe_command_suppressed/);
+  assert.doesNotMatch(markdown, /--live-save/);
+  assert.doesNotMatch(markdown, /--live-connect/);
+  assert.match(markdown, /Latest autoresearch: `\/tmp\/mvp-autoresearch.json`/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -12,6 +12,7 @@ const {
   buildMvpAutoresearchArtifact,
   renderMvpAutoresearchMarkdown,
   renderMvpOperatorDashboard,
+  renderMvpGateReport,
   writeMvpAutoresearchRun,
 } = require('../src/core/autoresearch-mvp');
 const { buildResearchLoopPlan } = require('../src/core/research-loop-planner');
@@ -446,6 +447,115 @@ test('buildMvpAutoresearchArtifact includes execution gate in JSON and Markdown'
   assert.equal(artifact.executionGate.liveSaveEligible, false);
   assert.match(markdown, /## Execution Gate/);
   assert.match(markdown, /Decision:/);
+});
+
+test('renderMvpGateReport gives an operator-facing read-only gate summary', () => {
+  const report = renderMvpGateReport({
+    artifactPath: '/tmp/mvp-autoresearch.json',
+    reportPath: '/tmp/mvp-autoresearch.md',
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'blocked_until_company_resolution',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'medium',
+      reasons: ['company_resolution_retry_pending', 'mutation_review_artifact_missing'],
+      allowedCommandTemplate: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+      checkpoints: ['do_not_run_live_save_until_gate_is_eligible'],
+    },
+    evaluationMetrics: {
+      overall: { riskLevel: 'medium', indicators: ['company_resolution_failure_rate'] },
+      fastResolve: { manualReviewRate: 0.25, duplicateRate: 0.1 },
+      background: { noiseRate: 0.2 },
+      companyResolution: { aliasDisagreementRate: 0.1 },
+    },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        {
+          id: 'company-resolution-retry',
+          type: 'cli_command',
+          command: 'node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25',
+          reason: 'retry failed scoped company resolution',
+        },
+        { id: 'operator-review', type: 'manual_gate', command: null, reason: 'review blockers' },
+      ],
+    },
+  });
+
+  assert.match(report, /# Autoresearch Execution Gate/);
+  assert.match(report, /Decision: `blocked_until_company_resolution`/);
+  assert.match(report, /Live save eligible: `no`/);
+  assert.match(report, /Primary command: `node src\/cli\.js run-company-resolution-retries/);
+  assert.match(report, /Operator stance: `dry_run_only`/);
+  assert.match(report, /company_resolution_retry_pending/);
+  assert.match(report, /## Why Blocked or Gated/);
+  assert.match(report, /## Evidence/);
+  assert.doesNotMatch(report, /--live-save/);
+  assert.doesNotMatch(report, /--live-connect/);
+});
+
+test('renderMvpGateReport makes eligible live-save explicit but supervised', () => {
+  const report = renderMvpGateReport({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'eligible_for_live_save',
+      liveSaveEligible: true,
+      requiresOperatorApproval: true,
+      riskLevel: 'low',
+      reasons: [],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save',
+      checkpoints: ['operator_confirms_mutation_review_before_live_save'],
+    },
+    evaluationMetrics: {
+      overall: { riskLevel: 'low', indicators: [] },
+      fastResolve: { manualReviewRate: 0, duplicateRate: 0 },
+      background: { noiseRate: 0 },
+      companyResolution: { aliasDisagreementRate: 0 },
+    },
+    researchLoopPlan: { drySafe: true, steps: [] },
+  });
+
+  assert.match(report, /Decision: `eligible_for_live_save`/);
+  assert.match(report, /Operator stance: `supervised_live_save_possible_after_human_approval`/);
+  assert.match(report, /Primary command: `node src\/cli\.js fast-list-import --source=<reviewed-source> --list-name=<reviewed-list> --live-save`/);
+  assert.match(report, /Required approval: `yes`/);
+});
+
+test('renderMvpGateReport suppresses unsafe commands in stale or malformed non-live artifacts', () => {
+  const report = renderMvpGateReport({
+    generatedAt: '2026-04-24T06:00:00.000Z',
+    executionGate: {
+      drySafe: true,
+      decision: 'allow_dry_run_only',
+      liveSaveEligible: false,
+      requiresOperatorApproval: false,
+      riskLevel: 'low',
+      reasons: [],
+      allowedCommandTemplate: 'node src/cli.js fast-list-import --source=/tmp/leads.md --live-save',
+      checkpoints: [],
+    },
+    evaluationMetrics: { overall: { riskLevel: 'low', indicators: [] } },
+    researchLoopPlan: {
+      drySafe: true,
+      steps: [
+        {
+          id: 'unsafe-connect',
+          type: 'cli_command',
+          command: 'node src/cli.js run-background-territory-loop --allow-background-connects --live-connect',
+          reason: 'malformed stale artifact',
+        },
+      ],
+    },
+  });
+
+  assert.match(report, /unsafe_command_suppressed/);
+  assert.match(report, /unsafe command suppressed/);
+  assert.doesNotMatch(report, /--live-save/);
+  assert.doesNotMatch(report, /--live-connect/);
+  assert.doesNotMatch(report, /allow-background-connects/);
 });
 
 test('research loop planner emits deterministic dry-safe CLI DAG from autoresearch evidence', () => {

--- a/tests/fast-list-import.test.js
+++ b/tests/fast-list-import.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const {
   buildCompanyAliasTerms,
+  buildFastResolveQueryCacheKey,
   buildFastResolveQueryPlan,
   bucketFastResolveLead,
   classifySaveFailure,
@@ -1444,4 +1445,144 @@ test('writeMutationReviewArtifact writes paired JSON and Markdown artifacts', ()
   assert.equal(parsed.summary.intendedAdds, 1);
   assert.match(markdown, /Live Mutation Review/);
   assert.match(written.reportPath, /\.md$/);
+});
+
+test('buildFastResolveQueryCacheKey includes maxCandidates so result shape cannot collide', () => {
+  assert.notEqual(
+    buildFastResolveQueryCacheKey({ query: 'Jane Doe Acme', maxCandidates: 4 }),
+    buildFastResolveQueryCacheKey({ query: 'Jane Doe Acme', maxCandidates: 8 }),
+  );
+  assert.equal(
+    buildFastResolveQueryCacheKey({ query: '  Jane Doe Acme  ', maxCandidates: 4 }),
+    buildFastResolveQueryCacheKey({ query: 'jane doe acme', maxCandidates: 4 }),
+  );
+});
+
+test('fastResolveLeads query cache: identical query across two leads runs search once and reports telemetry', async () => {
+  let openCount = 0;
+  let applyCount = 0;
+  let scrollCount = 0;
+  const calls = [];
+  const driver = {
+    async openPeopleSearch() {
+      openCount += 1;
+    },
+    async applySearchTemplate(template) {
+      applyCount += 1;
+      calls.push(template.keywords[0]);
+    },
+    async scrollAndCollectCandidates() {
+      scrollCount += 1;
+      return [{
+        fullName: 'Twin Lead',
+        title: 'Engineer',
+        company: 'Shared Accounts Co',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/twin-lead',
+      }];
+    },
+  };
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const sourcePath = path.join(os.tmpdir(), `fast-resolve-cache-dedupe-${Date.now()}.md`);
+  fs.writeFileSync(sourcePath, `
+| # | Account | Name | Titel | Score | Tier | LinkedIn |
+|---|---|---|---|---|---|---|
+| 1 | Shared Accounts Co | Twin Lead | Engineer | 50 | Tier 2 | [linkedin.com/in/twin-a](https://www.linkedin.com/in/twin-a) |
+| 2 | Shared Accounts Co | Twin Lead | Engineer | 50 | Tier 2 | [linkedin.com/in/twin-b](https://www.linkedin.com/in/twin-b) |
+`);
+
+  const artifact = await fastResolveLeads({
+    driver,
+    sourcePath,
+    aliasConfig: {
+      accounts: {
+        'shared accounts co': {
+          companyFilterAliases: ['Shared Accounts Co'],
+          resolutionStatus: 'resolved_exact',
+        },
+      },
+    },
+    searchTimeoutMs: 8000,
+    maxCandidates: 4,
+    groupedCompanyPool: false,
+  });
+
+  assert.equal(openCount, 1);
+  assert.equal(applyCount, 1);
+  assert.equal(scrollCount, 1);
+  assert.equal(artifact.queryCache?.enabled, true);
+  assert.equal(artifact.queryCache?.hits >= 1, true);
+  assert.equal(artifact.queryCache?.misses >= 1, true);
+  assert.equal(artifact.queryCache?.avoidedSearches >= 1, true);
+  assert.equal(artifact.bucketCounts.resolved_safe_to_save, 2);
+  assert.ok(Array.isArray(artifact.queryCache?.keyFingerprints));
+});
+
+test('fastResolveLeads query cache: rescored per lead; cached roster is scored independently (slug differs)', async () => {
+  let scrollCount = 0;
+  const driver = {
+    async openPeopleSearch() {},
+    async applySearchTemplate() {},
+    async scrollAndCollectCandidates() {
+      scrollCount += 1;
+      return [{
+        fullName: 'Jane Doe',
+        title: 'Engineer',
+        company: 'Cache Rescore Co',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/jane-doe',
+      }];
+    },
+  };
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const sourcePath = path.join(os.tmpdir(), `fast-resolve-cache-rescore-${Date.now()}.json`);
+  fs.writeFileSync(sourcePath, JSON.stringify({
+    listName: 'Rescore cache test',
+    leads: [
+      {
+        row: 1,
+        accountName: 'Cache Rescore Co',
+        fullName: 'Jane Doe',
+        title: 'Engineer',
+        publicLinkedInUrl: 'https://www.linkedin.com/in/jane-doe-sn',
+      },
+      {
+        row: 2,
+        accountName: 'Cache Rescore Co',
+        fullName: 'Jane Doe',
+        title: 'Engineer',
+        publicLinkedInUrl: 'https://www.linkedin.com/in/other-person',
+      },
+    ],
+  }));
+
+  const artifact = await fastResolveLeads({
+    driver,
+    sourcePath,
+    aliasConfig: {
+      accounts: {
+        'cache rescore co': {
+          accountSearchAliases: ['Cache Rescore'],
+          companyFilterAliases: ['Cache Rescore Co', 'Cache Rescore'],
+          resolutionStatus: 'resolved_exact',
+        },
+      },
+    },
+    searchTimeoutMs: 8000,
+    maxCandidates: 4,
+    groupedCompanyPool: false,
+  });
+
+  assert.equal(scrollCount, 1);
+  const [firstJane, secondJane] = artifact.leads;
+  assert.equal(firstJane.resolutionBucket, 'resolved_safe_to_save');
+  assert.ok(firstJane.candidateDecision?.bestCandidate?.slugMatch);
+  assert.equal(secondJane.candidateDecision?.bestCandidate?.slugMatch, false);
+  assert.equal(
+    secondJane.resolutionCandidates?.[0]?.fullName,
+    firstJane.resolutionCandidates?.[0]?.fullName,
+  );
+  assert.ok(artifact.queryCache?.hits >= 1);
 });

--- a/tests/release-readiness.test.js
+++ b/tests/release-readiness.test.js
@@ -37,6 +37,8 @@ test('package scripts keep autoresearch dry-safe and expose release checks', () 
   assert.equal(packageJson.scripts['test:release-readiness'], 'node --test tests/release-readiness.test.js tests/live-readiness.test.js tests/pilot-config.test.js tests/background-list-maintenance.test.js');
   assert.equal(packageJson.scripts['autoresearch:mvp'], 'node src/cli.js autoresearch-mvp');
   assert.doesNotMatch(packageJson.scripts['autoresearch:mvp'], /--live-save|--live-connect|allow-background-connects/);
+  assert.equal(packageJson.scripts['autoresearch:speed'], 'node src/cli.js autoresearch-speed-eval');
+  assert.doesNotMatch(packageJson.scripts['autoresearch:speed'], /--live-save|--live-connect|allow-background-connects/);
   assert.equal(packageJson.scripts['print-mvp-operator-dashboard'], 'node src/cli.js print-mvp-operator-dashboard');
 });
 


### PR DESCRIPTION
## Summary
- Adds a per-run Fast Resolve query cache/dedupe layer.
- Reuses raw candidate lists for identical normalized queries with the same `maxCandidates` instead of re-running driver search/apply/scroll.
- Re-scores cached candidates per lead; bucketed resolution decisions are never reused across leads.
- Adds query-cache telemetry to Fast Resolve artifacts: hits, misses, avoided searches, and hashed key fingerprints.
- Keeps grouped company pool behavior unchanged.

## Safety Notes
- No live Sales Navigator commands were run.
- No live-save/live-connect defaults were loosened.
- No browser/session/runtime/.env/credential files touched.
- Failed searches do not poison the cache.
- Raw query text is not added to new query-cache telemetry; fingerprints/counts are used.

## Verification
- `node --test tests/fast-list-import.test.js --test-name-pattern='query cache|dedupe|buildFastResolveQueryCacheKey|fastResolveLeads query cache:'`
- `node --test tests/fast-list-import.test.js`
- `npm run test:release-readiness`
- `npm test` — 296/296 passing
- `git diff --check`
- Secret/risky scans clean
- Independent review: APPROVE

## Stack
- Stacked on PR #14 / branch `cursor/m9-adaptive-sweep-pruning`.
