### PR TITLE
fix: align exhaustive parallel research planning

### DIFF
--- a/src/core/account-coverage.js
+++ b/src/core/account-coverage.js
@@ -141,6 +141,31 @@ function normalizeResearchMode(value = 'persona-led') {
   return RESEARCH_MODES.has(mode) ? mode : 'persona-led';
 }
 
+/**
+ * Normalize research mode, sweep speed profile, and adaptive pruning for buildSweepTemplates.
+ * Mirrors runAccountCoverageWorkflow: exhaustive research mode forces an exhaustive sweep template
+ * set and disables fast-path adaptive pruning expansion regardless of nominal speedProfile.
+ */
+function resolveSweepTemplateOptions({
+  researchMode,
+  speedProfile,
+  adaptiveSweepPruning,
+} = {}) {
+  const normalizedResearchMode = normalizeResearchMode(researchMode);
+  const normalizedSpeedProfile = normalizeSpeedProfile(speedProfile);
+  const effectiveSpeedProfile = normalizedResearchMode === 'exhaustive'
+    ? 'exhaustive'
+    : normalizedSpeedProfile;
+  const adaptiveRequested = Boolean(adaptiveSweepPruning);
+  const adaptiveSweepPruningForTemplates = adaptiveRequested && effectiveSpeedProfile === 'fast';
+
+  return {
+    researchMode: normalizedResearchMode,
+    speedProfile: effectiveSpeedProfile,
+    adaptiveSweepPruning: adaptiveSweepPruningForTemplates,
+  };
+}
+
 function inferPersonaLayerForSweep(sweep = {}) {
   const text = [
     sweep.id,
@@ -792,18 +817,17 @@ async function runAccountCoverageWorkflow({
   logger = null,
   now = Date.now,
 }) {
-  const normalizedSpeedProfile = normalizeSpeedProfile(speedProfile);
-  const normalizedResearchMode = normalizeResearchMode(researchMode);
-  const effectiveSpeedProfile = normalizedResearchMode === 'exhaustive' ? 'exhaustive' : normalizedSpeedProfile;
   const timings = createRunTimings(now);
   const adaptivePruningRequested = Boolean(adaptiveSweepPruning);
+  const sweepTemplateOptions = resolveSweepTemplateOptions({
+    researchMode,
+    speedProfile,
+    adaptiveSweepPruning,
+  });
+  const { researchMode: normalizedResearchMode, speedProfile: effectiveSpeedProfile } = sweepTemplateOptions;
   const adaptivePruningActive = adaptivePruningRequested && effectiveSpeedProfile !== 'exhaustive';
   const pruningThresholds = adaptivePruningActive ? getAdaptivePruningThresholds(effectiveSpeedProfile) : null;
-  const templates = buildSweepTemplates(coverageConfig, maxCandidates, {
-    speedProfile: effectiveSpeedProfile,
-    researchMode: normalizedResearchMode,
-    adaptiveSweepPruning: adaptivePruningRequested && effectiveSpeedProfile === 'fast',
-  });
+  const templates = buildSweepTemplates(coverageConfig, maxCandidates, sweepTemplateOptions);
   const aliasConfig = loadAccountAliasConfig();
   const aliasEntry = findAccountAliasEntry(aliasConfig, accountName);
   const priorCoverage = loadExistingAccountCoverageArtifact(accountName);
@@ -1387,6 +1411,7 @@ module.exports = {
   normalizeCandidateKey,
   normalizeResearchMode,
   normalizeSpeedProfile,
+  resolveSweepTemplateOptions,
   runAccountCoverageWorkflow,
   selectCoverageListCandidates,
   selectDeepReviewCandidates,

--- a/src/core/research-pipeline.js
+++ b/src/core/research-pipeline.js
@@ -1,6 +1,7 @@
 const {
   buildSweepTemplates,
   normalizeCandidateKey,
+  resolveSweepTemplateOptions,
   selectCoverageListCandidates,
   classifyCoverageBucket,
   classifySweepErrorCategory,
@@ -67,7 +68,12 @@ function planResearchJobs({
   const accounts = [...(queue?.accounts || [])];
   accounts.sort((a, b) => a.accountKey.localeCompare(b.accountKey));
 
-  const templates = buildSweepTemplates(coverageConfig, maxCandidates, options);
+  const sweepTemplateOptions = resolveSweepTemplateOptions({
+    researchMode: options.researchMode,
+    speedProfile: options.speedProfile,
+    adaptiveSweepPruning: options.adaptiveSweepPruning,
+  });
+  const templates = buildSweepTemplates(coverageConfig, maxCandidates, sweepTemplateOptions);
 
   /** @type {Array<Record<string, unknown>>} */
   const jobs = [];

--- a/tests/account-coverage.test.js
+++ b/tests/account-coverage.test.js
@@ -17,6 +17,7 @@ const {
   normalizeCandidateKey,
   normalizeResearchMode,
   normalizeSpeedProfile,
+  resolveSweepTemplateOptions,
   runAccountCoverageWorkflow,
   selectCoverageListCandidates,
   writeAccountCoverageArtifact,
@@ -99,7 +100,24 @@ test('buildSweepTemplates persona-led mode orders keyword packs by persona layer
   assert.equal(normalizeResearchMode('unknown'), 'persona-led');
 });
 
+test('resolveSweepTemplateOptions forces exhaustive sweep set when researchMode is exhaustive', () => {
+  const resolved = resolveSweepTemplateOptions({
+    researchMode: 'exhaustive',
+    speedProfile: 'fast',
+    adaptiveSweepPruning: true,
+  });
+  assert.equal(resolved.researchMode, 'exhaustive');
+  assert.equal(resolved.speedProfile, 'exhaustive');
+  assert.equal(resolved.adaptiveSweepPruning, false);
+});
+
 test('buildSweepTemplates exhaustive research mode keeps all persona keyword packs', () => {
+  const sweepOpts = resolveSweepTemplateOptions({
+    researchMode: 'exhaustive',
+    speedProfile: 'fast',
+    adaptiveSweepPruning: true,
+  });
+  assert.equal(sweepOpts.adaptiveSweepPruning, false);
   const templates = buildSweepTemplates({
     broadCrawl: { enabled: true },
     sweeps: [
@@ -107,11 +125,7 @@ test('buildSweepTemplates exhaustive research mode keeps all persona keyword pac
       { id: 'security', keywords: ['security'] },
       { id: 'data', keywords: ['data analytics'] },
     ],
-  }, null, {
-    researchMode: 'exhaustive',
-    speedProfile: 'fast',
-    adaptiveSweepPruning: true,
-  });
+  }, null, sweepOpts);
 
   assert.deepEqual(templates.map((template) => template.id), [
     'broad-crawl',
@@ -1383,7 +1397,51 @@ test('adaptive pruning (exhaustive): runs every sweep and does not prune', async
   assert.deepEqual(run.result.adaptivePruning.skippedTemplates || [], []);
 });
 
-test('adaptive pruning: skipped sweeps are not sweepErrors and do not force company-resolution summary', async () => {
+test('researchMode exhaustive overrides fast speedProfile for sweep planning and disables adaptive pruning', async () => {
+  const coverageConfig = {
+    version: 'exhaustive-plus-fast-mode',
+    broadCrawl: { enabled: true, maxCandidates: 3 },
+    sweeps: [
+      { id: 'platform', keywords: ['platform'], maxCandidates: 3 },
+      { id: 'data-rest', keywords: ['analytics_only_rest'], maxCandidates: 3 },
+    ],
+  };
+  const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
+  const applyCalls = [];
+
+  const driver = {
+    async openAccountSearch() {},
+    async enumerateAccounts(accounts) {
+      return accounts;
+    },
+    async openPeopleSearch() {},
+    async applySearchTemplate(template) {
+      applyCalls.push(template.id);
+    },
+    async scrollAndCollectCandidates() {
+      return [];
+    },
+  };
+
+  const run = await runAccountCoverageWorkflow({
+    driver,
+    accountName: 'Exhaustive Mode Fast Profile Account',
+    coverageConfig,
+    icpConfig,
+    priorityModel: null,
+    maxCandidates: 3,
+    researchMode: 'exhaustive',
+    speedProfile: 'fast',
+    adaptiveSweepPruning: true,
+  });
+
+  assert.deepEqual(applyCalls, ['broad-crawl', 'sweep-platform', 'sweep-data-rest']);
+  assert.equal(run.speedProfile, 'exhaustive');
+  assert.equal(run.researchMode, 'exhaustive');
+  assert.equal(run.result.adaptivePruning.enabled, false);
+});
+
+test('adaptive pruning clean run does not turn skipped sweeps into resolution blockers', async () => {
   const coverageConfig = {
     version: 'adaptive-prune-clean',
     broadCrawl: { enabled: true, maxCandidates: 3 },

--- a/tests/research-pipeline.test.js
+++ b/tests/research-pipeline.test.js
@@ -10,6 +10,7 @@ const {
   planResearchJobs,
   scoreResearchCandidates,
 } = require('../src/core/research-pipeline');
+const { buildSweepTemplates, resolveSweepTemplateOptions } = require('../src/core/account-coverage');
 const { createBrowserWorkerLock } = require('../src/core/browser-worker-lock');
 
 test('buildResearchQueue creates deterministic account jobs with dry-safe defaults', () => {
@@ -153,6 +154,44 @@ test('planResearchJobs passes maxCandidates and options into buildSweepTemplates
   assert.equal(sweeps.length, 2);
   assert.equal(sweeps[0].maxCandidates, 5);
   assert.equal(sweeps[1].maxCandidates, 5);
+});
+
+test('planResearchJobs matches exhaustive account-coverage sweep parity when speedProfile is fast', () => {
+  const coverageConfig = {
+    broadCrawl: { enabled: true },
+    sweeps: [
+      { id: 'platform', keywords: ['platform engineering'] },
+      { id: 'security', keywords: ['security'] },
+      { id: 'data', keywords: ['data analytics'] },
+    ],
+  };
+  const queue = buildResearchQueue({
+    accounts: [{ accountId: 'a1', accountName: 'Example AG' }],
+    runId: 'r',
+  });
+
+  const baseline = planResearchJobs({
+    queue,
+    coverageConfig,
+    options: { researchMode: 'exhaustive', speedProfile: 'exhaustive' },
+  });
+  const plan = planResearchJobs({
+    queue,
+    coverageConfig,
+    options: { researchMode: 'exhaustive', speedProfile: 'fast' },
+  });
+
+  const sweepTemplateIds = (p) => (
+    p.jobs.filter((job) => job.type === 'sweep').map((job) => job.templateId)
+  );
+  assert.deepEqual(sweepTemplateIds(plan), sweepTemplateIds(baseline));
+
+  const expected = buildSweepTemplates(
+    coverageConfig,
+    null,
+    resolveSweepTemplateOptions({ researchMode: 'exhaustive', speedProfile: 'fast' }),
+  ).map((template) => template.id);
+  assert.deepEqual([...sweepTemplateIds(plan)].sort(), [...expected].sort());
 });
 
 test('attachSweepCacheState calls readCache for sweep jobs only', async () => {


### PR DESCRIPTION
## Summary
- Add shared sweep-template option normalization for Account Coverage and Parallel Research planning.
- Ensure `researchMode=exhaustive` forces the exhaustive speed profile even when `speedProfile=fast` is provided.
- Keep adaptive sweep pruning disabled for exhaustive mode and add regression coverage for planner parity.

## Why
Cursor/Hermes review of the latest persona-led/data-AI research changes found a dry-safe evaluation parity gap: `runAccountCoverageWorkflow` already treated exhaustive mode as exhaustive, but `parallel-account-research`/`planResearchJobs` could still plan the fast template set. That could make offline Account Research experiments undercount sweeps while labeling the run exhaustive.

## Verification
- `node --test tests/account-coverage.test.js tests/research-pipeline.test.js`
- `npm run test:release-readiness`
- `npm run --silent parallel-research:stress -- --accounts="Example AG, Example GmbH" --local-concurrency-values=1,2 --repeat=2 --run-id-prefix=exhaustive-parity`
- `npm test`
- `git diff --check`
- forbidden-path scan against `origin/main...HEAD`
- secret-like diff scan

## Safety
- Dry-safe planning/scoring only.
- No live-save or live-connect behavior changed.
- No runtime/session/env files touched.
