### PR TITLE
test: add parallel research stress harness

### DIFF
--- a/automation/parallel-research-stress.js
+++ b/automation/parallel-research-stress.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+
+const DEFAULT_ACCOUNTS = ['Example AG', 'Example GmbH', 'Example SE'];
+const DEFAULT_LOCAL_CONCURRENCY_VALUES = [1, 2, 4];
+const FORBIDDEN_LIVE_FLAGS = new Set([
+  '--live-save',
+  '--live-connect',
+  '--allow-background-connects',
+]);
+
+function parseList(value, fallback, optionName = 'value') {
+  if (value === undefined || value === null) return [...fallback];
+  const parsed = String(value)
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parsed.length === 0) {
+    throw new Error(`${optionName} must include at least one value`);
+  }
+  return parsed;
+}
+
+function parseIntegerList(value, fallback, optionName = 'value') {
+  if (value === undefined || value === null) return [...fallback];
+  const parts = parseList(value, [], optionName);
+  const parsed = parts.map((part) => Number.parseInt(part, 10));
+  const invalid = parts.find((part, index) => String(parsed[index]) !== part || !Number.isInteger(parsed[index]) || parsed[index] <= 0);
+  if (invalid) {
+    throw new Error(`${optionName} must contain positive integers; invalid value: ${invalid}`);
+  }
+  return parsed;
+}
+
+function assertNoLiveFlags(args = []) {
+  const hit = args.find((arg) => {
+    const name = String(arg).split('=')[0];
+    return FORBIDDEN_LIVE_FLAGS.has(name);
+  });
+  if (hit) {
+    throw new Error(`parallel research stress harness refuses live or background mutation flags: ${hit}`);
+  }
+}
+
+function parseCliJsonPayload(stdout) {
+  const text = String(stdout || '');
+  const start = text.indexOf('{');
+  if (start < 0) {
+    throw new Error('parallel-account-research output did not contain a JSON payload');
+  }
+  return JSON.parse(text.slice(start));
+}
+
+function buildParallelResearchStressPlan({
+  accounts = DEFAULT_ACCOUNTS,
+  localConcurrencyValues = DEFAULT_LOCAL_CONCURRENCY_VALUES,
+  runIdPrefix = 'stress',
+  extraArgs = [],
+} = {}) {
+  assertNoLiveFlags(extraArgs);
+  const normalizedAccounts = Array.isArray(accounts)
+    ? accounts.map((account) => String(account).trim()).filter(Boolean)
+    : parseList(accounts, DEFAULT_ACCOUNTS, 'accounts');
+  const normalizedConcurrency = Array.isArray(localConcurrencyValues)
+    ? localConcurrencyValues.map((value) => Number.parseInt(value, 10)).filter((value) => Number.isInteger(value) && value > 0)
+    : parseIntegerList(localConcurrencyValues, DEFAULT_LOCAL_CONCURRENCY_VALUES, 'local-concurrency-values');
+  if (normalizedAccounts.length === 0) {
+    throw new Error('accounts must include at least one value');
+  }
+  if (normalizedConcurrency.length === 0) {
+    throw new Error('local-concurrency-values must include at least one positive integer');
+  }
+  const accountsArg = normalizedAccounts.join(', ');
+  const prefix = String(runIdPrefix || 'stress');
+  const runs = normalizedConcurrency.map((localConcurrency) => {
+    const runId = `${prefix}-local-${localConcurrency}`;
+    return {
+      runId,
+      localConcurrency,
+      args: [
+        'src/cli.js',
+        'parallel-account-research',
+        `--accounts=${accountsArg}`,
+        `--local-concurrency=${localConcurrency}`,
+        `--run-id=${runId}`,
+        ...extraArgs,
+      ],
+    };
+  });
+  return {
+    accounts: normalizedAccounts,
+    accountsArg,
+    localConcurrencyValues: normalizedConcurrency,
+    runs,
+  };
+}
+
+function validateParallelResearchStressPayload({ requestedLocalConcurrency, payload }) {
+  const failures = [];
+  if (!payload || typeof payload !== 'object') failures.push('payload_missing');
+  if (payload?.mode !== 'dry-safe') failures.push('mode_not_dry_safe');
+  if (payload?.browserConcurrency !== 1) failures.push('browser_concurrency_not_one');
+  if (payload?.localConcurrency !== requestedLocalConcurrency) failures.push('local_concurrency_mismatch');
+  const accounts = Array.isArray(payload?.accounts) ? payload.accounts : [];
+  if (accounts.length === 0) failures.push('accounts_missing');
+  let browserJobsExecuted = 0;
+  for (const account of accounts) {
+    const executed = Number(account?.metrics?.browserJobsExecuted || 0);
+    browserJobsExecuted += executed;
+    if (executed !== 0) failures.push(`browser_jobs_executed:${account?.accountName || 'unknown'}`);
+    const results = account?.browserResults?.results;
+    if (Array.isArray(results)) {
+      for (const result of results) {
+        if (result?.status !== 'skipped' || result?.reason !== 'dry_safe_cli_plan_only') {
+          failures.push(`unexpected_browser_result:${account?.accountName || 'unknown'}`);
+          break;
+        }
+      }
+    }
+  }
+  return {
+    ok: failures.length === 0,
+    failures,
+    requestedLocalConcurrency,
+    mode: payload?.mode,
+    browserConcurrency: payload?.browserConcurrency,
+    localConcurrency: payload?.localConcurrency,
+    accountCount: accounts.length,
+    browserJobsExecuted,
+  };
+}
+
+function defaultRunner({ args }) {
+  return spawnSync(process.execPath, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+function runParallelResearchStressHarness({
+  accounts = DEFAULT_ACCOUNTS,
+  localConcurrencyValues = DEFAULT_LOCAL_CONCURRENCY_VALUES,
+  runIdPrefix = 'stress',
+  extraArgs = [],
+  runner = defaultRunner,
+} = {}) {
+  assertNoLiveFlags(extraArgs);
+  const plan = buildParallelResearchStressPlan({
+    accounts,
+    localConcurrencyValues,
+    runIdPrefix,
+    extraArgs,
+  });
+  const runs = [];
+  for (const run of plan.runs) {
+    const result = runner({ args: run.args, run });
+    const status = Number.isInteger(result?.status) ? result.status : 1;
+    const stdout = result?.stdout || '';
+    const stderr = result?.stderr || '';
+    if (status !== 0) {
+      runs.push({
+        runId: run.runId,
+        localConcurrency: run.localConcurrency,
+        ok: false,
+        failures: [`exit_status:${status}`],
+        stderr,
+      });
+      continue;
+    }
+    try {
+      const payload = parseCliJsonPayload(stdout);
+      const validation = validateParallelResearchStressPayload({
+        requestedLocalConcurrency: run.localConcurrency,
+        payload,
+      });
+      runs.push({
+        runId: run.runId,
+        localConcurrency: run.localConcurrency,
+        ...validation,
+      });
+    } catch (error) {
+      runs.push({
+        runId: run.runId,
+        localConcurrency: run.localConcurrency,
+        ok: false,
+        failures: [`parse_or_validation_error:${error.message}`],
+      });
+    }
+  }
+  return {
+    ok: runs.every((run) => run.ok),
+    mode: 'dry-safe',
+    browserConcurrencyInvariant: 1,
+    accounts: plan.accounts,
+    localConcurrencyValues: plan.localConcurrencyValues,
+    runs,
+  };
+}
+
+function parseHarnessArgs(argv) {
+  assertNoLiveFlags(argv);
+  const options = {};
+  for (const arg of argv) {
+    if (arg.startsWith('--accounts=')) options.accounts = parseList(arg.slice('--accounts='.length), DEFAULT_ACCOUNTS, 'accounts');
+    if (arg.startsWith('--local-concurrency-values=')) {
+      options.localConcurrencyValues = parseIntegerList(arg.slice('--local-concurrency-values='.length), DEFAULT_LOCAL_CONCURRENCY_VALUES, 'local-concurrency-values');
+    }
+    if (arg.startsWith('--run-id-prefix=')) options.runIdPrefix = arg.slice('--run-id-prefix='.length);
+  }
+  return options;
+}
+
+if (require.main === module) {
+  try {
+    const summary = runParallelResearchStressHarness(parseHarnessArgs(process.argv.slice(2)));
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    if (!summary.ok) process.exitCode = 1;
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  buildParallelResearchStressPlan,
+  parseCliJsonPayload,
+  runParallelResearchStressHarness,
+  validateParallelResearchStressPayload,
+};

--- a/docs/testing/parallel-research-stress-verification.md
+++ b/docs/testing/parallel-research-stress-verification.md
@@ -38,7 +38,33 @@ Expected invariants for the smoke output:
 
 ## Concurrency stress matrix
 
-Run the dry-safe smoke with multiple local concurrency values. The CLI may print a human-readable `[cli] ...` line before the JSON payload, so capture raw stdout and extract the JSON object before parsing:
+Run the executable dry-safe stress harness:
+
+```bash
+npm run parallel-research:stress
+```
+
+For a custom matrix:
+
+```bash
+node automation/parallel-research-stress.js \
+  --accounts="Example AG, Example GmbH, Example SE" \
+  --local-concurrency-values=1,2,4 \
+  --run-id-prefix=stress
+```
+
+Expected summary invariants:
+
+- top-level `ok` is `true`
+- `mode` is `dry-safe`
+- `browserConcurrencyInvariant` is `1`
+- each run has `ok: true`
+- each run has `browserConcurrency: 1`
+- each run has `browserJobsExecuted: 0`
+
+The harness intentionally parses the mixed human/JSON output from `parallel-account-research`, so callers should consume the harness summary rather than redirecting the lower-level CLI directly.
+
+If debugging the lower-level CLI manually, remember that it may print a human-readable `[cli] ...` line before the JSON payload. Capture raw stdout and extract the JSON object before parsing:
 
 ```bash
 for c in 1 2 4; do

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "autoresearch:supervisor": "node src/cli.js print-autoresearch-supervisor",
     "autoresearch:speed": "node src/cli.js autoresearch-speed-eval",
     "parallel-account-research": "node src/cli.js parallel-account-research",
+    "parallel-research:stress": "node automation/parallel-research-stress.js",
     "autobrowse:mvp": "node automation/autobrowse-mvp.js",
     "test-hybrid-account-search": "node src/cli.js test-account-search --driver=hybrid",
     "test": "node --test",

--- a/tests/parallel-research-stress-harness.test.js
+++ b/tests/parallel-research-stress-harness.test.js
@@ -1,0 +1,115 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildParallelResearchStressPlan,
+  parseCliJsonPayload,
+  runParallelResearchStressHarness,
+  validateParallelResearchStressPayload,
+} = require('../automation/parallel-research-stress');
+
+test('parseCliJsonPayload extracts JSON after human cli log lines', () => {
+  const payload = parseCliJsonPayload('[cli] parallel-account-research: browserConcurrency=1\n{"mode":"dry-safe","accounts":[]}\n');
+  assert.deepEqual(payload, { mode: 'dry-safe', accounts: [] });
+});
+
+test('buildParallelResearchStressPlan uses deterministic dry-safe defaults', () => {
+  const plan = buildParallelResearchStressPlan({
+    accounts: ['Example AG', 'Example GmbH'],
+    localConcurrencyValues: [1, 2],
+    runIdPrefix: 'stress',
+  });
+
+  assert.deepEqual(plan.localConcurrencyValues, [1, 2]);
+  assert.equal(plan.accountsArg, 'Example AG, Example GmbH');
+  assert.deepEqual(plan.runs.map((r) => r.runId), ['stress-local-1', 'stress-local-2']);
+  assert.deepEqual(plan.runs[0].args, [
+    'src/cli.js',
+    'parallel-account-research',
+    '--accounts=Example AG, Example GmbH',
+    '--local-concurrency=1',
+    '--run-id=stress-local-1',
+  ]);
+});
+
+test('validateParallelResearchStressPayload enforces dry-safe browser invariants', () => {
+  const result = validateParallelResearchStressPayload({
+    requestedLocalConcurrency: 2,
+    payload: {
+      mode: 'dry-safe',
+      browserConcurrency: 1,
+      localConcurrency: 2,
+      accounts: [
+        {
+          accountName: 'Example AG',
+          metrics: { browserJobsExecuted: 0 },
+          browserResults: {
+            results: [{ status: 'skipped', reason: 'dry_safe_cli_plan_only' }],
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.accountCount, 1);
+  assert.equal(result.browserJobsExecuted, 0);
+});
+
+test('runParallelResearchStressHarness executes matrix and returns machine-readable summary', () => {
+  const commands = [];
+  const summary = runParallelResearchStressHarness({
+    accounts: ['Example AG'],
+    localConcurrencyValues: [1, 4],
+    runIdPrefix: 'stress',
+    runner: ({ args }) => {
+      commands.push(args);
+      const requested = Number(args.find((arg) => arg.startsWith('--local-concurrency=')).split('=')[1]);
+      return {
+        status: 0,
+        stdout: `[cli] dry-safe log\n${JSON.stringify({
+          mode: 'dry-safe',
+          browserConcurrency: 1,
+          localConcurrency: requested,
+          accounts: [{
+            accountName: 'Example AG',
+            metrics: { browserJobsExecuted: 0 },
+            browserResults: { results: [{ status: 'skipped', reason: 'dry_safe_cli_plan_only' }] },
+          }],
+        })}`,
+        stderr: '',
+      };
+    },
+  });
+
+  assert.equal(summary.ok, true);
+  assert.deepEqual(summary.localConcurrencyValues, [1, 4]);
+  assert.deepEqual(summary.runs.map((run) => run.ok), [true, true]);
+  assert.deepEqual(commands.map((args) => args.includes('--local-concurrency=4')), [false, true]);
+});
+
+test('runParallelResearchStressHarness rejects live flags before running anything', () => {
+  assert.throws(
+    () => runParallelResearchStressHarness({
+      accounts: ['Example AG'],
+      extraArgs: ['--live-save'],
+      runner: () => { throw new Error('runner should not be called'); },
+    }),
+    /refuses live or background mutation flags/
+  );
+});
+
+test('runParallelResearchStressHarness rejects invalid explicit stress inputs', () => {
+  assert.throws(
+    () => runParallelResearchStressHarness({ accounts: [] }),
+    /accounts must include at least one value/
+  );
+  assert.throws(
+    () => runParallelResearchStressHarness({ localConcurrencyValues: [0] }),
+    /local-concurrency-values must include at least one positive integer/
+  );
+  assert.throws(
+    () => runParallelResearchStressHarness({ localConcurrencyValues: 'abc' }),
+    /local-concurrency-values must contain positive integers/
+  );
+});

--- a/tests/release-readiness.test.js
+++ b/tests/release-readiness.test.js
@@ -41,6 +41,8 @@ test('package scripts keep autoresearch dry-safe and expose release checks', () 
   assert.doesNotMatch(packageJson.scripts['autoresearch:speed'], /--live-save|--live-connect|allow-background-connects/);
   assert.equal(packageJson.scripts['parallel-account-research'], 'node src/cli.js parallel-account-research');
   assert.doesNotMatch(packageJson.scripts['parallel-account-research'], /--live-save|--live-connect|allow-background-connects/);
+  assert.equal(packageJson.scripts['parallel-research:stress'], 'node automation/parallel-research-stress.js');
+  assert.doesNotMatch(packageJson.scripts['parallel-research:stress'], /--live-save|--live-connect|allow-background-connects/);
   assert.equal(packageJson.scripts['print-mvp-operator-dashboard'], 'node src/cli.js print-mvp-operator-dashboard');
 });
 


### PR DESCRIPTION
## Summary

- Adds an executable dry-safe Parallel Research stress harness: `automation/parallel-research-stress.js`.
- Exposes `npm run parallel-research:stress`.
- Runs a local-concurrency matrix against `parallel-account-research`, parses mixed CLI stdout, and emits a machine-readable summary.
- Validates key safety/performance invariants per run:
  - `mode === "dry-safe"`
  - `browserConcurrency === 1`
  - requested `localConcurrency` is preserved
  - `browserJobsExecuted === 0`
  - browser-required jobs remain skipped with `dry_safe_cli_plan_only`
- Refuses `--live-save`, `--live-connect`, and `--allow-background-connects` before running anything.
- Updates the stress-verification docs to prefer the executable harness.

## Stack position

- Base: `docs/agent-operating-context-pr25` / PR #28
- Depends on PR #28 docs/guardrails.
- This is the next stacked slice after the operating-context PR.

## Safety

- Dry-safe only.
- No Sales Navigator/LinkedIn browser execution added.
- No live mutation path changed.
- No runtime/session/secret artifacts committed.
- Browser concurrency invariant remains `1`.

## Verification

- TDD RED observed first: new test initially failed because `automation/parallel-research-stress` did not exist ✅
- `node --test tests/parallel-research-stress-harness.test.js tests/release-readiness.test.js` ✅ — 14/14 passing
- `npm run parallel-research:stress -- --accounts="Example AG, Example GmbH" --local-concurrency-values=1,2 --run-id-prefix=smoke` ✅
- `node automation/parallel-research-stress.js --live-save` refused before execution ✅
- `node automation/parallel-research-stress.js --local-concurrency-values=0` refused invalid explicit input ✅
- `npm run test:release-readiness` ✅ — 31/31 passing
- `npm test` ✅ — 342/342 passing
- `git diff --check` ✅
- forbidden-path scan ✅
- staged secret-value scan ✅
- independent spec/safety review: PASS ✅
- independent quality review requested chmod + invalid-input handling; both fixed and revalidated ✅

## Next PR

Recommended next slice: connect the stress harness to a repeat/flake mode or CI-style verification command so Hermes can run a stronger pre-merge stability gate for the full stack.
