### PR TITLE
Harden lead-list connect fallback

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1285,9 +1285,9 @@ function recordConnectEventIfKnown(repository, rowOrCandidate, approvalId, actio
 async function readLeadListSnapshot(driver, listName) {
   try {
     if (typeof driver.runHarnessJson === 'function') {
-      return readLeadListSnapshotViaHarness(driver, listName);
+      return await readLeadListSnapshotViaHarness(driver, listName);
     }
-    return readLeadListSnapshotViaPlaywright(driver, listName);
+    return await readLeadListSnapshotViaPlaywright(driver, listName);
   } catch (error) {
     const artifactSnapshot = readLatestLeadListArtifactSnapshot(listName);
     if (artifactSnapshot) {

--- a/src/drivers/playwright-sales-nav.js
+++ b/src/drivers/playwright-sales-nav.js
@@ -163,6 +163,7 @@ const DEFAULT_SELECTORS = {
     'a:has-text("Connect")',
   ],
   connectSendButtons: [
+    'button:has-text("Send Invitation")',
     'button:has-text("Send invitation")',
     'button:has-text("Send without a note")',
     'button:has-text("Send")',
@@ -684,8 +685,16 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     await connectButton.click().catch(() => {});
     await this.page.waitForTimeout(this.options.settleMs);
 
-    const sendButton = await findFirstVisible(this.page, DEFAULT_SELECTORS.connectSendButtons)
+    let sendButton = await findFirstVisible(this.page, DEFAULT_SELECTORS.connectSendButtons)
       || await findVisibleActionControl(this.page, SEND_INVITATION_PATTERNS);
+    if (!sendButton) {
+      const deadline = Date.now() + Math.max(2500, this.options.settleMs * 6);
+      while (!sendButton && Date.now() < deadline) {
+        await this.page.waitForTimeout(250).catch(() => {});
+        sendButton = await findFirstVisible(this.page, DEFAULT_SELECTORS.connectSendButtons)
+          || await findVisibleActionControl(this.page, SEND_INVITATION_PATTERNS);
+      }
+    }
     if (!sendButton) {
       const postClickUiState = await readConnectState(this.page);
       if (postClickUiState.hasInvitationSent || postClickUiState.hasPendingConnectControl) {


### PR DESCRIPTION
## Summary
- Await async lead-list snapshot readers so artifact fallback actually catches Sales Nav list lookup failures.
- Recognize the title-cased Sales Nav "Send Invitation" button and wait for the send dialog before classifying post-click connect outcomes.

## Validation
- npm test -- tests/playwright-driver.test.js tests/lead-list-snapshot.test.js

## Live verification
- Used the guarded flow on "Grafana Calibration Leads - BurdaForward Riverty Sky - 2026-05-03".
- Confirmed 14 new sends, 1 already pending, 1 email_required, 16 skipped by daily guardrail.
