### PR TITLE
feat: add parallel research pipeline stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
     "autoresearch:supervisor": "node src/cli.js print-autoresearch-supervisor",
     "autoresearch:speed": "node src/cli.js autoresearch-speed-eval",
+    "parallel-account-research": "node src/cli.js parallel-account-research",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/src/cli.js
+++ b/src/cli.js
@@ -69,6 +69,14 @@ const {
   writeAccountBatchReport,
 } = require('./core/account-batch');
 const {
+  attachSweepCacheState,
+  buildResearchPipelineArtifact,
+  buildResearchQueue,
+  normalizeResearchAccount,
+  planResearchJobs,
+  scoreResearchCandidates,
+} = require('./core/research-pipeline');
+const {
   fastResolveLeads,
   buildMutationReviewArtifact,
   loadCoverageImportPlan,
@@ -267,6 +275,9 @@ async function main() {
         break;
       case 'autoresearch-speed-eval':
         await handleAutoresearchSpeedEval(values, logger);
+        break;
+      case 'parallel-account-research':
+        await handleParallelAccountResearch(values, logger);
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
@@ -3044,6 +3055,116 @@ async function handleAutoresearchSpeedEval(values, logger) {
   console.log(renderAutoresearchSpeedEvaluationMarkdown(evaluation));
 }
 
+async function handleParallelAccountResearch(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-background-connects')) {
+    throw new Error('parallel-account-research is dry-safe only and refuses live-save, live-connect, or background connects');
+  }
+
+  const accountsRaw = getString(values, 'accounts') || getString(values, 'account-names');
+  if (!accountsRaw) {
+    throw new Error('parallel-account-research requires --accounts="Account A, Account B"');
+  }
+  const names = parseAccountNames(accountsRaw);
+  if (names.length === 0) {
+    throw new Error('parallel-account-research requires at least one account name');
+  }
+
+  const runIdBase = getString(values, 'run-id') || 'parallel-account-research';
+  const localConcurrency = Math.max(1, Number(getString(values, 'local-concurrency') || 4));
+  const coverageConfigPath = getString(values, 'coverage-config');
+  const coverageConfig = loadAccountCoverageConfig(coverageConfigPath);
+  const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
+  const priorityModel = loadPriorityModel();
+
+  logger.info(`parallel-account-research: browserConcurrency=1 (fixed), localConcurrency=${localConcurrency}, accounts=${names.length}`);
+
+  /** @type {Array<object>} */
+  const accountArtifacts = [];
+
+  for (const accountName of names) {
+    const normalized = normalizeResearchAccount({ accountName });
+    const startedAt = Date.now();
+    const queue = buildResearchQueue({
+      accounts: [normalized],
+      runId: `${runIdBase}:${normalized.accountKey}`,
+    });
+    const plan = planResearchJobs({ queue, coverageConfig });
+    const jobsWithCache = await attachSweepCacheState({
+      jobs: plan.jobs,
+      readCache: () => null,
+    });
+    const browserExec = {
+      runId: queue.runId,
+      results: jobsWithCache
+        .filter((job) => job.type === 'sweep' && job.requiresBrowser)
+        .map((job) => ({
+          jobId: job.id,
+          templateId: job.templateId,
+          accountKey: job.accountKey,
+          cacheHit: false,
+          candidates: [],
+          status: 'skipped',
+          reason: 'dry_safe_cli_plan_only',
+        })),
+      rateLimitHitCount: 0,
+      browserJobsExecuted: 0,
+    };
+
+    /** @type {Array<{ templateId?: string, candidates?: Array<object>, cacheHit?: boolean }>} */
+    const rawResults = [];
+    for (const job of jobsWithCache) {
+      if (job.type !== 'sweep') continue;
+      if (job.cacheHit) {
+        rawResults.push({
+          templateId: job.templateId,
+          candidates: job.cacheCandidates || [],
+          cacheHit: true,
+        });
+      }
+    }
+    for (const row of browserExec.results || []) {
+      if (row.status === 'completed') {
+        rawResults.push({
+          templateId: row.templateId,
+          candidates: row.candidates || [],
+          cacheHit: false,
+        });
+      }
+    }
+
+    const scoringResults = await scoreResearchCandidates({
+      accountName,
+      rawResults,
+      icpConfig,
+      coverageConfig,
+      priorityModel,
+      localConcurrency,
+    });
+
+    const artifact = buildResearchPipelineArtifact({
+      queue,
+      plannedJobs: plan,
+      cacheResults: jobsWithCache,
+      browserResults: browserExec,
+      scoringResults,
+      lockTelemetry: [],
+      startedAt,
+      finishedAt: Date.now(),
+      localConcurrency,
+    });
+    accountArtifacts.push(artifact);
+  }
+
+  console.log(JSON.stringify({
+    version: '1.0.0',
+    mode: 'dry-safe',
+    browserConcurrency: 1,
+    localConcurrency,
+    accountCount: names.length,
+    accounts: accountArtifacts,
+  }, null, 2));
+}
+
 function loadAutoresearchArtifactForReadOnlyReport(values) {
   const explicitArtifactPath = getString(values, 'artifact');
   if (!explicitArtifactPath) {
@@ -3722,6 +3843,7 @@ Usage:
   node src/cli.js print-autoresearch-gate [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js autoresearch-speed-eval --baseline=runtime/artifacts/autoresearch/baseline.json --candidate=runtime/artifacts/autoresearch/candidate.json [--min-speedup-percent=25]
+  node src/cli.js parallel-account-research --accounts="Account A, Account B" [--local-concurrency=4] [--coverage-config=config/account-coverage/default.json] [--run-id=my-run]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=playwright|hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--adaptive-sweep-pruning] [--live-save] [--live-connect]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect

--- a/src/core/autoresearch-mvp.js
+++ b/src/core/autoresearch-mvp.js
@@ -1053,24 +1053,47 @@ function numberOrZero(value) {
 function extractSpeedEvaluationMetrics(artifact = {}) {
   const fastResolve = artifact.evaluationMetrics?.fastResolve || {};
   const companyResolution = artifact.evaluationMetrics?.companyResolution || {};
+  const pipelineMetrics = artifact.researchPipeline?.metrics || null;
+  const flatPipelineMetrics = artifact.metrics?.browserConcurrency === 1 && artifact.metrics?.cacheHits != null
+    ? artifact.metrics
+    : null;
+  const mergedPipelineMetrics = pipelineMetrics || flatPipelineMetrics;
+
+  const candidatesUniqueForRate = numberOrZero(mergedPipelineMetrics?.candidatesUnique);
+  const manualReviewFromPipeline = (
+    mergedPipelineMetrics
+    && candidatesUniqueForRate > 0
+    && mergedPipelineMetrics.manualReviewCount != null
+  )
+    ? numberOrZero(mergedPipelineMetrics.manualReviewCount) / candidatesUniqueForRate
+    : null;
+
   return {
-    totalMs: numberOrZero(artifact.timings?.totalMs || artifact.totalMs || artifact.durationMs),
+    totalMs: numberOrZero(
+      artifact.timings?.totalMs
+      || artifact.totalMs
+      || artifact.durationMs
+      || mergedPipelineMetrics?.totalMs,
+    ),
     resolvedSafeToSave: numberOrZero(
       fastResolve.resolvedSafeToSave
       ?? fastResolve.bucketCounts?.resolved_safe_to_save
       ?? artifact.bucketCounts?.resolved_safe_to_save
       ?? artifact.resolvedSafeToSave
-      ?? artifact.resolvedLeads,
+      ?? artifact.resolvedLeads
+      ?? mergedPipelineMetrics?.selectedForList,
     ),
     manualReviewRate: numberOrZero(
       fastResolve.manualReviewRate
-      ?? artifact.manualReviewRate,
+      ?? artifact.manualReviewRate
+      ?? manualReviewFromPipeline,
     ),
     duplicateWarningRate: numberOrZero(
       fastResolve.duplicateWarningRate
       ?? fastResolve.duplicateRate
       ?? artifact.duplicateWarningRate
-      ?? artifact.duplicateRate,
+      ?? artifact.duplicateRate
+      ?? mergedPipelineMetrics?.duplicateWarningRate,
     ),
     companyResolutionBlockers: numberOrZero(
       companyResolution.blockerCount

--- a/src/core/browser-worker-lock.js
+++ b/src/core/browser-worker-lock.js
@@ -1,0 +1,52 @@
+/**
+ * In-process Browser Worker lock: serializes async browser-backed jobs for one LinkedIn session (v1).
+ */
+
+function createBrowserWorkerLock() {
+  let tail = Promise.resolve();
+  /** @type {Array<Record<string, unknown>>} */
+  const telemetry = [];
+
+  /**
+   * @param {string} jobId
+   * @param {() => Promise<unknown>} fn
+   */
+  async function runExclusive(jobId, fn) {
+    const previous = tail;
+    /** @type {(value?: unknown) => void} */
+    let release;
+    tail = new Promise((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    const startedAt = Date.now();
+    let status = 'completed';
+    try {
+      return await fn();
+    } catch (err) {
+      status = 'failed';
+      throw err;
+    } finally {
+      telemetry.push({
+        jobId,
+        startedAt,
+        finishedAt: Date.now(),
+        status,
+      });
+      release();
+    }
+  }
+
+  function getTelemetry() {
+    return [...telemetry];
+  }
+
+  return {
+    runExclusive,
+    getTelemetry,
+  };
+}
+
+module.exports = {
+  createBrowserWorkerLock,
+};

--- a/src/core/research-pipeline.js
+++ b/src/core/research-pipeline.js
@@ -1,4 +1,13 @@
-const { buildSweepTemplates } = require('./account-coverage');
+const {
+  buildSweepTemplates,
+  normalizeCandidateKey,
+  selectCoverageListCandidates,
+  classifyCoverageBucket,
+  classifySweepErrorCategory,
+} = require('./account-coverage');
+const { scoreCandidate } = require('./scoring');
+const { scoreCandidateWithPriorityModel } = require('./priority-score');
+const { buildCoverageSummary } = require('./coverage');
 
 function slugFromDisplayName(value) {
   const slug = String(value || '')
@@ -112,8 +121,440 @@ function planResearchJobs({
   };
 }
 
+/**
+ * @param {Array<{ raw: object, sweeps: string[] }>} rows
+ * @param {number} localConcurrency
+ */
+function partitionForLocalConcurrency(rows, localConcurrency) {
+  const n = rows.length;
+  if (n === 0) return [];
+  const k = Math.min(Math.max(1, Number(localConcurrency) || 4), n);
+  const buckets = Array.from({ length: k }, () => []);
+  rows.forEach((row, index) => {
+    buckets[index % k].push(row);
+  });
+  return buckets;
+}
+
+/**
+ * Marks sweep jobs with cache hits/misses using injected readCache(job).
+ * Malformed reads never throw to callers.
+ *
+ * @param {{ jobs?: Array<Record<string, unknown>>, readCache?: (job: object) => unknown }} params
+ */
+async function attachSweepCacheState({ jobs = [], readCache } = {}) {
+  const reader = readCache ?? (() => null);
+  /** @type {Array<Record<string, unknown>>} */
+  const out = [];
+
+  for (const job of jobs) {
+    if (job.type !== 'sweep') {
+      out.push({ ...job });
+      continue;
+    }
+
+    let payload = null;
+    try {
+      payload = await Promise.resolve(reader(job));
+    } catch {
+      payload = null;
+    }
+
+    const candidates = payload?.candidates;
+    const isHit = Array.isArray(candidates);
+
+    if (isHit) {
+      out.push({
+        ...job,
+        requiresBrowser: false,
+        cacheHit: true,
+        cacheCandidates: [...candidates],
+      });
+    } else {
+      out.push({
+        ...job,
+        cacheHit: false,
+        requiresBrowser: job.requiresBrowser !== false,
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Runs sweep jobs that still require a browser, serialized through lock.runExclusive.
+ *
+ * @param {{
+ *   jobs?: Array<Record<string, unknown>>,
+ *   driver: {
+ *     openPeopleSearch: (account: object, context: object) => Promise<void>,
+ *     applySearchTemplate: (template: object, context: object) => Promise<void>,
+ *     scrollAndCollectCandidates: (account: object, template: object, context: object) => Promise<Array<object>>,
+ *   },
+ *   lock: { runExclusive: (jobId: string, fn: () => Promise<unknown>) => Promise<unknown> },
+ *   runId?: string | null,
+ *   stopOnRateLimit?: boolean,
+ * }} params
+ */
+async function executeBrowserSweepJobs({
+  jobs = [],
+  driver,
+  lock,
+  runId,
+  stopOnRateLimit = true,
+} = {}) {
+  if (!driver || !lock) {
+    throw new Error('executeBrowserSweepJobs requires driver and lock');
+  }
+
+  const browserJobs = jobs
+    .filter((j) => j.type === 'sweep' && j.requiresBrowser)
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+  /** @type {Array<Record<string, unknown>>} */
+  const results = [];
+  let rateLimitHitCount = 0;
+  let stopped = false;
+
+  for (const job of browserJobs) {
+    if (stopped) {
+      results.push({
+        jobId: job.id,
+        templateId: job.templateId,
+        accountKey: job.accountKey,
+        cacheHit: false,
+        candidates: [],
+        status: 'skipped',
+        reason: 'stopped_after_rate_limit',
+      });
+      continue;
+    }
+
+    try {
+      const sweepCandidates = await lock.runExclusive(String(job.id), async () => {
+        const account = {
+          accountKey: job.accountKey,
+          accountName: job.accountName,
+          name: job.accountName,
+        };
+        const template = {
+          id: job.templateId,
+          keywords: job.keywords || [],
+          titleIncludes: job.titleIncludes || [],
+          ...(job.maxCandidates !== undefined ? { maxCandidates: job.maxCandidates } : {}),
+        };
+        const context = { runId };
+
+        if (
+          typeof driver.openPeopleSearch !== 'function'
+          || typeof driver.applySearchTemplate !== 'function'
+          || typeof driver.scrollAndCollectCandidates !== 'function'
+        ) {
+          throw new Error(
+            'driver must implement openPeopleSearch, applySearchTemplate, scrollAndCollectCandidates',
+          );
+        }
+
+        await driver.openPeopleSearch(account, context);
+        await driver.applySearchTemplate(template, context);
+        const collected = await driver.scrollAndCollectCandidates(account, template, context);
+        return Array.isArray(collected) ? collected : [];
+      });
+
+      results.push({
+        jobId: job.id,
+        templateId: job.templateId,
+        accountKey: job.accountKey,
+        cacheHit: false,
+        candidates: sweepCandidates,
+        status: 'completed',
+      });
+    } catch (err) {
+      const category = classifySweepErrorCategory(err);
+      const isRateLimited = category === 'rate_limited';
+      if (isRateLimited) {
+        rateLimitHitCount += 1;
+      }
+      results.push({
+        jobId: job.id,
+        templateId: job.templateId,
+        accountKey: job.accountKey,
+        cacheHit: false,
+        candidates: [],
+        status: 'failed',
+        errorCategory: category,
+        message: String(err?.message || err),
+      });
+      if (isRateLimited && stopOnRateLimit) {
+        stopped = true;
+      }
+    }
+  }
+
+  return {
+    runId,
+    results,
+    rateLimitHitCount,
+    browserJobsExecuted: results.filter((r) => r.status === 'completed').length,
+  };
+}
+
+/**
+ * @param {{
+ *   accountName?: string,
+ *   rawResults?: Array<{ templateId?: string, candidates?: Array<object> }>,
+ *   icpConfig?: object,
+ *   coverageConfig?: object,
+ *   priorityModel?: object | null,
+ *   localConcurrency?: number,
+ * }} params
+ */
+async function scoreResearchCandidates({
+  accountName = '',
+  rawResults = [],
+  icpConfig = {},
+  coverageConfig = {},
+  priorityModel = null,
+  localConcurrency = 4,
+} = {}) {
+  const sortedResults = [...rawResults].sort((a, b) =>
+    String(a.templateId || '').localeCompare(String(b.templateId || '')));
+
+  const byKey = new Map();
+  for (const result of sortedResults) {
+    const tid = result.templateId;
+    for (const candidate of result.candidates || []) {
+      const key = normalizeCandidateKey(candidate);
+      if (!byKey.has(key)) {
+        byKey.set(key, { raw: candidate, sweeps: [tid] });
+      } else {
+        const existing = byKey.get(key);
+        if (!existing.sweeps.includes(tid)) {
+          existing.sweeps.push(tid);
+        }
+      }
+    }
+  }
+
+  const entries = [...byKey.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const candidatesRaw = sortedResults.reduce(
+    (sum, r) => sum + (Array.isArray(r.candidates) ? r.candidates.length : 0),
+    0,
+  );
+
+  const rowInputs = entries.map(([key, data]) => ({ key, ...data }));
+  const buckets = partitionForLocalConcurrency(rowInputs, localConcurrency);
+
+  const scoredChunks = await Promise.all(
+    buckets.map((bucket) => Promise.all(
+      bucket.map(({ key, raw, sweeps }) => {
+        const scored = scoreCandidate(raw, icpConfig);
+        const priority = priorityModel
+          ? scoreCandidateWithPriorityModel(raw, priorityModel)
+          : null;
+        return {
+          key,
+          raw,
+          sweeps: [...sweeps].sort(),
+          scored,
+          priority,
+        };
+      }),
+    )),
+  );
+
+  const scoredFlat = scoredChunks.flat().sort((a, b) => a.key.localeCompare(b.key));
+
+  const merged = scoredFlat.map((row) => ({
+    fullName: row.raw.fullName,
+    title: row.raw.title,
+    company: row.raw.company,
+    location: row.raw.location,
+    profileUrl: row.raw.profileUrl || null,
+    salesNavigatorUrl: row.raw.salesNavigatorUrl || null,
+    headline: row.raw.headline || null,
+    summary: row.raw.summary || null,
+    outOfNetwork: Boolean(row.raw.outOfNetwork),
+    networkDistance: row.raw.networkDistance || null,
+    sweeps: row.sweeps,
+    roleFamily: row.scored.roleFamily,
+    seniority: row.scored.seniority,
+    score: row.scored.score,
+    scoreBreakdown: row.scored.breakdown,
+    priorityModel: row.priority,
+    scoringEligible: row.scored.eligible,
+    coverageBucket: classifyCoverageBucket({
+      roleFamily: row.scored.roleFamily,
+      score: row.scored.score,
+    }, coverageConfig),
+  }));
+
+  merged.sort((left, right) => {
+    const rightPriority = right.priorityModel?.priorityScore || 0;
+    const leftPriority = left.priorityModel?.priorityScore || 0;
+    if (rightPriority !== leftPriority) {
+      return rightPriority - leftPriority;
+    }
+    return (right.score || 0) - (left.score || 0);
+  });
+
+  const coverage = buildCoverageSummary({
+    runAccounts: [{
+      runId: 'account-coverage',
+      accountKey: `coverage:${accountName}`,
+      name: accountName,
+      listName: null,
+    }],
+    candidates: merged.map((candidate, index) => ({
+      candidateId: candidate.salesNavigatorUrl || candidate.profileUrl || `coverage-${index}`,
+      accountKey: `coverage:${accountName}`,
+      fullName: candidate.fullName,
+      title: candidate.title,
+      score: candidate.score,
+      roleFamily: candidate.roleFamily,
+      scoreBreakdown: {
+        priorityModel: candidate.priorityModel || null,
+      },
+    })),
+    buyerGroupRoles: priorityModel?.buyerGroupRoles || {},
+  })[0] || null;
+
+  const consolidated = {
+    accountName,
+    generatedAt: new Date().toISOString(),
+    candidateCount: merged.length,
+    candidates: merged,
+    coverage,
+  };
+
+  const selectedForList = selectCoverageListCandidates(consolidated, {});
+  const selectedKeys = new Set(selectedForList.map((c) => normalizeCandidateKey(c)));
+
+  const rejected = merged.filter((c) => c.scoringEligible === false);
+  const manualReviewCount = merged.filter((c) =>
+    c.scoringEligible !== false
+    && !selectedKeys.has(normalizeCandidateKey(c)),
+  ).length;
+
+  return {
+    consolidated,
+    selectedForList,
+    rejected,
+    metrics: {
+      candidatesRaw,
+      candidatesUnique: merged.length,
+      selectedForList: selectedForList.length,
+      manualReviewCount,
+    },
+    localConcurrency,
+  };
+}
+
+function parseTimeMs(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * @param {{
+ *   queue?: object,
+ *   plannedJobs?: object,
+ *   cacheResults?: Array<object> | null,
+ *   browserResults?: object | null,
+ *   scoringResults?: object | null,
+ *   lockTelemetry?: Array<object> | null,
+ *   startedAt?: number | string,
+ *   finishedAt?: number | string,
+ *   localConcurrency?: number,
+ * }} params
+ */
+function buildResearchPipelineArtifact({
+  queue,
+  plannedJobs,
+  cacheResults = null,
+  browserResults = null,
+  scoringResults = null,
+  lockTelemetry = null,
+  startedAt,
+  finishedAt,
+  localConcurrency = 4,
+} = {}) {
+  const jobsWithCache = cacheResults ?? plannedJobs?.jobs ?? [];
+  const sweepJobs = jobsWithCache.filter((j) => j.type === 'sweep');
+  const cacheHits = sweepJobs.filter((j) => j.cacheHit === true).length;
+  const cacheMisses = sweepJobs.filter((j) => j.requiresBrowser === true).length;
+
+  const browser = browserResults || {};
+  const br = browser.results || [];
+  const rateLimitHitCount = Number(browser.rateLimitHitCount || 0);
+  const browserJobsExecuted = Number(
+    browser.browserJobsExecuted ?? br.filter((r) => r.status === 'completed').length,
+  );
+
+  const scoring = scoringResults || {};
+  const sm = scoring.metrics || {};
+
+  const startMs = parseTimeMs(startedAt);
+  const endMs = parseTimeMs(finishedAt);
+  const totalMs = startMs != null && endMs != null ? Math.max(0, endMs - startMs) : 0;
+
+  const metrics = {
+    totalMs,
+    preBrowserMs: 0,
+    browserMs: 0,
+    postBrowserMs: 0,
+    cacheHits,
+    cacheMisses,
+    browserJobsExecuted,
+    browserJobsSkippedByCache: cacheHits,
+    candidatesRaw: Number(sm.candidatesRaw ?? 0),
+    candidatesUnique: Number(sm.candidatesUnique ?? 0),
+    selectedForList: Number(sm.selectedForList ?? 0),
+    manualReviewCount: Number(sm.manualReviewCount ?? 0),
+    rateLimitHitCount,
+    duplicateWarningRate: Number(sm.duplicateWarningRate ?? 0),
+  };
+
+  const pipelineId = queue?.runId
+    ? `parallel-research-${queue.runId}`
+    : 'parallel-research-unknown';
+
+  return {
+    version: '1.0.0',
+    pipelineId,
+    mode: 'dry-safe',
+    accountCount: queue?.accounts?.length ?? 0,
+    browserConcurrency: 1,
+    localConcurrency,
+    status: 'completed',
+    metrics,
+    researchPipeline: {
+      metrics,
+    },
+    safety: {
+      liveSaveAllowed: false,
+      liveConnectAllowed: false,
+      browserWorkerLock: 'held_serially',
+      companyScopeRequired: true,
+    },
+    lockTelemetry: lockTelemetry ?? null,
+    accounts: [],
+    queue,
+    plannedJobs,
+    browserResults: browser,
+    scoringResults: scoring,
+  };
+}
+
 module.exports = {
+  attachSweepCacheState,
+  buildResearchPipelineArtifact,
   buildResearchQueue,
+  executeBrowserSweepJobs,
   normalizeResearchAccount,
   planResearchJobs,
+  scoreResearchCandidates,
 };

--- a/src/core/research-pipeline.js
+++ b/src/core/research-pipeline.js
@@ -1,0 +1,119 @@
+const { buildSweepTemplates } = require('./account-coverage');
+
+function slugFromDisplayName(value) {
+  const slug = String(value || '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'unnamed-account';
+}
+
+function normalizeResearchAccount(account = {}) {
+  const nameSource =
+    account.accountName
+    ?? account.name
+    ?? account.companyName
+    ?? '';
+
+  const accountName = String(nameSource).trim();
+  const hasAccountId =
+    account.accountId != null && String(account.accountId).trim() !== '';
+  const accountKey = hasAccountId
+    ? String(account.accountId).trim()
+    : slugFromDisplayName(accountName);
+
+  const resolvedName = accountName || accountKey;
+
+  return {
+    ...account,
+    accountKey,
+    accountName: resolvedName,
+  };
+}
+
+function buildResearchQueue({ accounts = [], runId, generatedAt } = {}) {
+  const normalized = accounts.map((a) => normalizeResearchAccount(a));
+  normalized.sort((a, b) => a.accountKey.localeCompare(b.accountKey));
+
+  return {
+    version: '1.0.0',
+    runId: runId ?? null,
+    generatedAt: generatedAt ?? null,
+    mode: 'dry-safe',
+    safety: {
+      liveSaveAllowed: false,
+      liveConnectAllowed: false,
+    },
+    accounts: normalized,
+  };
+}
+
+function planResearchJobs({
+  queue,
+  coverageConfig,
+  maxCandidates = null,
+  options = {},
+} = {}) {
+  const accounts = [...(queue?.accounts || [])];
+  accounts.sort((a, b) => a.accountKey.localeCompare(b.accountKey));
+
+  const templates = buildSweepTemplates(coverageConfig, maxCandidates, options);
+
+  /** @type {Array<Record<string, unknown>>} */
+  const jobs = [];
+
+  for (const account of accounts) {
+    const { accountKey, accountName } = account;
+    jobs.push({
+      id: `company-resolution:${accountKey}`,
+      type: 'company_resolution',
+      accountKey,
+      accountName,
+      safety: {
+        liveSaveAllowed: false,
+        liveConnectAllowed: false,
+      },
+    });
+  }
+
+  for (const account of accounts) {
+    const { accountKey, accountName } = account;
+    for (const template of templates) {
+      jobs.push({
+        id: `sweep:${accountKey}:${template.id}`,
+        type: 'sweep',
+        accountKey,
+        accountName,
+        templateId: template.id,
+        keywords: template.keywords ?? [],
+        titleIncludes: template.titleIncludes ?? [],
+        ...(template.maxCandidates !== undefined
+          ? { maxCandidates: template.maxCandidates }
+          : {}),
+        requiresBrowser: true,
+        safety: {
+          liveSaveAllowed: false,
+          liveConnectAllowed: false,
+          companyScopeRequired: true,
+        },
+      });
+    }
+  }
+
+  jobs.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+  return {
+    safety: {
+      liveSaveAllowed: false,
+      liveConnectAllowed: false,
+    },
+    jobs,
+  };
+}
+
+module.exports = {
+  buildResearchQueue,
+  normalizeResearchAccount,
+  planResearchJobs,
+};

--- a/src/lib/args.js
+++ b/src/lib/args.js
@@ -55,6 +55,7 @@ function parseCliArgs(argv) {
       'search-timeout-ms': { type: 'string' },
       'speed-profile': { type: 'string' },
       'research-concurrency': { type: 'string' },
+      'local-concurrency': { type: 'string' },
       'reuse-sweep-cache': { type: 'boolean' },
       'adaptive-sweep-pruning': { type: 'boolean' },
       'max-age-hours': { type: 'string' },

--- a/tests/autoresearch-mvp.test.js
+++ b/tests/autoresearch-mvp.test.js
@@ -760,6 +760,46 @@ test('buildAutoresearchSpeedEvaluation rejects real evaluation metric duplicate 
   assert.match(evaluation.failedGates.join(' '), /company_resolution_blockers_regressed/);
 });
 
+test('buildAutoresearchSpeedEvaluation reads researchPipeline.metrics for pipeline artifacts', () => {
+  const baseline = {
+    researchPipeline: {
+      metrics: {
+        totalMs: 100000,
+        selectedForList: 30,
+        candidatesUnique: 100,
+        manualReviewCount: 10,
+        duplicateWarningRate: 0.03,
+      },
+    },
+  };
+  const candidate = {
+    researchPipeline: {
+      metrics: {
+        totalMs: 70000,
+        selectedForList: 31,
+        candidatesUnique: 100,
+        manualReviewCount: 9,
+        duplicateWarningRate: 0.02,
+      },
+    },
+  };
+
+  const evaluation = buildAutoresearchSpeedEvaluation({
+    baseline,
+    candidate,
+    minSpeedupPercent: 25,
+  });
+
+  assert.equal(evaluation.speed.baselineMs, 100000);
+  assert.equal(evaluation.speed.candidateMs, 70000);
+  assert.equal(evaluation.speed.speedupPercent, 30);
+  assert.equal(evaluation.decision, 'keep_candidate');
+  assert.equal(evaluation.quality.baseline.resolvedSafeToSave, 30);
+  assert.equal(evaluation.quality.candidate.resolvedSafeToSave, 31);
+  assert.ok(Math.abs(evaluation.quality.baseline.manualReviewRate - 0.1) < 1e-9);
+  assert.ok(Math.abs(evaluation.quality.candidate.manualReviewRate - 0.09) < 1e-9);
+});
+
 test('renderAutoresearchSpeedEvaluationMarkdown is operator-facing and read-only', () => {
   const markdown = renderAutoresearchSpeedEvaluationMarkdown(buildAutoresearchSpeedEvaluation({
     baseline: {

--- a/tests/browser-worker-lock.test.js
+++ b/tests/browser-worker-lock.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createBrowserWorkerLock } = require('../src/core/browser-worker-lock');
+
+test('browser worker lock serializes async browser jobs', async () => {
+  const lock = createBrowserWorkerLock();
+  const events = [];
+
+  await Promise.all([
+    lock.runExclusive('job-a', async () => {
+      events.push('a:start');
+      await Promise.resolve();
+      events.push('a:end');
+      return 'a';
+    }),
+    lock.runExclusive('job-b', async () => {
+      events.push('b:start');
+      events.push('b:end');
+      return 'b';
+    }),
+  ]);
+
+  assert.deepEqual(events, ['a:start', 'a:end', 'b:start', 'b:end']);
+});
+
+test('browser worker lock releases after thrown errors', async () => {
+  const lock = createBrowserWorkerLock();
+  const events = [];
+
+  await assert.rejects(
+    () => lock.runExclusive('job-a', async () => {
+      events.push('a:start');
+      throw new Error('boom');
+    }),
+    /boom/,
+  );
+
+  await lock.runExclusive('job-b', async () => {
+    events.push('b:ok');
+    return true;
+  });
+
+  assert.deepEqual(events, ['a:start', 'b:ok']);
+  const tel = lock.getTelemetry();
+  assert.equal(tel.length, 2);
+  assert.equal(tel[0].status, 'failed');
+  assert.equal(tel[1].status, 'completed');
+});

--- a/tests/parallel-research-benchmark.test.js
+++ b/tests/parallel-research-benchmark.test.js
@@ -1,0 +1,205 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createBrowserWorkerLock } = require('../src/core/browser-worker-lock');
+const {
+  attachSweepCacheState,
+  buildResearchPipelineArtifact,
+  buildResearchQueue,
+  executeBrowserSweepJobs,
+  planResearchJobs,
+  scoreResearchCandidates,
+} = require('../src/core/research-pipeline');
+
+/**
+ * Deterministic “benchmark”: fake delays via injected counters, no wall-clock assertions.
+ */
+test('pipeline skips browser work on sweep cache hits', async () => {
+  const queue = buildResearchQueue({
+    accounts: [{ accountId: 'a1', accountName: 'BenchCo' }],
+    runId: 'bench',
+  });
+  const plan = planResearchJobs({
+    queue,
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [{ id: 'x', keywords: ['obs'] }],
+    },
+  });
+
+  const hydrated = await attachSweepCacheState({
+    jobs: plan.jobs,
+    readCache: () => ({ candidates: [{ fullName: 'C', title: 'VP Platform Engineering' }] }),
+  });
+
+  let browserCalls = 0;
+  const driver = {
+    async openPeopleSearch() {
+      browserCalls += 1;
+    },
+    async applySearchTemplate() {},
+    async scrollAndCollectCandidates() {
+      browserCalls += 1;
+      return [];
+    },
+  };
+
+  const lock = createBrowserWorkerLock();
+  await executeBrowserSweepJobs({
+    jobs: hydrated,
+    driver,
+    lock,
+    runId: 'bench',
+  });
+
+  assert.equal(browserCalls, 0);
+  const sweepCount = hydrated.filter((j) => j.type === 'sweep').length;
+  assert.ok(sweepCount >= 1);
+  assert.equal(hydrated.filter((j) => j.type === 'sweep' && j.cacheHit).length, sweepCount);
+});
+
+test('browser worker telemetry records serial execution order', async () => {
+  const lock = createBrowserWorkerLock();
+  await Promise.all([
+    lock.runExclusive('j1', async () => {
+      await Promise.resolve();
+    }),
+    lock.runExclusive('j2', async () => {
+      await Promise.resolve();
+    }),
+  ]);
+  const tel = lock.getTelemetry();
+  assert.deepEqual(tel.map((t) => t.jobId), ['j1', 'j2']);
+});
+
+test('local scoring concurrency preserves merged ordering', async () => {
+  const rawResults = [];
+  for (let i = 0; i < 8; i += 1) {
+    rawResults.push({
+      templateId: `t-${String(i).padStart(2, '0')}`,
+      candidates: [{
+        fullName: `Person ${i}`,
+        title: 'VP Platform Engineering',
+        salesNavigatorUrl: `https://www.linkedin.com/sales/lead/${i}`,
+      }],
+    });
+  }
+
+  const icpConfig = {
+    titleIncludeKeywords: ['platform'],
+    seniorityWeights: { vp: 10 },
+    roleFamilyWeights: { platform_engineering: 30 },
+  };
+  const coverageConfig = {
+    bucketRules: {
+      directObservabilityRoleFamilies: ['platform_engineering'],
+      adjacentRoleFamilies: [],
+    },
+  };
+
+  const s1 = await scoreResearchCandidates({
+    accountName: 'BenchCo',
+    rawResults,
+    icpConfig,
+    coverageConfig,
+    priorityModel: null,
+    localConcurrency: 2,
+  });
+  const s2 = await scoreResearchCandidates({
+    accountName: 'BenchCo',
+    rawResults,
+    icpConfig,
+    coverageConfig,
+    priorityModel: null,
+    localConcurrency: 8,
+  });
+
+  assert.deepEqual(
+    s1.consolidated.candidates.map((c) => c.fullName),
+    s2.consolidated.candidates.map((c) => c.fullName),
+  );
+});
+
+test('merge artifact exposes cache vs browser counters', async () => {
+  const queue = buildResearchQueue({
+    accounts: [{ accountId: 'a1', accountName: 'BenchCo' }],
+    runId: 'bench',
+  });
+  const plan = planResearchJobs({
+    queue,
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [{ id: 'y', keywords: ['obs'] }],
+    },
+  });
+
+  const hydrated = await attachSweepCacheState({
+    jobs: plan.jobs,
+    readCache: (job) => (
+      job.templateId === 'broad-crawl'
+        ? { candidates: [] }
+        : null
+    ),
+  });
+
+  const lock = createBrowserWorkerLock();
+  const browser = await executeBrowserSweepJobs({
+    jobs: hydrated,
+    driver: {
+      async openPeopleSearch() {},
+      async applySearchTemplate() {},
+      async scrollAndCollectCandidates() {
+        return [{ fullName: 'Z', title: 'VP Platform Engineering' }];
+      },
+    },
+    lock,
+    runId: 'bench',
+  });
+
+  const rawResults = [];
+  for (const job of hydrated) {
+    if (job.type !== 'sweep') continue;
+    if (job.cacheHit) {
+      rawResults.push({ templateId: job.templateId, candidates: job.cacheCandidates || [] });
+    }
+  }
+  for (const row of browser.results) {
+    if (row.status === 'completed') {
+      rawResults.push({ templateId: row.templateId, candidates: row.candidates || [] });
+    }
+  }
+
+  const scoring = await scoreResearchCandidates({
+    accountName: 'BenchCo',
+    rawResults,
+    icpConfig: {
+      titleIncludeKeywords: ['platform'],
+      seniorityWeights: { vp: 10 },
+      roleFamilyWeights: { platform_engineering: 30 },
+    },
+    coverageConfig: {
+      bucketRules: {
+        directObservabilityRoleFamilies: ['platform_engineering'],
+        adjacentRoleFamilies: [],
+      },
+    },
+    priorityModel: null,
+    localConcurrency: 4,
+  });
+
+  const artifact = buildResearchPipelineArtifact({
+    queue,
+    plannedJobs: plan,
+    cacheResults: hydrated,
+    browserResults: browser,
+    scoringResults: scoring,
+    lockTelemetry: lock.getTelemetry(),
+    startedAt: 0,
+    finishedAt: 100,
+    localConcurrency: 4,
+  });
+
+  assert.equal(artifact.browserConcurrency, 1);
+  assert.equal(artifact.metrics.browserJobsSkippedByCache, artifact.metrics.cacheHits);
+  assert.equal(artifact.metrics.browserJobsExecuted, 1);
+});

--- a/tests/release-readiness.test.js
+++ b/tests/release-readiness.test.js
@@ -39,7 +39,37 @@ test('package scripts keep autoresearch dry-safe and expose release checks', () 
   assert.doesNotMatch(packageJson.scripts['autoresearch:mvp'], /--live-save|--live-connect|allow-background-connects/);
   assert.equal(packageJson.scripts['autoresearch:speed'], 'node src/cli.js autoresearch-speed-eval');
   assert.doesNotMatch(packageJson.scripts['autoresearch:speed'], /--live-save|--live-connect|allow-background-connects/);
+  assert.equal(packageJson.scripts['parallel-account-research'], 'node src/cli.js parallel-account-research');
+  assert.doesNotMatch(packageJson.scripts['parallel-account-research'], /--live-save|--live-connect|allow-background-connects/);
   assert.equal(packageJson.scripts['print-mvp-operator-dashboard'], 'node src/cli.js print-mvp-operator-dashboard');
+});
+
+test('parallel-account-research CLI entry refuses live-save', () => {
+  const { spawnSync } = require('node:child_process');
+  const r = spawnSync(process.execPath, ['src/cli.js', 'parallel-account-research', '--accounts=Example', '--live-save'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+  });
+  assert.notEqual(r.status, 0);
+  assert.match(`${r.stderr}${r.stdout}`, /refuses live-save/i);
+});
+
+test('parallel-account-research CLI is dry-safe plan-only without executing browser jobs', () => {
+  const { spawnSync } = require('node:child_process');
+  const r = spawnSync(process.execPath, ['src/cli.js', 'parallel-account-research', '--accounts=Example', '--local-concurrency=2'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, `${r.stderr}${r.stdout}`);
+  const jsonStart = r.stdout.indexOf('{');
+  assert.ok(jsonStart >= 0, r.stdout);
+  const payload = JSON.parse(r.stdout.slice(jsonStart));
+  assert.equal(payload.mode, 'dry-safe');
+  assert.equal(payload.browserConcurrency, 1);
+  assert.equal(payload.localConcurrency, 2);
+  assert.equal(payload.accounts[0].metrics.browserJobsExecuted, 0);
+  assert.ok(payload.accounts[0].metrics.cacheMisses > 0);
+  assert.equal(payload.accounts[0].browserResults.results.every((row) => row.reason === 'dry_safe_cli_plan_only'), true);
 });
 
 test('gitignore keeps local runtime and browser artifacts out of the shared repo', () => {

--- a/tests/research-pipeline.test.js
+++ b/tests/research-pipeline.test.js
@@ -1,0 +1,151 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildResearchQueue,
+  normalizeResearchAccount,
+  planResearchJobs,
+} = require('../src/core/research-pipeline');
+
+test('buildResearchQueue creates deterministic account jobs with dry-safe defaults', () => {
+  const queue = buildResearchQueue({
+    accounts: [
+      { accountId: 'a1', accountName: 'Example AG' },
+      { accountId: 'a2', accountName: 'Example GmbH' },
+    ],
+    runId: 'research-run-1',
+    generatedAt: '2026-04-30T12:00:00Z',
+  });
+
+  assert.equal(queue.version, '1.0.0');
+  assert.equal(queue.runId, 'research-run-1');
+  assert.equal(queue.generatedAt, '2026-04-30T12:00:00Z');
+  assert.equal(queue.mode, 'dry-safe');
+  assert.equal(queue.safety.liveSaveAllowed, false);
+  assert.equal(queue.safety.liveConnectAllowed, false);
+  assert.deepEqual(queue.accounts.map((job) => job.accountKey), ['a1', 'a2']);
+});
+
+test('normalizeResearchAccount falls back to stable name key', () => {
+  const account = normalizeResearchAccount({ accountName: 'Example AG' });
+  assert.equal(account.accountKey, 'example-ag');
+  assert.equal(account.accountName, 'Example AG');
+});
+
+test('normalizeResearchAccount prefers accountId as accountKey', () => {
+  const account = normalizeResearchAccount({ accountId: '  x9  ', accountName: 'Other' });
+  assert.equal(account.accountKey, 'x9');
+  assert.equal(account.accountName, 'Other');
+});
+
+test('normalizeResearchAccount uses name then companyName for display', () => {
+  const fromName = normalizeResearchAccount({ name: 'Acme Corp' });
+  assert.equal(fromName.accountKey, 'acme-corp');
+  assert.equal(fromName.accountName, 'Acme Corp');
+
+  const fromCompany = normalizeResearchAccount({ companyName: 'Beta LLC' });
+  assert.equal(fromCompany.accountKey, 'beta-llc');
+  assert.equal(fromCompany.accountName, 'Beta LLC');
+});
+
+test('buildResearchQueue sorts accounts by accountKey for determinism', () => {
+  const queue = buildResearchQueue({
+    accounts: [
+      { accountId: 'z', accountName: 'Zed' },
+      { accountId: 'a', accountName: 'Aye' },
+    ],
+    runId: 'r1',
+  });
+  assert.deepEqual(queue.accounts.map((a) => a.accountKey), ['a', 'z']);
+});
+
+test('planResearchJobs emits scoped sweep jobs without live mutation permissions', () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'a1', accountName: 'Example AG' }],
+      runId: 'research-run-1',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [{ id: 'platform', keywords: ['platform'] }],
+    },
+  });
+
+  assert.ok(plan.jobs.some((job) => job.type === 'company_resolution'));
+  const sweepJobs = plan.jobs.filter((job) => job.type === 'sweep');
+  assert.equal(sweepJobs.length, 2);
+  assert.equal(sweepJobs.every((job) => job.requiresBrowser === true), true);
+  assert.equal(sweepJobs.every((job) => job.safety.companyScopeRequired === true), true);
+  assert.equal(sweepJobs.every((job) => job.safety.liveSaveAllowed === false), true);
+  assert.equal(sweepJobs.every((job) => job.safety.liveConnectAllowed === false), true);
+  assert.equal(plan.safety.liveSaveAllowed, false);
+  assert.equal(plan.safety.liveConnectAllowed, false);
+});
+
+test('planResearchJobs includes template fields on sweep jobs', () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'a1', accountName: 'Example AG' }],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true, titleIncludes: ['VP'] },
+      sweeps: [{ id: 'platform', keywords: ['platform'], titleIncludes: ['Engineer'] }],
+    },
+  });
+  const broad = plan.jobs.find((j) => j.type === 'sweep' && j.templateId === 'broad-crawl');
+  const platform = plan.jobs.find((j) => j.type === 'sweep' && j.templateId === 'sweep-platform');
+  assert.ok(broad);
+  assert.ok(platform);
+  assert.deepEqual(broad.keywords, []);
+  assert.deepEqual(broad.titleIncludes, ['VP']);
+  assert.deepEqual(platform.keywords, ['platform']);
+  assert.deepEqual(platform.titleIncludes, ['Engineer']);
+  assert.equal(broad.accountKey, 'a1');
+  assert.equal(broad.accountName, 'Example AG');
+  assert.equal(platform.accountKey, 'a1');
+  assert.equal(platform.accountName, 'Example AG');
+});
+
+test('planResearchJobs emits one company_resolution per account in deterministic order', () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [
+        { accountId: 'b2', accountName: 'B' },
+        { accountId: 'a1', accountName: 'A' },
+      ],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [],
+    },
+  });
+  const cr = plan.jobs.filter((j) => j.type === 'company_resolution');
+  assert.equal(cr.length, 2);
+  assert.deepEqual(cr.map((j) => j.accountKey), ['a1', 'b2']);
+  assert.equal(cr.every((j) => j.safety.liveSaveAllowed === false), true);
+  assert.equal(cr.every((j) => j.safety.liveConnectAllowed === false), true);
+  const expectedIds = plan.jobs.map((j) => j.id);
+  const sorted = [...expectedIds].sort();
+  assert.deepEqual(expectedIds, sorted, 'job ids should be sorted for stable ordering');
+});
+
+test('planResearchJobs passes maxCandidates and options into buildSweepTemplates', () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'x', accountName: 'X' }],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [{ id: 's1', keywords: ['k'] }],
+    },
+    maxCandidates: 5,
+    options: { speedProfile: 'exhaustive' },
+  });
+  const sweeps = plan.jobs.filter((j) => j.type === 'sweep');
+  assert.equal(sweeps.length, 2);
+  assert.equal(sweeps[0].maxCandidates, 5);
+  assert.equal(sweeps[1].maxCandidates, 5);
+});

--- a/tests/research-pipeline.test.js
+++ b/tests/research-pipeline.test.js
@@ -2,10 +2,15 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+  attachSweepCacheState,
+  buildResearchPipelineArtifact,
   buildResearchQueue,
+  executeBrowserSweepJobs,
   normalizeResearchAccount,
   planResearchJobs,
+  scoreResearchCandidates,
 } = require('../src/core/research-pipeline');
+const { createBrowserWorkerLock } = require('../src/core/browser-worker-lock');
 
 test('buildResearchQueue creates deterministic account jobs with dry-safe defaults', () => {
   const queue = buildResearchQueue({
@@ -148,4 +153,285 @@ test('planResearchJobs passes maxCandidates and options into buildSweepTemplates
   assert.equal(sweeps.length, 2);
   assert.equal(sweeps[0].maxCandidates, 5);
   assert.equal(sweeps[1].maxCandidates, 5);
+});
+
+test('attachSweepCacheState calls readCache for sweep jobs only', async () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'a1', accountName: 'Acme' }],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [{ id: 's1', keywords: ['k'] }],
+    },
+  });
+  const calls = [];
+  const jobs = await attachSweepCacheState({
+    jobs: plan.jobs,
+    readCache: (job) => {
+      calls.push(job.type);
+      return null;
+    },
+  });
+  assert.deepEqual(calls, ['sweep', 'sweep']);
+  assert.equal(jobs.filter((j) => j.type === 'company_resolution').length, 1);
+});
+
+test('attachSweepCacheState marks cache hits without browser', async () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'a1', accountName: 'Acme' }],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [],
+    },
+  });
+  const sweepId = plan.jobs.find((j) => j.type === 'sweep').id;
+  const jobs = await attachSweepCacheState({
+    jobs: plan.jobs,
+    readCache: (job) => {
+      if (job.id === sweepId) {
+        return { candidates: [{ fullName: 'A', title: 'VP Platform Engineering' }] };
+      }
+      return null;
+    },
+  });
+  const hit = jobs.find((j) => j.id === sweepId);
+  assert.equal(hit.cacheHit, true);
+  assert.equal(hit.requiresBrowser, false);
+  assert.equal(hit.cacheCandidates.length, 1);
+});
+
+test('attachSweepCacheState treats thrown readCache as cache miss', async () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'a1', accountName: 'Acme' }],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [],
+    },
+  });
+  const jobs = await attachSweepCacheState({
+    jobs: plan.jobs,
+    readCache: () => {
+      throw new Error('bad cache');
+    },
+  });
+  const sweep = jobs.find((j) => j.type === 'sweep');
+  assert.equal(sweep.cacheHit, false);
+  assert.equal(sweep.requiresBrowser, true);
+});
+
+test('executeBrowserSweepJobs skips cache-hit jobs and serializes driver calls', async () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'a1', accountName: 'Acme' }],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [{ id: 's2', keywords: ['obs'] }],
+    },
+  });
+  const withCache = await attachSweepCacheState({
+    jobs: plan.jobs,
+    readCache: (job) => {
+      if (String(job.templateId) === 'broad-crawl') {
+        return { candidates: [{ fullName: 'Cached', title: 'Director SRE' }] };
+      }
+      return null;
+    },
+  });
+
+  const events = [];
+  const driver = {
+    async openPeopleSearch() {
+      events.push('open');
+    },
+    async applySearchTemplate(t) {
+      events.push(`tpl:${t.id}`);
+    },
+    async scrollAndCollectCandidates(account, template) {
+      events.push(`collect:${template.id}`);
+      return [{ fullName: 'Live', title: 'VP Platform Engineering', company: account.accountName }];
+    },
+  };
+
+  const lock = createBrowserWorkerLock();
+  const out = await executeBrowserSweepJobs({
+    jobs: withCache,
+    driver,
+    lock,
+    runId: 'run1',
+  });
+
+  assert.equal(out.browserJobsExecuted, 1);
+  assert.deepEqual(events.filter((e) => e.startsWith('collect:')), ['collect:sweep-s2']);
+});
+
+test('executeBrowserSweepJobs stops on rate limit when stopOnRateLimit is true', async () => {
+  const plan = planResearchJobs({
+    queue: buildResearchQueue({
+      accounts: [{ accountId: 'a1', accountName: 'Acme' }],
+      runId: 'r',
+    }),
+    coverageConfig: {
+      broadCrawl: { enabled: true },
+      sweeps: [{ id: 's2', keywords: ['obs'] }],
+    },
+  });
+  let n = 0;
+  const driver = {
+    async openPeopleSearch() {},
+    async applySearchTemplate() {},
+    async scrollAndCollectCandidates() {
+      n += 1;
+      if (n === 1) {
+        const err = new Error('too many requests');
+        err.code = 'rate_limited';
+        throw err;
+      }
+      return [{ fullName: 'X', title: 'VP Platform Engineering' }];
+    },
+  };
+  const lock = createBrowserWorkerLock();
+  const out = await executeBrowserSweepJobs({
+    jobs: plan.jobs,
+    driver,
+    lock,
+    runId: 'run1',
+    stopOnRateLimit: true,
+  });
+  assert.equal(out.rateLimitHitCount, 1);
+  assert.equal(out.browserJobsExecuted, 0);
+  const skipped = out.results.filter((r) => r.status === 'skipped');
+  assert.ok(skipped.length >= 1);
+});
+
+test('scoreResearchCandidates dedupes and matches consolidate ordering across concurrency', async () => {
+  const icpConfig = {
+    titleExcludeKeywords: ['buildings'],
+    titleIncludeKeywords: ['platform'],
+    seniorityWeights: { vp: 10 },
+    roleFamilyWeights: { platform_engineering: 30 },
+  };
+  const coverageConfig = {
+    bucketRules: {
+      directObservabilityRoleFamilies: ['platform_engineering'],
+      adjacentRoleFamilies: [],
+    },
+  };
+  const rawResults = [
+    {
+      templateId: 'broad-crawl',
+      candidates: [
+        {
+          fullName: 'Jane',
+          title: 'VP Platform Engineering',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/foo',
+        },
+      ],
+    },
+    {
+      templateId: 'sweep-x',
+      candidates: [
+        {
+          fullName: 'Jane',
+          title: 'VP Platform Engineering',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/foo',
+        },
+        {
+          fullName: 'Bob',
+          title: 'Director Corporate Buildings Strategy',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/bar',
+        },
+      ],
+    },
+  ];
+
+  const one = await scoreResearchCandidates({
+    accountName: 'Acme',
+    rawResults,
+    icpConfig,
+    coverageConfig,
+    priorityModel: null,
+    localConcurrency: 1,
+  });
+  const four = await scoreResearchCandidates({
+    accountName: 'Acme',
+    rawResults,
+    icpConfig,
+    coverageConfig,
+    priorityModel: null,
+    localConcurrency: 4,
+  });
+
+  assert.equal(one.metrics.candidatesRaw, 3);
+  assert.equal(one.metrics.candidatesUnique, 2);
+  assert.equal(one.consolidated.candidates.length, four.consolidated.candidates.length);
+  assert.deepEqual(
+    one.consolidated.candidates.map((c) => c.fullName),
+    four.consolidated.candidates.map((c) => c.fullName),
+  );
+  assert.ok(one.rejected.some((c) => c.scoringEligible === false));
+});
+
+test('buildResearchPipelineArtifact includes browserConcurrency and metrics', () => {
+  const queue = buildResearchQueue({
+    accounts: [{ accountId: 'x', accountName: 'X' }],
+    runId: 'rid',
+  });
+  const plan = planResearchJobs({
+    queue,
+    coverageConfig: { broadCrawl: { enabled: true }, sweeps: [] },
+  });
+  const jobsWithCache = [
+    ...plan.jobs.map((j) => {
+      if (j.type !== 'sweep') return j;
+      return { ...j, requiresBrowser: false, cacheHit: true, cacheCandidates: [] };
+    }),
+  ];
+  const browserResults = {
+    results: [],
+    rateLimitHitCount: 0,
+    browserJobsExecuted: 0,
+  };
+  const scoringResults = {
+    metrics: {
+      candidatesRaw: 10,
+      candidatesUnique: 5,
+      selectedForList: 3,
+      manualReviewCount: 1,
+    },
+  };
+  const art = buildResearchPipelineArtifact({
+    queue,
+    plannedJobs: plan,
+    cacheResults: jobsWithCache,
+    browserResults,
+    scoringResults,
+    lockTelemetry: [],
+    startedAt: '2026-04-30T12:00:00.000Z',
+    finishedAt: '2026-04-30T12:01:40.000Z',
+    localConcurrency: 4,
+  });
+
+  assert.equal(art.browserConcurrency, 1);
+  assert.equal(art.localConcurrency, 4);
+  assert.equal(art.metrics.cacheHits, 1);
+  assert.equal(art.metrics.cacheMisses, 0);
+  assert.equal(art.metrics.browserJobsSkippedByCache, 1);
+  assert.equal(art.metrics.browserJobsExecuted, 0);
+  assert.equal(art.metrics.totalMs, 100000);
+  assert.equal(art.metrics.selectedForList, 3);
+  assert.equal(art.metrics.manualReviewCount, 1);
+  assert.equal(art.metrics.rateLimitHitCount, 0);
+  assert.equal(art.safety.liveSaveAllowed, false);
+  assert.equal(art.safety.liveConnectAllowed, false);
+  assert.equal(art.safety.browserWorkerLock, 'held_serially');
 });


### PR DESCRIPTION
## Summary
- Expands PR #25 from the initial job planner into an integration PR for the Parallel Research Pipeline stack.
- Adds deterministic research queue/job planning, sweep-cache state attachment, serial Browser Worker lock, fake-driver-compatible browser executor, local parallel scoring, merge artifact metrics, speed evaluation hooks, deterministic benchmark tests, and a dry-safe plan-only CLI entry.
- Keeps Sales Navigator browser concurrency fixed at `1`; the new CLI does not execute browser jobs and reports browser-required jobs as `dry_safe_cli_plan_only` until real browser integration is explicitly added later.

## Parallel-agent model
- Parallelized / dry-safe: queue planning, sweep planning, cache analysis, local scoring, quality/merge metrics, speed evaluation.
- Serialized / guarded: browser-backed Sales Navigator work via `createBrowserWorkerLock()` and `executeBrowserSweepJobs()` using injected drivers only.
- No parallel Sales Navigator browser sessions are introduced.

## Safety
- No live-save, live-connect, message sending, or live mutation behavior added.
- New CLI refuses `--live-save`, `--live-connect`, and `--allow-background-connects`.
- No runtime, `.env`, cookie, browser-profile, screenshot, DB, secret, or lockfile changes.
- Browser concurrency remains exactly `1` in artifact and CLI outputs.
- CLI smoke verifies dry-safe plan-only mode with `browserJobsExecuted = 0`.

## Verification
- `node --test tests/research-pipeline.test.js tests/browser-worker-lock.test.js tests/parallel-research-benchmark.test.js tests/autoresearch-mvp.test.js tests/release-readiness.test.js` ✅ — 55/55 passed
- `npm run test:release-readiness` ✅ — 31/31 passed
- `node src/cli.js parallel-account-research --accounts="Example AG, Example GmbH" --local-concurrency=2 --run-id=smoke` ✅ — dry-safe JSON smoke passed; browserConcurrency=1; browserJobsExecuted=0
- `npm test` ✅ — 336/336 passed
- `git diff --check` ✅
- Safety/path scan ✅ — no runtime/session/secret/lockfile paths modified

## Follow-ups after merge
- Wire real read-only `readSweepCache` into the CLI behind `--reuse-sweep-cache`.
- Add explicit phase timings (`preBrowserMs`, `browserMs`, `postBrowserMs`) once real executor integration lands.
- Add live/dry-run integration only after Operator-approved browser-session testing.
