### PR TITLE
test: add repeat mode to parallel research stress harness

### DIFF
--- a/automation/parallel-research-stress.js
+++ b/automation/parallel-research-stress.js
@@ -33,6 +33,16 @@ function parseIntegerList(value, fallback, optionName = 'value') {
   return parsed;
 }
 
+function parsePositiveInteger(value, fallback, optionName = 'value') {
+  if (value === undefined || value === null) return fallback;
+  const text = String(value).trim();
+  const parsed = Number.parseInt(text, 10);
+  if (String(parsed) !== text || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${optionName} must be a positive integer`);
+  }
+  return parsed;
+}
+
 function assertNoLiveFlags(args = []) {
   const hit = args.find((arg) => {
     const name = String(arg).split('=')[0];
@@ -56,6 +66,7 @@ function buildParallelResearchStressPlan({
   accounts = DEFAULT_ACCOUNTS,
   localConcurrencyValues = DEFAULT_LOCAL_CONCURRENCY_VALUES,
   runIdPrefix = 'stress',
+  repeat = 1,
   extraArgs = [],
 } = {}) {
   assertNoLiveFlags(extraArgs);
@@ -65,6 +76,7 @@ function buildParallelResearchStressPlan({
   const normalizedConcurrency = Array.isArray(localConcurrencyValues)
     ? localConcurrencyValues.map((value) => Number.parseInt(value, 10)).filter((value) => Number.isInteger(value) && value > 0)
     : parseIntegerList(localConcurrencyValues, DEFAULT_LOCAL_CONCURRENCY_VALUES, 'local-concurrency-values');
+  const normalizedRepeat = parsePositiveInteger(repeat, 1, 'repeat');
   if (normalizedAccounts.length === 0) {
     throw new Error('accounts must include at least one value');
   }
@@ -73,25 +85,32 @@ function buildParallelResearchStressPlan({
   }
   const accountsArg = normalizedAccounts.join(', ');
   const prefix = String(runIdPrefix || 'stress');
-  const runs = normalizedConcurrency.map((localConcurrency) => {
-    const runId = `${prefix}-local-${localConcurrency}`;
-    return {
-      runId,
-      localConcurrency,
-      args: [
-        'src/cli.js',
-        'parallel-account-research',
-        `--accounts=${accountsArg}`,
-        `--local-concurrency=${localConcurrency}`,
-        `--run-id=${runId}`,
-        ...extraArgs,
-      ],
-    };
-  });
+  const runs = [];
+  for (const localConcurrency of normalizedConcurrency) {
+    for (let repeatIndex = 1; repeatIndex <= normalizedRepeat; repeatIndex += 1) {
+      const runId = normalizedRepeat === 1
+        ? `${prefix}-local-${localConcurrency}`
+        : `${prefix}-local-${localConcurrency}-repeat-${repeatIndex}`;
+      runs.push({
+        runId,
+        localConcurrency,
+        repeatIndex,
+        args: [
+          'src/cli.js',
+          'parallel-account-research',
+          `--accounts=${accountsArg}`,
+          `--local-concurrency=${localConcurrency}`,
+          `--run-id=${runId}`,
+          ...extraArgs,
+        ],
+      });
+    }
+  }
   return {
     accounts: normalizedAccounts,
     accountsArg,
     localConcurrencyValues: normalizedConcurrency,
+    repeat: normalizedRepeat,
     runs,
   };
 }
@@ -143,6 +162,7 @@ function runParallelResearchStressHarness({
   accounts = DEFAULT_ACCOUNTS,
   localConcurrencyValues = DEFAULT_LOCAL_CONCURRENCY_VALUES,
   runIdPrefix = 'stress',
+  repeat = 1,
   extraArgs = [],
   runner = defaultRunner,
 } = {}) {
@@ -151,6 +171,7 @@ function runParallelResearchStressHarness({
     accounts,
     localConcurrencyValues,
     runIdPrefix,
+    repeat,
     extraArgs,
   });
   const runs = [];
@@ -163,6 +184,7 @@ function runParallelResearchStressHarness({
       runs.push({
         runId: run.runId,
         localConcurrency: run.localConcurrency,
+        repeatIndex: run.repeatIndex,
         ok: false,
         failures: [`exit_status:${status}`],
         stderr,
@@ -178,12 +200,14 @@ function runParallelResearchStressHarness({
       runs.push({
         runId: run.runId,
         localConcurrency: run.localConcurrency,
+        repeatIndex: run.repeatIndex,
         ...validation,
       });
     } catch (error) {
       runs.push({
         runId: run.runId,
         localConcurrency: run.localConcurrency,
+        repeatIndex: run.repeatIndex,
         ok: false,
         failures: [`parse_or_validation_error:${error.message}`],
       });
@@ -195,6 +219,8 @@ function runParallelResearchStressHarness({
     browserConcurrencyInvariant: 1,
     accounts: plan.accounts,
     localConcurrencyValues: plan.localConcurrencyValues,
+    repeat: plan.repeat,
+    runCount: runs.length,
     runs,
   };
 }
@@ -207,6 +233,7 @@ function parseHarnessArgs(argv) {
     if (arg.startsWith('--local-concurrency-values=')) {
       options.localConcurrencyValues = parseIntegerList(arg.slice('--local-concurrency-values='.length), DEFAULT_LOCAL_CONCURRENCY_VALUES, 'local-concurrency-values');
     }
+    if (arg.startsWith('--repeat=')) options.repeat = parsePositiveInteger(arg.slice('--repeat='.length), 1, 'repeat');
     if (arg.startsWith('--run-id-prefix=')) options.runIdPrefix = arg.slice('--run-id-prefix='.length);
   }
   return options;

--- a/docs/testing/parallel-research-stress-verification.md
+++ b/docs/testing/parallel-research-stress-verification.md
@@ -41,7 +41,7 @@ Expected invariants for the smoke output:
 Run the executable dry-safe stress harness:
 
 ```bash
-npm run parallel-research:stress
+npm run --silent parallel-research:stress
 ```
 
 For a custom matrix:
@@ -50,14 +50,19 @@ For a custom matrix:
 node automation/parallel-research-stress.js \
   --accounts="Example AG, Example GmbH, Example SE" \
   --local-concurrency-values=1,2,4 \
+  --repeat=3 \
   --run-id-prefix=stress
 ```
+
+Use `--repeat=N` for merge-readiness flake detection. The harness expands every local-concurrency value for every repeat index and emits stable run IDs such as `stress-local-2-repeat-3`. The default is `--repeat=1`, which preserves the shorter run IDs used for quick smoke checks.
 
 Expected summary invariants:
 
 - top-level `ok` is `true`
 - `mode` is `dry-safe`
 - `browserConcurrencyInvariant` is `1`
+- `repeat` matches the requested repeat count
+- `runCount` equals `localConcurrencyValues.length * repeat`
 - each run has `ok: true`
 - each run has `browserConcurrency: 1`
 - each run has `browserJobsExecuted: 0`
@@ -108,15 +113,17 @@ Validate each extracted JSON artifact:
 
 ## Flake/repeat loop
 
-For docs or small pipeline changes, run at least one repeat loop before merge readiness:
+For docs or small pipeline changes, run at least one harness repeat loop before merge readiness:
 
 ```bash
-for i in 1 2 3; do
-  node --test tests/research-pipeline.test.js tests/browser-worker-lock.test.js tests/parallel-research-benchmark.test.js || exit 1
-done
+npm run --silent parallel-research:stress -- \
+  --accounts="Example AG, Example GmbH" \
+  --local-concurrency-values=1,2 \
+  --repeat=3 \
+  --run-id-prefix=merge-readiness
 ```
 
-For changes touching scheduler, lock, cache, scoring, or CLI behavior, increase to 5-10 iterations or add a deterministic benchmark fixture.
+For changes touching scheduler, lock, cache, scoring, or CLI behavior, increase to 5-10 iterations or add a deterministic benchmark fixture. Keep this dry-safe: do not add live/background flags to the repeat loop.
 
 ## Forbidden-path scan
 

--- a/tests/parallel-research-stress-harness.test.js
+++ b/tests/parallel-research-stress-harness.test.js
@@ -21,6 +21,7 @@ test('buildParallelResearchStressPlan uses deterministic dry-safe defaults', () 
   });
 
   assert.deepEqual(plan.localConcurrencyValues, [1, 2]);
+  assert.equal(plan.repeat, 1);
   assert.equal(plan.accountsArg, 'Example AG, Example GmbH');
   assert.deepEqual(plan.runs.map((r) => r.runId), ['stress-local-1', 'stress-local-2']);
   assert.deepEqual(plan.runs[0].args, [
@@ -29,6 +30,33 @@ test('buildParallelResearchStressPlan uses deterministic dry-safe defaults', () 
     '--accounts=Example AG, Example GmbH',
     '--local-concurrency=1',
     '--run-id=stress-local-1',
+  ]);
+});
+
+test('buildParallelResearchStressPlan expands repeat runs with stable run ids', () => {
+  const plan = buildParallelResearchStressPlan({
+    accounts: ['Example AG'],
+    localConcurrencyValues: [1, 2],
+    runIdPrefix: 'flake',
+    repeat: 3,
+  });
+
+  assert.equal(plan.repeat, 3);
+  assert.deepEqual(plan.runs.map((r) => r.runId), [
+    'flake-local-1-repeat-1',
+    'flake-local-1-repeat-2',
+    'flake-local-1-repeat-3',
+    'flake-local-2-repeat-1',
+    'flake-local-2-repeat-2',
+    'flake-local-2-repeat-3',
+  ]);
+  assert.deepEqual(plan.runs.map((r) => r.repeatIndex), [1, 2, 3, 1, 2, 3]);
+  assert.deepEqual(plan.runs[0].args, [
+    'src/cli.js',
+    'parallel-account-research',
+    '--accounts=Example AG',
+    '--local-concurrency=1',
+    '--run-id=flake-local-1-repeat-1',
   ]);
 });
 
@@ -83,9 +111,50 @@ test('runParallelResearchStressHarness executes matrix and returns machine-reada
   });
 
   assert.equal(summary.ok, true);
+  assert.equal(summary.repeat, 1);
+  assert.equal(summary.runCount, 2);
   assert.deepEqual(summary.localConcurrencyValues, [1, 4]);
   assert.deepEqual(summary.runs.map((run) => run.ok), [true, true]);
   assert.deepEqual(commands.map((args) => args.includes('--local-concurrency=4')), [false, true]);
+});
+
+test('runParallelResearchStressHarness repeats every local concurrency value for flake detection', () => {
+  const seenRunIds = [];
+  const summary = runParallelResearchStressHarness({
+    accounts: ['Example AG'],
+    localConcurrencyValues: [1, 2],
+    runIdPrefix: 'flake',
+    repeat: 2,
+    runner: ({ args, run }) => {
+      seenRunIds.push(run.runId);
+      const requested = Number(args.find((arg) => arg.startsWith('--local-concurrency=')).split('=')[1]);
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          mode: 'dry-safe',
+          browserConcurrency: 1,
+          localConcurrency: requested,
+          accounts: [{
+            accountName: 'Example AG',
+            metrics: { browserJobsExecuted: 0 },
+            browserResults: { results: [{ status: 'skipped', reason: 'dry_safe_cli_plan_only' }] },
+          }],
+        }),
+        stderr: '',
+      };
+    },
+  });
+
+  assert.equal(summary.ok, true);
+  assert.equal(summary.repeat, 2);
+  assert.equal(summary.runCount, 4);
+  assert.deepEqual(seenRunIds, [
+    'flake-local-1-repeat-1',
+    'flake-local-1-repeat-2',
+    'flake-local-2-repeat-1',
+    'flake-local-2-repeat-2',
+  ]);
+  assert.deepEqual(summary.runs.map((run) => run.repeatIndex), [1, 2, 1, 2]);
 });
 
 test('runParallelResearchStressHarness rejects live flags before running anything', () => {
@@ -111,5 +180,13 @@ test('runParallelResearchStressHarness rejects invalid explicit stress inputs', 
   assert.throws(
     () => runParallelResearchStressHarness({ localConcurrencyValues: 'abc' }),
     /local-concurrency-values must contain positive integers/
+  );
+  assert.throws(
+    () => runParallelResearchStressHarness({ repeat: 0 }),
+    /repeat must be a positive integer/
+  );
+  assert.throws(
+    () => runParallelResearchStressHarness({ repeat: 'abc' }),
+    /repeat must be a positive integer/
   );
 });


### PR DESCRIPTION
## Summary
- Adds `--repeat=N` to the dry-safe parallel research stress harness for merge-readiness flake detection.
- Expands every requested local-concurrency value across stable repeat run IDs, while preserving existing short run IDs when `repeat=1`.
- Adds summary fields (`repeat`, `runCount`) and tests/docs for repeat behavior and invalid repeat input.

## Stack position
- Stacked on PR #29 (`feat/parallel-research-stress-harness`).
- Base: `feat/parallel-research-stress-harness`
- Head: `feat/parallel-research-stress-repeat`

## Safety
- Dry-safe only.
- Does not change browser-backed execution paths.
- Does not change live-save or live-connect paths.
- Still refuses `--live-save`, `--live-connect`, and `--allow-background-connects` before spawning child CLI runs.
- Repeat mode still validates `browserConcurrencyInvariant: 1` and per-run `browserJobsExecuted: 0`.

## Verification
- TDD RED observed before implementation: repeat-related tests failed against the previous harness.
- `node --test tests/parallel-research-stress-harness.test.js tests/release-readiness.test.js` ✅
- `npm run --silent parallel-research:stress -- --accounts="Example AG, Example GmbH" --local-concurrency-values=1,2 --repeat=2 --run-id-prefix=repeat-smoke` ✅
- `node automation/parallel-research-stress.js --repeat=0` fails with `repeat must be a positive integer` ✅
- `npm run test:release-readiness` ✅ — 31/31
- `npm test` ✅ — 344/344
- `git diff --check` ✅
- forbidden-path scan ✅
- staged/full diff secret-value scan ✅
- Independent spec/safety review ✅
- Independent quality review ✅

## Notes
- Use `npm run --silent parallel-research:stress -- --repeat=3` when a machine-readable JSON summary is needed from npm without npm's script banner.
- Nothing here enables live Sales Navigator / LinkedIn browser work or browser parallelism.
