### PR TITLE
Calibrate Data/AI buyer selection

### DIFF
--- a/src/core/account-coverage.js
+++ b/src/core/account-coverage.js
@@ -506,10 +506,10 @@ function classifyPersonaTier(candidate) {
 
   if (
     roleFamily === 'executive_engineering'
-    || /\b(cio|cto|cdo|chief information officer|chief technology officer|chief data officer)\b/.test(title)
+    || /\b(cio|cto|cdo|chief information officer|chief technology officer|chief data officer|chief data\s*&\s*analytics officer|chief analytics officer|chief ai officer|chief artificial intelligence officer)\b/.test(title)
     || (
       ['director', 'vp', 'head'].includes(seniority)
-      && /\b(data\s*&\s*ai|data and ai|directeur data|directrice data|director data|director de datos|direttore dati|direttrice dati|daten\s*&\s*ki|datos e ia|dati e ai|digital transformation|transformation digitale|digitale transformation|transformacion digital|transformación digital|trasformazione digitale|marketplace director|head of tech)\b/.test(title)
+      && /\b(data\s*&\s*ai|data and ai|data\s*&\s*analytics|data and analytics|artificial intelligence|head of ai|director of ai|vp ai|directeur data|directrice data|director data|director de datos|direttore dati|direttrice dati|daten\s*&\s*ki|datos e ia|dati e ai|digital transformation|transformation digitale|digitale transformation|transformacion digital|transformación digital|trasformazione digitale|marketplace director|head of tech)\b/.test(title)
     )
   ) {
     return 'buyer';
@@ -1097,7 +1097,7 @@ function normalizeSelectionText(value) {
 
 function hasExecutiveTechnologyTitle(candidate) {
   const text = normalizeSelectionText(`${candidate.title || ''} ${candidate.headline || ''}`);
-  return /\b(chief information officer|chief technology officer|cio|cto)\b/.test(text);
+  return /\b(chief information officer|chief technology officer|chief data officer|chief data\s*&\s*analytics officer|chief analytics officer|chief ai officer|chief artificial intelligence officer|cio|cto|cdo)\b/.test(text);
 }
 
 function hasMicroservicesObservabilityTitle(candidate) {

--- a/src/core/scoring.js
+++ b/src/core/scoring.js
@@ -53,6 +53,7 @@ function detectRoleFamily(candidate, icpConfig = {}) {
 
   if (matchesAnyText(title, multilingual.observabilityOperator)) return 'site_reliability';
   if (matchesAnyText(text, multilingual.executiveDataBuyer)) return 'executive_engineering';
+  if (/\b(chief (data|analytics|ai|artificial intelligence)(\s*&\s*|\s+and\s+)?(analytics|ai|artificial intelligence)? officer|chief data\s*&\s*analytics officer|head of (ai|artificial intelligence)|director of (ai|artificial intelligence)|vp (of )?(ai|artificial intelligence|data|analytics))\b/.test(text)) return 'executive_engineering';
   if (matchesAnyText(text, multilingual.platformOperator)) return 'platform_engineering';
   if (/\b(platform engineering|director of platform engineering|head of cloud|head of platform|cloud technology|platform operations|technology foundation operations)\b/.test(text)) return 'platform_engineering';
   if (/\b(chief information officer|chief technology officer|chief data officer|cio|cto|cdo|directeur technique|directrice technique|directeur des systemes d'information|directrice des systemes d'information|dsi|directeur informatique|directrice informatique|director tecnico|directora tecnica|director de tecnologia|directora de tecnologia|direttore tecnico|direttrice tecnica|direttore tecnologia|direttrice tecnologia)\b/.test(text)) return 'executive_engineering';
@@ -82,7 +83,7 @@ function detectSeniority(candidate, icpConfig = {}) {
   const text = normalizeText(candidate.title);
   const multilingual = getMultilingualPersonaSignals(icpConfig);
 
-  if (/\b(chief information officer|chief technology officer|chief data officer|cio|cto|cdo|directeur technique|directrice technique|directeur informatique|directrice informatique|dsi|director tecnico|directora tecnica|direttore tecnico|direttrice tecnica)\b/.test(text)) return 'vp';
+  if (/\b(chief information officer|chief technology officer|chief data officer|chief data\s*&\s*analytics officer|chief analytics officer|chief ai officer|chief artificial intelligence officer|cio|cto|cdo|directeur technique|directrice technique|directeur informatique|directrice informatique|dsi|director tecnico|directora tecnica|direttore tecnico|direttrice tecnica)\b/.test(text)) return 'vp';
   if (/vice president|\bvp\b/.test(text)) return 'vp';
   if (matchesAnyText(text, multilingual.seniorityDirector)) return 'director';
   if (/director|directeur|directrice|direktor|direktorin|direttore|direttrice|directora/.test(text)) return 'director';

--- a/tests/account-coverage.test.js
+++ b/tests/account-coverage.test.js
@@ -464,12 +464,30 @@ test('selectCoverageListCandidates force-includes CIO CTO and microservices buil
         seniority: 'senior',
         score: 10,
       },
+      {
+        fullName: 'Chief Data Analytics',
+        title: 'Chief Data & Analytics Officer',
+        coverageBucket: 'technical_adjacent',
+        roleFamily: 'executive_engineering',
+        seniority: 'vp',
+        score: 4,
+      },
+      {
+        fullName: 'Out Of Network Chief Data',
+        title: 'Chief Data Officer',
+        coverageBucket: 'technical_adjacent',
+        roleFamily: 'executive_engineering',
+        seniority: 'vp',
+        score: 80,
+        outOfNetwork: true,
+      },
     ],
   }, { minScore: 50 });
 
-  assert.deepEqual(selected.map((candidate) => candidate.fullName), ['Microservices Lead', 'Company CIO']);
+  assert.deepEqual(selected.map((candidate) => candidate.fullName), ['Microservices Lead', 'Chief Data Analytics', 'Company CIO']);
   assert.deepEqual(selected.map((candidate) => candidate.listSelectionReason), [
     'microservices_observability_path',
+    'executive_cto_cio_always_include',
     'executive_cto_cio_always_include',
   ]);
 });
@@ -502,6 +520,14 @@ test('selectCoverageListCandidates narrows technical adjacent to ICP-positive su
         score: 18,
       },
       {
+        fullName: 'Head AI',
+        title: 'Head of Artificial Intelligence',
+        coverageBucket: 'technical_adjacent',
+        roleFamily: 'executive_engineering',
+        seniority: 'head',
+        score: 14,
+      },
+      {
         fullName: 'BI Analyst',
         title: 'Senior BI Analyst',
         coverageBucket: 'technical_adjacent',
@@ -522,10 +548,12 @@ test('selectCoverageListCandidates narrows technical adjacent to ICP-positive su
 
   assert.deepEqual(selected.map((candidate) => candidate.fullName), [
     'VP Cloud',
+    'Head AI',
     'Head Cloud AI',
     'Principal Data AI',
   ]);
   assert.deepEqual(selected.map((candidate) => candidate.listSelectionReason), [
+    'technical_adjacent_executive_engineering',
     'technical_adjacent_executive_engineering',
     'technical_adjacent_core_technical_scope',
     'technical_adjacent_core_technical_scope',

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -145,6 +145,31 @@ test('scoreCandidate recognizes CIO and CTO titles as executive engineering', ()
   assert.notEqual(ciso.roleFamily, 'executive_engineering');
 });
 
+test('scoreCandidate recognizes data analytics and AI executives as buyer-tier engineering', () => {
+  const chiefDataAnalytics = scoreCandidate({
+    title: 'Chief Data & Analytics Officer',
+    headline: 'Owns enterprise data, analytics platforms and AI strategy',
+  }, icpConfig);
+  const headOfArtificialIntelligence = scoreCandidate({
+    title: 'Head of Artificial Intelligence',
+    headline: 'Leads AI platforms and production model operations',
+  }, icpConfig);
+  const directorDataAiFactory = scoreCandidate({
+    title: 'Director of Data & AI Factory',
+    headline: 'Owns data products, AI delivery and platform teams',
+  }, icpConfig);
+
+  assert.equal(chiefDataAnalytics.roleFamily, 'executive_engineering');
+  assert.equal(chiefDataAnalytics.seniority, 'vp');
+  assert.ok(chiefDataAnalytics.score >= icpConfig.saveToListThreshold);
+  assert.equal(headOfArtificialIntelligence.roleFamily, 'executive_engineering');
+  assert.equal(headOfArtificialIntelligence.seniority, 'head');
+  assert.ok(headOfArtificialIntelligence.score >= icpConfig.saveToListThreshold);
+  assert.equal(directorDataAiFactory.roleFamily, 'executive_engineering');
+  assert.equal(directorDataAiFactory.seniority, 'director');
+  assert.ok(directorDataAiFactory.score >= icpConfig.saveToListThreshold);
+});
+
 test('scoreCandidate recognizes microservices builders as platform engineering', () => {
   const developer = scoreCandidate({
     title: 'Senior Microservices Developer',


### PR DESCRIPTION
## Summary
- Recognize Chief Data & Analytics, Chief Analytics/AI, Head of AI, and Director/VP AI/Data titles as executive engineering buyer personas.
- Force-include reachable data/AI executive titles in coverage list selection while keeping out-of-network profiles excluded from live-save targets.
- Add regression tests for Cartier-style Data/AI buyer misses and AI leadership selection.

## Validation
- npm test -- tests/scoring.test.js tests/account-coverage.test.js
- npm test
- Re-ran Cartier batch dry-safe: 22 candidates -> 3 list candidates
- Re-ran Cartier live-save to existing list: 3 saved, 0 failed