### PR TITLE
Add connect pacing operator notice

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -98,7 +98,11 @@ const {
 const { createDriver } = require('./drivers');
 const { createDashboardServer } = require('./server/dashboard');
 const { sendApprovedConnects } = require('./core/connect-executor');
-const { computeBudgetState, resolveConnectBudgetPolicy } = require('./core/budget');
+const {
+  buildConnectBudgetOperatorNotice,
+  computeBudgetState,
+  resolveConnectBudgetPolicy,
+} = require('./core/budget');
 const { reconcileState } = require('./core/reconciler');
 const { maybeFallbackToLeadPageConnect } = require('./core/connect-fallback');
 const { isConnectMenuActionLabel } = require('./core/connect-menu');
@@ -1097,6 +1101,13 @@ async function handleConnectLeadList(repository, values, logger) {
       dailyMax: budgetPolicy.dailyMax,
       dailyMin: budgetPolicy.dailyMin,
     });
+    const pendingAvailableCount = snapshot.rows
+      .filter((row) => !row.invitationSent && !row.connectionSent)
+      .length;
+    logConnectBudgetOperatorNotice(logger, budget, {
+      label: 'connect-lead-list',
+      requestedCount: Math.min(limit, pendingAvailableCount),
+    });
 
     if (budget.remainingToday <= 0 || budget.remainingThisWeek <= 0) {
       logger.info(`Driver: ${driverName}`);
@@ -1260,6 +1271,12 @@ function buildConnectBudgetPolicy(values) {
     dailyMax: getString(values, 'daily-max'),
     dailyMin: getString(values, 'daily-min'),
   });
+}
+
+function logConnectBudgetOperatorNotice(logger, budget, options = {}) {
+  const notice = buildConnectBudgetOperatorNotice(budget, options);
+  notice.lines.forEach((line) => logger.info(line));
+  return notice;
 }
 
 function resolveKnownCandidateId(repository, rowOrCandidate) {
@@ -2400,6 +2417,20 @@ async function handleSendApproved(repository, values, logger) {
     throw new Error('No run available for connect execution.');
   }
   const budgetPolicy = buildConnectBudgetPolicy(values);
+  const rawBudget = repository.getBudgetState(budgetPolicy.effectiveWeeklyCap);
+  const budget = computeBudgetState({
+    weeklyCap: rawBudget.weeklyCap,
+    sentThisWeek: rawBudget.weekCount,
+    sentToday: rawBudget.dayCount,
+    budgetMode: budgetPolicy.budgetMode,
+    toolSharePercent: budgetPolicy.toolSharePercent,
+    dailyMax: budgetPolicy.dailyMax,
+    dailyMin: budgetPolicy.dailyMin,
+  });
+  logConnectBudgetOperatorNotice(logger, budget, {
+    label: 'send-approved-connects',
+    requestedCount: Number(getString(values, 'limit') || 25),
+  });
 
   const driver = createDriver(run.driver, buildDriverOptions(values, run, {
     sessionMode: 'persistent',
@@ -3255,6 +3286,11 @@ async function handleRunAccountBatch(repository, values, logger) {
     dailyMax: budgetPolicy.dailyMax,
     dailyMin: budgetPolicy.dailyMin,
   });
+  if (liveConnect) {
+    logConnectBudgetOperatorNotice(logger, budget, {
+      label: 'run-account-batch live-connect',
+    });
+  }
 
   const batchSessionMode = getString(values, 'session-mode')
     || ((driverName === 'playwright' && (liveSave || liveConnect)) ? 'storage-state' : 'persistent');
@@ -3611,6 +3647,10 @@ async function handlePilotConnectBatch(repository, values, logger) {
       toolSharePercent: budgetPolicy.toolSharePercent,
       dailyMax: budgetPolicy.dailyMax,
       dailyMin: budgetPolicy.dailyMin,
+    });
+    logConnectBudgetOperatorNotice(logger, budget, {
+      label: 'pilot-connect-batch',
+      requestedCount: accountNames.length * maxConnectsPerAccount,
     });
 
     const results = [];

--- a/src/core/budget.js
+++ b/src/core/budget.js
@@ -98,7 +98,54 @@ function computeBudgetState({
   };
 }
 
+function buildConnectBudgetOperatorNotice(budget, {
+  requestedCount = null,
+  label = 'connect run',
+} = {}) {
+  const requested = Number.isFinite(Number(requestedCount)) ? Number(requestedCount) : null;
+  const lines = [
+    `Connect pacing notice (${label}): LinkedIn invitations use a daily and weekly budget.`,
+    `Current budget: ${budget.budgetMode} mode, daily target ${budget.recommendedTodayLimit}, remaining today ${budget.remainingToday}, remaining this week ${budget.remainingThisWeek}/${budget.weeklyCap}.`,
+  ];
+
+  if (budget.remainingToday <= 0 || budget.remainingThisWeek <= 0) {
+    lines.push('Today\'s connect pacing is exhausted. Wait for the next business day or explicitly change --daily-max/--budget-mode.');
+    return {
+      label,
+      requestedCount: requested,
+      cappedByDailyPacing: true,
+      exhausted: true,
+      lines,
+    };
+  }
+
+  if (requested !== null && requested > budget.remainingToday) {
+    lines.push(`Requested/pending connects: ${requested}. This run will cap at ${budget.remainingToday} unless you explicitly raise --daily-max/--budget-mode.`);
+    lines.push('You can send more today, but that spends the same weekly allowance faster and leaves fewer connects for later this week.');
+    return {
+      label,
+      requestedCount: requested,
+      cappedByDailyPacing: true,
+      exhausted: false,
+      lines,
+    };
+  }
+
+  if (requested !== null) {
+    lines.push(`Requested/pending connects: ${requested}. This is within today's pacing.`);
+  }
+
+  return {
+    label,
+    requestedCount: requested,
+    cappedByDailyPacing: false,
+    exhausted: false,
+    lines,
+  };
+}
+
 module.exports = {
+  buildConnectBudgetOperatorNotice,
   DEFAULT_CONNECT_BUDGET_MODES,
   computeBudgetState,
   resolveConnectBudgetPolicy,

--- a/tests/budget.test.js
+++ b/tests/budget.test.js
@@ -1,7 +1,11 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { computeBudgetState, resolveConnectBudgetPolicy } = require('../src/core/budget');
+const {
+  buildConnectBudgetOperatorNotice,
+  computeBudgetState,
+  resolveConnectBudgetPolicy,
+} = require('../src/core/budget');
 
 test('computeBudgetState distributes remaining budget across business days', () => {
   const budget = computeBudgetState({
@@ -40,4 +44,55 @@ test('computeBudgetState respects daily max pacing', () => {
 
   assert.equal(budget.recommendedTodayLimit, 20);
   assert.equal(budget.remainingToday, 16);
+});
+
+test('buildConnectBudgetOperatorNotice explains normal pacing', () => {
+  const notice = buildConnectBudgetOperatorNotice({
+    budgetMode: 'assist',
+    weeklyCap: 70,
+    remainingThisWeek: 60,
+    recommendedTodayLimit: 15,
+    remainingToday: 12,
+  }, {
+    requestedCount: 8,
+    label: 'lead list connect',
+  });
+
+  assert.equal(notice.cappedByDailyPacing, false);
+  assert.equal(notice.exhausted, false);
+  assert.match(notice.lines.join('\n'), /Connect pacing notice \(lead list connect\)/);
+  assert.match(notice.lines.join('\n'), /within today's pacing/);
+});
+
+test('buildConnectBudgetOperatorNotice warns when a request exceeds daily pacing', () => {
+  const notice = buildConnectBudgetOperatorNotice({
+    budgetMode: 'assist',
+    weeklyCap: 70,
+    remainingThisWeek: 40,
+    recommendedTodayLimit: 15,
+    remainingToday: 5,
+  }, {
+    requestedCount: 20,
+  });
+
+  assert.equal(notice.cappedByDailyPacing, true);
+  assert.equal(notice.exhausted, false);
+  assert.match(notice.lines.join('\n'), /will cap at 5/);
+  assert.match(notice.lines.join('\n'), /leaves fewer connects for later this week/);
+});
+
+test('buildConnectBudgetOperatorNotice marks exhausted budgets', () => {
+  const notice = buildConnectBudgetOperatorNotice({
+    budgetMode: 'assist',
+    weeklyCap: 70,
+    remainingThisWeek: 35,
+    recommendedTodayLimit: 15,
+    remainingToday: 0,
+  }, {
+    requestedCount: 3,
+  });
+
+  assert.equal(notice.cappedByDailyPacing, true);
+  assert.equal(notice.exhausted, true);
+  assert.match(notice.lines.join('\n'), /pacing is exhausted/);
 });


### PR DESCRIPTION
## Summary
- add a reusable connect pacing operator notice to the budget module
- show the notice before live connect sends in lead-list, approved-connect, account-batch, and pilot-connect flows
- cover normal, capped, and exhausted budget messaging with tests

## Tests
- npm test -- tests/budget.test.js
- npm test -- tests/budget.test.js tests/playwright-driver.test.js tests/connect-fallback.test.js tests/lead-list-snapshot.test.js
