### PR TITLE
fix: route automated mutations through Playwright

### DIFF
--- a/docs/app-roadmap.md
+++ b/docs/app-roadmap.md
@@ -5,8 +5,8 @@ This roadmap turns the current Sales Navigator research workflow into a real int
 ## What the app already has
 
 - account-first LinkedIn Sales Navigator traversal
-- Playwright for fast discovery
-- Browser Harness for real-browser mutations such as save-to-list
+- Playwright for fast discovery and automated live mutations such as save-to-list
+- Browser Harness as an explicit manual diagnostic surface for fragile LinkedIn UI variants
 - SQLite state, approvals, checkpoints, and local dashboard
 - configurable ICP scoring and deep profile review
 

--- a/docs/browser-harness-hybrid-stack.md
+++ b/docs/browser-harness-hybrid-stack.md
@@ -5,7 +5,8 @@
 The platform now supports a `hybrid` browser architecture:
 
 - `PlaywrightSalesNavigatorDriver` remains the fast, structured discovery engine.
-- `BrowserHarnessSalesNavigatorDriver` adds direct-CDP control of the user's real Chrome for fragile live actions.
+- `PlaywrightSalesNavigatorDriver` owns automated live mutations such as save-to-list and supervised connect attempts.
+- `BrowserHarnessSalesNavigatorDriver` is retained as an explicit manual diagnostic tool for observing fragile UI shapes.
 - `HybridSalesNavigatorDriver` combines both behind the existing `DriverAdapter` interface.
 
 ## Why this exists
@@ -19,13 +20,13 @@ Our platform already had the right operational structure:
 - approval queue
 - pacing and dedupe
 
-What it lacked was a second execution path for browser work that is:
+What it lacked was a safe boundary for browser work that is:
 
-- closer to the user's real browser session
-- more tolerant of odd UI flows
-- better suited for mutation-heavy tasks like `save to list`
+- fast enough for automated background research
+- predictable for live mutations
+- still debuggable when LinkedIn changes a UI shape
 
-Browser Harness fills that gap without replacing the platform.
+Playwright fills the automated path. Browser Harness fills the manual observation gap without owning production mutations.
 
 ## Current driver split
 
@@ -36,21 +37,22 @@ Browser Harness fills that gap without replacing the platform.
 - template application
 - candidate extraction
 - structured evidence capture from known Sales Navigator DOMs
+- automated save-to-list flows
+- supervised connect flows when explicitly requested
 
 ### Browser Harness owns
 
 - attach to the user's real Chrome through CDP
-- session verification in a real browser context
-- mutation-oriented flows such as `saveCandidateToList`
-- recovery screenshots in the real browser context
-- future path for fragile connect/dialog flows
+- manual UI inspection when Playwright selectors need repair
+- evidence gathering for fragile LinkedIn UI variants
+- one-off operator-driven debugging via explicit `--driver=browser-harness`
 
 ### Hybrid owns
 
 - one `DriverAdapter` surface to the orchestrator
 - Playwright for discovery methods
-- Browser Harness for mutation methods
-- health gating that can require both layers for live mutation runs
+- Playwright for mutation methods
+- no automatic Browser Harness subprocesses
 
 ## Practical stack
 
@@ -62,24 +64,24 @@ flowchart TD
   B --> E["DriverAdapter"]
 
   E --> F["Playwright Driver"]
-  E --> G["Browser Harness Driver"]
 
   F --> H["Sales Nav Discovery"]
   F --> I["Candidate Extraction"]
-
-  G --> J["Real Chrome via CDP"]
-  G --> K["Save To List / Recovery / Future Connect"]
+  F --> K["Headless Save To List / Supervised Connect"]
 
   I --> C
   K --> C
   C --> D
+
+  L["Manual Browser Harness Debug"] -. explicit opt-in .-> J["Real Chrome via CDP"]
+  J -. selector evidence .-> F
 ```
 
 ## Recommended operating mode
 
 ### Default for runs
 
-Use `--driver=hybrid` for production-oriented discovery runs where list-save matters.
+Use `--driver=playwright` for automated live-save/live-connect work. `--driver=hybrid` remains compatible, but it is Playwright-backed for both discovery and mutation.
 
 ### Use `playwright` alone when
 
@@ -90,19 +92,19 @@ Use `--driver=hybrid` for production-oriented discovery runs where list-save mat
 ### Use `browser-harness` alone when
 
 - checking direct Chrome attach behavior
-- testing a live save-to-list flow
 - debugging fragile UI behavior in the user's real browser
+- collecting selector evidence for a Playwright fix
+- running a manual repair session with the operator watching
 
 ## Known limitations
 
-- Browser Harness is not yet the primary discovery engine.
-- The harness integration currently prioritizes session, mutation, and recovery paths.
-- LinkedIn-specific Browser Harness domain-skills are not yet authored in this repo.
+- Browser Harness is intentionally not the automated mutation engine.
+- LinkedIn-specific Browser Harness domain skills may help diagnose UI changes, but shipped automation should land in Playwright.
 - Cloud-profile sync is intentionally not part of the default production path for LinkedIn.
 
 ## Next build steps
 
-1. Add a dedicated `linkedin-sales-navigator` Browser Harness skill pack.
-2. Expand harness-backed list-save handling with LinkedIn-specific selectors and waits learned from live tests.
-3. Add harness-backed connect dialog handling only after list-save is stable.
-4. Optionally add a fallback policy so Playwright discovery failures can trigger Browser Harness recovery flows automatically.
+1. Keep Playwright list-save and supervised connect flows as the production path.
+2. Use Browser Harness only to observe new LinkedIn UI shapes and translate findings back into Playwright selectors.
+3. Add release tests that prevent automated flows from depending on a local `browser-harness` binary.
+4. Keep explicit `--driver=browser-harness` available for manual diagnostics, not unattended runs.

--- a/docs/first-hybrid-smoke-test.md
+++ b/docs/first-hybrid-smoke-test.md
@@ -2,44 +2,46 @@
 
 ## Goal
 
-Validate the new `hybrid` stack with the smallest real scope:
+Validate the `hybrid` compatibility stack with the smallest real scope:
 
-- Playwright remains the discovery engine
-- Browser Harness is available as the mutation path
-- no connects are sent
-- only one known lead and one existing list are used
+- Playwright remains the discovery engine.
+- Playwright owns automated mutation paths such as save-to-list.
+- Browser Harness remains available only as an explicit manual diagnostic path.
+- No connects are sent.
+- Only one known lead and one existing list are used.
 
 ## Preconditions
 
-- `automation/browser-harness` exists and is executable
-- `vendor/browser-harness/.venv` is installed
-- Chrome is running in the normal desktop context
-- LinkedIn Sales Navigator session is already valid in the browser you want to use
-- one known-good Sales Navigator lead URL is available
-- one already existing safe test list is available
+- Playwright session is already bootstrapped:
+  ```bash
+  npm run bootstrap-session -- --driver=playwright --wait-minutes=10
+  ```
+- One known-good Sales Navigator lead URL is available.
+- One already existing safe test list is available.
+- Browser Harness is not required for this smoke. If it is missing from `PATH`, the automated Playwright/hybrid path should still work.
 
 ## Sequence
 
-1. `npm run bootstrap-browser-harness`
-2. `node src/cli.js bootstrap-session --driver=playwright --wait-minutes=10`
-3. `node src/cli.js check-driver-session --driver=browser-harness`
-4. `node src/cli.js check-driver-session --driver=hybrid --session-mode=persistent`
-5. `node src/cli.js check-live-readiness --driver=hybrid --candidate-url="https://www.linkedin.com/sales/lead/..." --list-name="Existing Test List"`
-6. `node src/cli.js test-account-search --driver=hybrid --account-name="Known Account" --keywords="Known Query"`
-7. `node src/cli.js test-list-save --driver=browser-harness --candidate-url="https://www.linkedin.com/sales/lead/..." --list-name="Existing Test List" --live-save`
-8. `node src/cli.js reconcile-state`
+1. `node src/cli.js check-driver-session --driver=playwright --session-mode=storage-state`
+2. `node src/cli.js check-driver-session --driver=hybrid --session-mode=storage-state`
+3. `node src/cli.js check-live-readiness --driver=playwright --candidate-url="https://www.linkedin.com/sales/lead/..." --list-name="Existing Test List"`
+4. `node src/cli.js test-account-search --driver=hybrid --account-name="Known Account" --keywords="Known Query"`
+5. `node src/cli.js test-list-save --driver=playwright --candidate-url="https://www.linkedin.com/sales/lead/..." --list-name="Existing Test List" --live-save`
+6. Optional manual diagnostic only: `node src/cli.js check-driver-session --driver=browser-harness`
+7. `node src/cli.js reconcile-state`
 
 ## Expected Result
 
-- Browser Harness is found locally through `automation/browser-harness`
-- hybrid health output shows separate `Discovery` and `Mutation` states
-- account search still works through the hybrid driver
-- list save succeeds through Browser Harness with `selectionMode: existing_list`
-- no connect action is sent
+- `playwright` health reports an authenticated Sales Navigator session.
+- `hybrid` health reports Playwright-backed discovery and mutation readiness.
+- Account search still works through the hybrid driver.
+- List save succeeds through Playwright with `selectionMode: existing_list`.
+- Browser Harness absence does not block automated discovery or mutation flows.
+- No connect action is sent.
 
 ## Stop Conditions
 
-- Browser Harness reports `reauth_required`, `blocked`, or `captcha_or_checkpoint`
-- hybrid discovery and mutation states disagree in a way that suggests session drift
-- the safe target list is not found
-- any unexpected modal or restriction warning appears
+- Playwright reports `reauth_required`, `blocked`, or `captcha_or_checkpoint`.
+- Hybrid discovery and mutation states disagree in a way that suggests session drift.
+- The safe target list is not found.
+- Any unexpected modal or restriction warning appears.

--- a/docs/plans/multi-agent-research-loop-project-plan.md
+++ b/docs/plans/multi-agent-research-loop-project-plan.md
@@ -67,7 +67,7 @@ The repository already ships a substantial supervised pipeline: CLI orchestratio
 |--------|------|
 | `src/drivers/playwright-sales-nav.js` | Discovery-heavy flows; `saveCandidateToList`, company filter/scoping, URL checks for `/sales/lead/`. |
 | `src/drivers/browser-harness-sales-nav.js` | CDP-backed mutations; **already_saved** path checks selection **before** secondary clicks (lines ~418–426 region). |
-| `src/drivers/hybrid-sales-nav.js` | Playwright discovery + browser-harness mutations; `checkSessionHealth` ties mutation readiness to `allowMutations` and non-dry-run. |
+| `src/drivers/hybrid-sales-nav.js` | Playwright-backed discovery + mutations; Browser Harness is manual-only unless explicitly selected as `--driver=browser-harness`. |
 | `src/drivers/driver-adapter.js` | Adapter surface. |
 | `src/drivers/mock-driver.js` | Tests/offline. |
 

--- a/docs/ways-of-working/driver-architecture.md
+++ b/docs/ways-of-working/driver-architecture.md
@@ -1,0 +1,28 @@
+# Driver Architecture
+
+## Decision
+
+Playwright headless is the automated execution engine for Sales Navigator research and live mutations.
+
+Browser Harness is a manual diagnostic and repair tool. It can be selected explicitly with `--driver=browser-harness`, but no automated command should choose it implicitly.
+
+## Why
+
+Automated mutation commands must not take over the operator's visible Chrome tabs or depend on a local Browser Harness binary being installed. Playwright gives the project a predictable, repo-owned browser runtime for both discovery and supervised live-save/connect actions.
+
+Browser Harness is still useful when LinkedIn ships a new UI shape. Use it to observe the page, understand selectors, and then move the durable implementation back into Playwright.
+
+## Rules
+
+- `--live-save` and `--live-connect` default to Playwright.
+- `hybrid` remains a compatibility driver, but its default mutation path is Playwright-backed.
+- Browser Harness is only used when the operator explicitly passes `--driver=browser-harness`.
+- Missing Browser Harness binaries must not block Playwright or hybrid automated flows.
+- New shipped mutation logic should be implemented in `src/drivers/playwright-sales-nav.js` first.
+- Browser Harness helpers can live under `vendor/browser-harness/`, but automated `src/` flows must not require them.
+
+## Practical Defaults
+
+- Use `--driver=playwright` for normal supervised live-save and live-connect runs.
+- Use `--driver=hybrid` only when a command still expects the hybrid adapter surface; it should behave like Playwright for automated mutations.
+- Use `--driver=browser-harness` only during a watched manual debugging session.

--- a/src/cli.js
+++ b/src/cli.js
@@ -949,7 +949,7 @@ async function handleFastResolveLeads(values, logger) {
 }
 
 async function handleTestConnect(values, logger) {
-  const driverName = getString(values, 'driver') || 'browser-harness';
+  const driverName = getString(values, 'driver') || 'playwright';
   const candidateUrl = getString(values, 'candidate-url');
   const fullName = getString(values, 'full-name') || 'Smoke Test Candidate';
   if (!candidateUrl) {
@@ -1045,7 +1045,7 @@ async function handleInspectConnectSurface(values, logger) {
 }
 
 async function handleConnectLeadList(repository, values, logger) {
-  const driverName = getString(values, 'driver') || 'browser-harness';
+  const driverName = getString(values, 'driver') || 'playwright';
   const listName = getString(values, 'list-name');
   const limit = Number(getString(values, 'limit') || Number.MAX_SAFE_INTEGER);
   if (!listName) {
@@ -3087,7 +3087,7 @@ async function handleRunAccountBatch(repository, values, logger) {
   const liveSave = getBoolean(values, 'liveSave', 'live-save');
   const liveConnect = getBoolean(values, 'liveConnect', 'live-connect');
   const pilotConfig = getString(values, 'pilot-config') ? loadPilotConfig(getString(values, 'pilot-config')) : null;
-  const driverName = getString(values, 'driver') || ((liveSave || liveConnect) ? 'hybrid' : 'playwright');
+  const driverName = getString(values, 'driver') || 'playwright';
   const peopleSearchUrl = getString(values, 'people-search-url') || 'https://www.linkedin.com/sales/search/people?viewAllFilters=true';
   const maxCandidates = parseOptionalCandidateLimit(getString(values, 'max-candidates'));
   const speedProfile = getString(values, 'speed-profile') || 'balanced';
@@ -3436,7 +3436,7 @@ async function handlePilotConnectBatch(repository, values, logger) {
 
   const listPrefix = getString(values, 'list-prefix');
   const maxConnectsPerAccount = Number(getString(values, 'max-connects-per-account') || 1);
-  const driverName = getString(values, 'driver') || 'browser-harness';
+  const driverName = getString(values, 'driver') || 'playwright';
   const pilotConfig = loadPilotConfig(getString(values, 'pilot-config'));
   const driverOptions = buildDriverOptions(values, { dryRun: false }, {
     sessionMode: 'persistent',
@@ -3700,9 +3700,9 @@ Usage:
   node src/cli.js fast-list-import --source=/path/to/leads.md[,/path/to/coverage.json] [--bucket=direct_observability] [--min-score=40] [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create]
   node src/cli.js retry-failed-fast-list-import --artifact=/path/to/failed-fast-import.json [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create]
   node src/cli.js import-coverage --accounts=example-marketplace-a,example-saas-marketplace,olx-group [--bucket=direct_observability] [--min-score=40] [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create]
-  node src/cli.js test-connect --driver=browser-harness|hybrid --candidate-url="https://www.linkedin.com/sales/lead/..." [--full-name="Jane Doe"] --live-connect
+  node src/cli.js test-connect --driver=playwright|browser-harness|hybrid --candidate-url="https://www.linkedin.com/sales/lead/..." [--full-name="Jane Doe"] --live-connect
   node src/cli.js inspect-connect-surface --driver=playwright --candidate-url="https://www.linkedin.com/sales/lead/..." [--full-name="Jane Doe"]
-  node src/cli.js connect-lead-list --driver=browser-harness --list-name="Territory List" [--limit=25] --live-connect
+  node src/cli.js connect-lead-list --driver=playwright|browser-harness|hybrid --list-name="Territory List" [--limit=25] --live-connect
   node src/cli.js remove-lead-list-members --driver=playwright --list-name="Territory List" --names="Name A, Name B" --live-save
   node src/cli.js send-approved-connects [--run-id=<run-id>] [--limit=25]
   node src/cli.js reconcile-state
@@ -3722,7 +3722,7 @@ Usage:
   node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js autoresearch-speed-eval --baseline=runtime/artifacts/autoresearch/baseline.json --candidate=runtime/artifacts/autoresearch/candidate.json [--min-speedup-percent=25]
-  node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--adaptive-sweep-pruning] [--live-save] [--live-connect]
+  node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=playwright|hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--adaptive-sweep-pruning] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect
 `);

--- a/src/drivers/hybrid-sales-nav.js
+++ b/src/drivers/hybrid-sales-nav.js
@@ -1,6 +1,5 @@
 const { DriverAdapter } = require('./driver-adapter');
 const { PlaywrightSalesNavigatorDriver } = require('./playwright-sales-nav');
-const { BrowserHarnessSalesNavigatorDriver } = require('./browser-harness-sales-nav');
 
 class HybridSalesNavigatorDriver extends DriverAdapter {
   constructor(options = {}) {
@@ -8,12 +7,9 @@ class HybridSalesNavigatorDriver extends DriverAdapter {
     this.options = { ...options };
     this.discoveryDriver = options.discoveryDriver || new PlaywrightSalesNavigatorDriver({
       ...options,
-      allowMutations: false,
-    });
-    this.mutationDriver = options.mutationDriver || new BrowserHarnessSalesNavigatorDriver({
-      ...options,
       allowMutations: options.allowMutations,
     });
+    this.mutationDriver = options.mutationDriver || this.discoveryDriver;
     this.runContext = null;
     this.mutationOpenError = null;
   }
@@ -22,10 +18,12 @@ class HybridSalesNavigatorDriver extends DriverAdapter {
     this.runContext = context;
     this.mutationOpenError = null;
     await this.discoveryDriver.openSession(context);
-    try {
-      await this.mutationDriver.openSession(context);
-    } catch (error) {
-      this.mutationOpenError = error;
+    if (this.mutationDriver !== this.discoveryDriver) {
+      try {
+        await this.mutationDriver.openSession(context);
+      } catch (error) {
+        this.mutationOpenError = error;
+      }
     }
   }
 
@@ -33,12 +31,14 @@ class HybridSalesNavigatorDriver extends DriverAdapter {
     const discovery = await this.discoveryDriver.checkSessionHealth();
     let mutation = null;
 
-    if (this.mutationOpenError) {
+    if (this.mutationDriver === this.discoveryDriver) {
+      mutation = discovery;
+    } else if (this.mutationOpenError) {
       mutation = {
         ok: false,
         authenticated: false,
         state: 'mutation_driver_not_ready',
-        mode: 'browser-harness',
+        mode: this.mutationDriver?.options?.mode || 'custom',
         error: this.mutationOpenError.message,
       };
     } else {
@@ -128,6 +128,18 @@ class HybridSalesNavigatorDriver extends DriverAdapter {
   }
 
   async recoverFromInterruption(event, context) {
+    if (this.mutationDriver === this.discoveryDriver) {
+      const recovery = await this.discoveryDriver.recoverFromInterruption(event, context);
+      return {
+        status: recovery?.status || 'recorded',
+        screenshotPath: recovery?.screenshotPath || null,
+        htmlPath: recovery?.htmlPath || null,
+        textPath: recovery?.textPath || null,
+        discovery: recovery,
+        mutation: recovery,
+      };
+    }
+
     let mutation = null;
     let discovery = null;
 
@@ -162,10 +174,10 @@ class HybridSalesNavigatorDriver extends DriverAdapter {
   }
 
   async close() {
-    await Promise.allSettled([
-      this.discoveryDriver.close(),
-      this.mutationDriver.close(),
-    ]);
+    const drivers = this.mutationDriver === this.discoveryDriver
+      ? [this.discoveryDriver]
+      : [this.discoveryDriver, this.mutationDriver];
+    await Promise.allSettled(drivers.map((driver) => driver.close()));
   }
 }
 

--- a/tests/browser-harness-driver.test.js
+++ b/tests/browser-harness-driver.test.js
@@ -748,6 +748,83 @@ test('browser harness driver normalizes unverifiable post-click connect flows to
   assert.equal(result.driver, 'browser-harness');
 });
 
+test('hybrid driver defaults automated mutations to the Playwright discovery driver', async () => {
+  class StubPlaywrightDriver extends DriverAdapter {
+    constructor() {
+      super();
+      this.openCount = 0;
+      this.closeCount = 0;
+      this.ensureListCalls = [];
+      this.saveCalls = [];
+      this.connectCalls = [];
+      this.health = {
+        ok: true,
+        authenticated: true,
+        state: 'authenticated',
+        mode: 'playwright',
+        url: 'https://www.linkedin.com/sales/home',
+      };
+    }
+
+    async openSession() {
+      this.openCount += 1;
+    }
+
+    async checkSessionHealth() {
+      return this.health;
+    }
+
+    async ensureList(listName, context) {
+      this.ensureListCalls.push({ listName, context });
+      return { status: 'ready', driver: 'playwright' };
+    }
+
+    async saveCandidateToList(candidate, listInfo, context) {
+      this.saveCalls.push({ candidate, listInfo, context });
+      return { status: 'saved', driver: 'playwright' };
+    }
+
+    async sendConnect(candidate, context) {
+      this.connectCalls.push({ candidate, context });
+      return { status: 'sent', driver: 'playwright' };
+    }
+
+    async close() {
+      this.closeCount += 1;
+    }
+  }
+
+  const playwright = new StubPlaywrightDriver();
+  const hybrid = new HybridSalesNavigatorDriver({
+    allowMutations: true,
+    discoveryDriver: playwright,
+  });
+
+  await hybrid.openSession({ runId: 'run-1', dryRun: false });
+  const health = await hybrid.checkSessionHealth();
+  await hybrid.ensureList('Headless List', { dryRun: false });
+  const saveResult = await hybrid.saveCandidateToList(
+    { fullName: 'Headless Save', salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/headless' },
+    { listName: 'Headless List' },
+    { dryRun: false },
+  );
+  const connectResult = await hybrid.sendConnect(
+    { fullName: 'Headless Connect', salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/connect' },
+    { dryRun: false },
+  );
+  await hybrid.close();
+
+  assert.equal(playwright.openCount, 1);
+  assert.equal(playwright.closeCount, 1);
+  assert.equal(health.ok, true);
+  assert.equal(health.mutation.mode, 'playwright');
+  assert.equal(saveResult.driver, 'playwright');
+  assert.equal(connectResult.driver, 'playwright');
+  assert.equal(playwright.ensureListCalls.length, 1);
+  assert.equal(playwright.saveCalls.length, 1);
+  assert.equal(playwright.connectCalls.length, 1);
+});
+
 test('hybrid driver requires mutation health for live mutation runs', async () => {
   class StubDriver extends DriverAdapter {
     constructor(health) {

--- a/tests/release-readiness.test.js
+++ b/tests/release-readiness.test.js
@@ -63,6 +63,19 @@ test('default configs are generic and keep live connects guarded', () => {
   assert.ok(Object.hasOwn(pilot.connectPolicy.manualReviewAccounts, 'Example Manual Review Account'));
 });
 
+test('automated hybrid mutations do not depend on Browser Harness', () => {
+  const hybridDriver = read('src/drivers/hybrid-sales-nav.js');
+  const cli = read('src/cli.js');
+  const architecture = read('docs/ways-of-working/driver-architecture.md');
+
+  assert.doesNotMatch(hybridDriver, /browser-harness-sales-nav/);
+  assert.match(hybridDriver, /this\.mutationDriver = options\.mutationDriver \|\| this\.discoveryDriver/);
+  assert.match(cli, /async function handleImportCoverage[\s\S]+const driverName = getString\(values, 'driver'\) \|\| 'playwright'/);
+  assert.match(cli, /async function handleFastListImport[\s\S]+const driverName = getString\(values, 'driver'\) \|\| 'playwright'/);
+  assert.match(cli, /async function handleConnectLeadList[\s\S]+const driverName = getString\(values, 'driver'\) \|\| 'playwright'/);
+  assert.match(architecture, /Browser Harness is a manual diagnostic and repair tool/);
+});
+
 test('tracked docs do not include historical handoff or acceptance snapshots', () => {
   const docs = fs.readdirSync(path.join(projectRoot, 'docs'));
   const forbidden = docs.filter((fileName) =>


### PR DESCRIPTION
## Summary\n- Routes hybrid automated mutation methods through the Playwright-backed driver instead of Browser Harness.\n- Changes live connect/batch CLI defaults to Playwright while keeping explicit `--driver=browser-harness` available for manual diagnostics.\n- Documents the driver boundary and updates smoke-test guidance.\n- Adds regression coverage so hybrid automated mutations no longer depend on Browser Harness.\n\n## Tests\n- `node --test tests/browser-harness-driver.test.js tests/playwright-driver.test.js tests/release-readiness.test.js tests/account-batch.test.js tests/fast-list-import.test.js`\n- `npm test`\n- `npm run test:release-readiness`\n\nCloses #19\nCloses #20