### PR TITLE
Harden list-save verification

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -701,6 +701,7 @@ async function handleFastListImport(values, logger) {
         maxRetries,
         runId,
         existingLeadUrls: existingSnapshot?.rows?.map((row) => row.salesNavigatorUrl) || [],
+        readLeadListSnapshot: (targetListName) => readLeadListSnapshotStrict(driver, targetListName || importPlan.listName),
         onProgress(row) {
           logger.info(`${row.status} | ${row.accountName || 'Unknown account'} | ${row.fullName || 'Unknown lead'}${row.attempt ? ` | attempt=${row.attempt}` : ''}`);
         },
@@ -788,6 +789,7 @@ async function handleRetryFailedFastListImport(values, logger) {
         maxRetries,
         runId,
         existingLeadUrls: existingSnapshot?.rows?.map((row) => row.salesNavigatorUrl) || [],
+        readLeadListSnapshot: (targetListName) => readLeadListSnapshotStrict(driver, targetListName || importPlan.listName),
         onProgress(row) {
           logger.info(`${row.status} | ${row.accountName || 'Unknown account'} | ${row.fullName || 'Unknown lead'}${row.attempt ? ` | attempt=${row.attempt}` : ''}`);
         },
@@ -882,6 +884,7 @@ async function handleImportCoverage(values, logger) {
         maxRetries,
         runId,
         existingLeadUrls: existingSnapshot?.rows?.map((row) => row.salesNavigatorUrl) || [],
+        readLeadListSnapshot: (targetListName) => readLeadListSnapshotStrict(driver, targetListName || importPlan.listName),
         onProgress(row) {
           logger.info(`${row.status} | ${row.accountName || 'Unknown account'} | ${row.fullName || 'Unknown lead'}${row.attempt ? ` | attempt=${row.attempt}` : ''}`);
         },
@@ -1301,10 +1304,7 @@ function recordConnectEventIfKnown(repository, rowOrCandidate, approvalId, actio
 
 async function readLeadListSnapshot(driver, listName) {
   try {
-    if (typeof driver.runHarnessJson === 'function') {
-      return await readLeadListSnapshotViaHarness(driver, listName);
-    }
-    return await readLeadListSnapshotViaPlaywright(driver, listName);
+    return await readLeadListSnapshotStrict(driver, listName);
   } catch (error) {
     const artifactSnapshot = readLatestLeadListArtifactSnapshot(listName);
     if (artifactSnapshot) {
@@ -1312,6 +1312,13 @@ async function readLeadListSnapshot(driver, listName) {
     }
     throw error;
   }
+}
+
+async function readLeadListSnapshotStrict(driver, listName) {
+  if (typeof driver.runHarnessJson === 'function') {
+    return await readLeadListSnapshotViaHarness(driver, listName);
+  }
+  return await readLeadListSnapshotViaPlaywright(driver, listName);
 }
 
 function readLeadListSnapshotViaHarness(driver, listName) {

--- a/src/core/fast-list-import.js
+++ b/src/core/fast-list-import.js
@@ -32,6 +32,11 @@ const {
   timePhase,
 } = require('./speed-telemetry');
 const { isSalesNavigatorLeadUrl } = require('../lib/live-readiness');
+const {
+  buildSalesNavigatorLeadIdentity,
+  findSalesNavigatorLeadIdentityMatch,
+  normalizeSalesNavigatorLeadUrl,
+} = require('./sales-nav-identity');
 
 const FAST_IMPORT_ARTIFACTS_DIR = path.join(ARTIFACTS_DIR, 'fast-import');
 const LEARNED_LEAD_RESOLUTION_SUGGESTIONS_PATH = path.join(FAST_IMPORT_ARTIFACTS_DIR, 'learned-lead-resolution-suggestions.json');
@@ -1392,18 +1397,7 @@ function isMissingListCreationDisabledError(note) {
 }
 
 function normalizeLeadUrl(url) {
-  const raw = String(url || '').trim();
-  if (!raw) {
-    return '';
-  }
-  try {
-    const parsed = new URL(raw);
-    parsed.search = '';
-    parsed.hash = '';
-    return parsed.toString().replace(/\/$/, '');
-  } catch {
-    return raw.replace(/[?#].*$/, '').replace(/\/$/, '');
-  }
+  return normalizeSalesNavigatorLeadUrl(url);
 }
 
 function buildExistingLeadUrlSet(existingLeadUrls = []) {
@@ -1422,11 +1416,13 @@ async function saveFastListImport({
   stopOnRateLimit = true,
   wait = null,
   rateLimitBackoffMs = 0,
+  readLeadListSnapshot = null,
 } = {}) {
   const results = [];
   const listInfo = { listName: importPlan.listName, externalRef: null };
   const initialExistingLeadUrlSet = buildExistingLeadUrlSet(existingLeadUrls);
   const existingLeadUrlSet = new Set(initialExistingLeadUrlSet);
+  const attemptedLeadUrlSet = new Set();
   let rateLimitStop = null;
 
   if (!liveSave) {
@@ -1513,6 +1509,28 @@ async function saveFastListImport({
       continue;
     }
 
+    if (attemptedLeadUrlSet.has(normalizeLeadUrl(lead.salesNavigatorUrl))) {
+      const row = {
+        ...lead,
+        status: 'save_clicked_unverified',
+        saveRecoveryPath: 'in_run_duplicate_unverified',
+        failureCategory: 'save_unverified',
+        selectionMode: 'in_run_duplicate_unverified',
+        attempt: 0,
+        note: 'Skipped duplicate lead URL after an earlier unverified save attempt in this run.',
+        verificationStatus: 'unverified_duplicate_attempt',
+        verificationMethod: 'lead_list_readback',
+        verifiedSaved: false,
+        intendedLeadIdentity: buildSalesNavigatorLeadIdentity(lead),
+        nextAction: 'verify_list_membership_before_connect',
+      };
+      results.push(row);
+      if (typeof onProgress === 'function') {
+        onProgress(row);
+      }
+      continue;
+    }
+
     let attempt = 0;
     let saved = false;
     let lastNote = null;
@@ -1533,7 +1551,7 @@ async function saveFastListImport({
           { runId, accountKey: lead.accountName || 'fast-list-import', dryRun: false },
         );
         const normalizedSave = normalizeSaveResult(saveResult);
-        const row = {
+        let row = {
           ...lead,
           status: normalizedSave.status,
           saveRecoveryPath: normalizedSave.recoveryPath,
@@ -1541,9 +1559,19 @@ async function saveFastListImport({
           selectionMode: saveResult.selectionMode || null,
           attempt,
           note: saveResult.note || null,
+          intendedLeadIdentity: buildSalesNavigatorLeadIdentity(lead),
         };
+        row = await verifyFastListSaveRow({
+          row,
+          lead,
+          listName: importPlan.listName,
+          readLeadListSnapshot,
+        });
         results.push(row);
-        existingLeadUrlSet.add(normalizeLeadUrl(lead.salesNavigatorUrl));
+        if (row.verifiedSaved) {
+          existingLeadUrlSet.add(normalizeLeadUrl(lead.salesNavigatorUrl));
+        }
+        attemptedLeadUrlSet.add(normalizeLeadUrl(lead.salesNavigatorUrl));
         if (typeof onProgress === 'function') {
           onProgress(row);
         }
@@ -1609,6 +1637,76 @@ function normalizeSaveResult(saveResult = {}) {
   return { status: saveResult.status || 'saved', recoveryPath: saveResult.selectionMode || 'lead_page_save' };
 }
 
+async function verifyFastListSaveRow({
+  row,
+  lead,
+  listName,
+  readLeadListSnapshot,
+}) {
+  const base = {
+    ...row,
+    verifiedSaved: false,
+    verificationStatus: 'unverified',
+    verificationMethod: 'lead_list_readback',
+  };
+
+  if (typeof readLeadListSnapshot !== 'function') {
+    return {
+      ...base,
+      status: row.status === 'already_saved' ? 'already_saved' : 'save_clicked_unverified',
+      failureCategory: row.status === 'already_saved' ? null : 'save_unverified',
+      note: row.note || 'save clicked but no live list readback verifier was available',
+      nextAction: row.status === 'already_saved' ? undefined : 'verify_list_membership_before_connect',
+    };
+  }
+
+  let snapshot;
+  try {
+    snapshot = await readLeadListSnapshot(listName);
+  } catch (error) {
+    return {
+      ...base,
+      status: row.status === 'already_saved' ? 'already_saved' : 'save_clicked_unverified',
+      failureCategory: row.status === 'already_saved' ? null : 'save_readback_unavailable',
+      note: `save clicked but live list readback failed: ${String(error.message || error)}`,
+      nextAction: row.status === 'already_saved' ? undefined : 'verify_list_membership_before_connect',
+    };
+  }
+
+  const match = findSalesNavigatorLeadIdentityMatch(lead, snapshot?.rows || []);
+  if (match.status === 'matched') {
+    return {
+      ...base,
+      status: row.status === 'already_saved' ? 'already_saved_verified' : 'saved_and_verified',
+      verifiedSaved: true,
+      verificationStatus: 'verified',
+      readbackLeadIdentity: match.identity,
+      note: row.note || 'verified in target Sales Navigator list',
+    };
+  }
+
+  if (match.status === 'same_name_wrong_identity') {
+    return {
+      ...base,
+      status: 'wrong_identity_detected',
+      verificationStatus: 'wrong_identity_detected',
+      failureCategory: 'wrong_identity_detected',
+      readbackLeadIdentity: match.identity,
+      note: 'same-name row found in target list, but Sales Navigator lead identity does not match intended lead',
+      nextAction: 'manual_review_before_connect',
+    };
+  }
+
+  return {
+    ...base,
+    status: 'save_clicked_unverified',
+    verificationStatus: 'missing_after_save',
+    failureCategory: 'missing_after_save',
+    note: 'save clicked but intended Sales Navigator lead identity was missing from target list readback',
+    nextAction: 'retry_or_manual_review_list_membership',
+  };
+}
+
 function classifySaveFailure(note) {
   const message = String(note || '');
   if (/too many requests|rate.?limit|throttl|429|please wait before trying again|try again later/i.test(message)) {
@@ -1657,15 +1755,16 @@ function buildFastListImportResult(payload) {
   const failed = results.filter((row) => failedStatuses.has(row.status)).length;
   const unresolved = results.filter((row) => row.status === 'unresolved').length;
   const manualReview = results.filter((row) => row.status === 'manual_review').length;
+  const unverified = results.filter((row) => ['save_clicked_unverified', 'wrong_identity_detected'].includes(row.status)).length;
   const mutationReviewExcluded = results.filter((row) => row.saveRecoveryPath === 'mutation_review_exclusion').length;
-  const confirmedSaved = results.filter((row) => ['saved', 'results_row_fallback_saved'].includes(row.status)).length;
-  const alreadySaved = results.filter((row) => row.status === 'already_saved').length;
-  const snapshotSkipped = results.filter((row) => row.status === 'already_saved' && row.saveRecoveryPath === 'snapshot_preflight').length;
+  const confirmedSaved = results.filter((row) => row.status === 'saved_and_verified').length;
+  const alreadySaved = results.filter((row) => ['already_saved', 'already_saved_verified'].includes(row.status)).length;
+  const snapshotSkipped = results.filter((row) => ['already_saved', 'already_saved_verified'].includes(row.status) && row.saveRecoveryPath === 'snapshot_preflight').length;
   const rateLimitSkipped = results.filter((row) => row.status === 'skipped_rate_limit_cooldown').length;
   const failureBreakdown = summarizeSaveFailureBreakdown(results);
   return {
     ...payload,
-    status: failed || unresolved || manualReview || mutationReviewExcluded || rateLimitSkipped ? 'completed_with_followup' : 'completed',
+    status: failed || unresolved || manualReview || unverified || mutationReviewExcluded || rateLimitSkipped ? 'completed_with_followup' : 'completed',
     saved: confirmedSaved,
     confirmedSaved,
     alreadySaved,
@@ -1674,9 +1773,10 @@ function buildFastListImportResult(payload) {
     failed,
     unresolved,
     manualReview,
+    unverified,
     mutationReviewExcluded,
     failureBreakdown,
-    nextAction: deriveFastListImportNextAction({ failed, unresolved, manualReview, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }),
+    nextAction: deriveFastListImportNextAction({ failed, unresolved, manualReview, unverified, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }),
   };
 }
 
@@ -1687,6 +1787,10 @@ function summarizeSaveFailureBreakdown(results = []) {
         ? 'unresolved'
         : row.status === 'skipped_rate_limit_cooldown'
           ? 'rate_limit_cooldown'
+          : row.status === 'save_clicked_unverified'
+            ? (row.verificationStatus || 'save_unverified')
+            : row.status === 'wrong_identity_detected'
+              ? 'wrong_identity_detected'
           : null
     );
     if (!key) {
@@ -1697,9 +1801,12 @@ function summarizeSaveFailureBreakdown(results = []) {
   }, {});
 }
 
-function deriveFastListImportNextAction({ failed, unresolved, manualReview, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }) {
+function deriveFastListImportNextAction({ failed, unresolved, manualReview, unverified, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }) {
   if (failureBreakdown?.rate_limit || rateLimitSkipped) {
     return 'wait_10_min_and_retry_failed';
+  }
+  if (unverified || failureBreakdown?.missing_after_save || failureBreakdown?.wrong_identity_detected) {
+    return 'verify_list_membership_before_connect';
   }
   if (failureBreakdown?.runtime_failure) {
     return 'rebootstrap_session_then_retry_failed';
@@ -2065,6 +2172,7 @@ module.exports = {
   inferFullNameFromLinkedInSlug,
   isRetryableSaveError,
   normalizeSaveResult,
+  verifyFastListSaveRow,
   loadCoverageImportPlan,
   loadCoverageLeadIndex,
   loadFastListImportSource,

--- a/src/core/lead-list-snapshot.js
+++ b/src/core/lead-list-snapshot.js
@@ -2,12 +2,15 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { readJson } = require('../lib/json');
 const { resolveProjectPath } = require('../lib/paths');
+const {
+  buildSalesNavigatorLeadIdentity,
+  normalizeSalesNavigatorLeadUrl,
+} = require('./sales-nav-identity');
 
 const ACCOUNT_BATCH_ARTIFACTS_DIR = resolveProjectPath('runtime/artifacts/account-batches');
 const CONFIRMED_SAVED_STATUSES = new Set([
-  'saved',
-  'already_saved',
-  'results_row_fallback_saved',
+  'saved_and_verified',
+  'already_saved_verified',
 ]);
 
 function normalizeLeadListName(value) {
@@ -63,7 +66,7 @@ function buildLeadListSnapshotFromArtifact(artifact, { listName = null, artifact
   const seen = new Set();
   const rows = [];
   for (const row of sourceRows) {
-    const salesNavigatorUrl = row.salesNavigatorUrl || row.profileUrl || row.candidate?.salesNavigatorUrl || null;
+    const salesNavigatorUrl = normalizeSalesNavigatorLeadUrl(row.salesNavigatorUrl || row.profileUrl || row.candidate?.salesNavigatorUrl || null);
     const fullName = row.fullName || row.name || row.candidate?.fullName || null;
     if (!fullName || !salesNavigatorUrl || !/linkedin\.com\/sales\/lead\//i.test(salesNavigatorUrl)) {
       continue;
@@ -77,6 +80,11 @@ function buildLeadListSnapshotFromArtifact(artifact, { listName = null, artifact
     rows.push({
       fullName,
       salesNavigatorUrl,
+      ...buildSalesNavigatorLeadIdentity({
+        ...row,
+        salesNavigatorUrl,
+        fullName,
+      }),
       rowText: [fullName, row.title, row.accountName, row.status, row.note].filter(Boolean).join(' | '),
       invitationSent: /already_sent|invitation sent|connection sent|sent/i.test(statusText),
       connectionSent: /already_connected|connected|vernetzt/i.test(statusText),

--- a/src/core/sales-nav-identity.js
+++ b/src/core/sales-nav-identity.js
@@ -1,0 +1,97 @@
+function normalizeSalesNavigatorLeadUrl(url) {
+  const raw = String(url || '').trim();
+  if (!raw) {
+    return '';
+  }
+  try {
+    const parsed = new URL(raw);
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return raw.replace(/[?#].*$/, '').replace(/\/$/, '');
+  }
+}
+
+function extractSalesNavigatorLeadId(url) {
+  const normalized = normalizeSalesNavigatorLeadUrl(url);
+  const match = normalized.match(/\/sales\/lead\/([^/?#]+)/i);
+  if (!match) {
+    return '';
+  }
+  return decodeURIComponent(match[1]).split(',')[0].trim();
+}
+
+function normalizeIdentityName(value) {
+  return String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function buildSalesNavigatorLeadIdentity(value = {}) {
+  const salesNavigatorUrl = normalizeSalesNavigatorLeadUrl(
+    value.salesNavigatorUrl
+      || value.profileUrl
+      || value.url
+      || value.candidate?.salesNavigatorUrl
+      || '',
+  );
+  return {
+    salesNavigatorUrl,
+    salesNavigatorLeadId: value.salesNavigatorLeadId
+      || value.leadId
+      || value.entityUrn
+      || extractSalesNavigatorLeadId(salesNavigatorUrl),
+    fullName: value.fullName || value.name || value.candidate?.fullName || '',
+    title: value.title || value.headline || value.candidate?.title || '',
+    accountName: value.accountName || value.company || value.candidate?.accountName || '',
+  };
+}
+
+function salesNavigatorLeadIdentitiesMatch(left = {}, right = {}) {
+  const leftIdentity = buildSalesNavigatorLeadIdentity(left);
+  const rightIdentity = buildSalesNavigatorLeadIdentity(right);
+  if (leftIdentity.salesNavigatorLeadId && rightIdentity.salesNavigatorLeadId) {
+    return leftIdentity.salesNavigatorLeadId === rightIdentity.salesNavigatorLeadId;
+  }
+  return Boolean(
+    leftIdentity.salesNavigatorUrl
+      && rightIdentity.salesNavigatorUrl
+      && leftIdentity.salesNavigatorUrl === rightIdentity.salesNavigatorUrl,
+  );
+}
+
+function findSalesNavigatorLeadIdentityMatch(target = {}, rows = []) {
+  const sameIdentity = (rows || []).find((row) => salesNavigatorLeadIdentitiesMatch(target, row));
+  if (sameIdentity) {
+    return {
+      status: 'matched',
+      row: sameIdentity,
+      identity: buildSalesNavigatorLeadIdentity(sameIdentity),
+    };
+  }
+
+  const targetName = normalizeIdentityName(target.fullName || target.name);
+  const sameName = targetName
+    ? (rows || []).find((row) => normalizeIdentityName(row.fullName || row.name) === targetName)
+    : null;
+  if (sameName) {
+    return {
+      status: 'same_name_wrong_identity',
+      row: sameName,
+      identity: buildSalesNavigatorLeadIdentity(sameName),
+    };
+  }
+
+  return {
+    status: 'missing',
+    row: null,
+    identity: null,
+  };
+}
+
+module.exports = {
+  buildSalesNavigatorLeadIdentity,
+  extractSalesNavigatorLeadId,
+  findSalesNavigatorLeadIdentityMatch,
+  normalizeSalesNavigatorLeadUrl,
+  salesNavigatorLeadIdentitiesMatch,
+};

--- a/tests/fast-list-import.test.js
+++ b/tests/fast-list-import.test.js
@@ -401,6 +401,12 @@ test('saveFastListImport retries lead-detail render failures once', async () => 
     driver,
     liveSave: true,
     maxRetries: 1,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -417,7 +423,74 @@ test('saveFastListImport retries lead-detail render failures once', async () => 
   assert.equal(attempts, 2);
   assert.equal(result.status, 'completed');
   assert.equal(result.saved, 1);
+  assert.equal(result.results[0].status, 'saved_and_verified');
   assert.equal(result.results[0].attempt, 2);
+});
+
+test('saveFastListImport downgrades click-only saves when no live readback verifier is available', async () => {
+  const result = await saveFastListImport({
+    driver: {
+      async saveCandidateToList() {
+        return { status: 'saved', selectionMode: 'existing_list' };
+      },
+    },
+    liveSave: true,
+    maxRetries: 0,
+    importPlan: {
+      listName: 'Calling List',
+      leads: [
+        {
+          accountName: 'Example Network Co',
+          fullName: 'Nora Platform',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+          resolutionStatus: 'resolved',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 'completed_with_followup');
+  assert.equal(result.confirmedSaved, 0);
+  assert.equal(result.unverified, 1);
+  assert.equal(result.results[0].status, 'save_clicked_unverified');
+  assert.equal(result.results[0].verifiedSaved, false);
+});
+
+test('saveFastListImport flags same-name wrong-identity readback', async () => {
+  const result = await saveFastListImport({
+    driver: {
+      async saveCandidateToList() {
+        return { status: 'saved', selectionMode: 'results_row_fallback' };
+      },
+    },
+    liveSave: true,
+    maxRetries: 0,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Patryk Szymczak',
+        title: 'Co-Founder',
+        accountName: 'Ci Labs',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/wrong-id',
+      }],
+    }),
+    importPlan: {
+      listName: 'Calling List',
+      leads: [
+        {
+          accountName: 'Riverty',
+          fullName: 'Patryk Szymczak',
+          title: 'IT Infrastructure Expert',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/intended-id',
+          resolutionStatus: 'resolved',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 'completed_with_followup');
+  assert.equal(result.confirmedSaved, 0);
+  assert.equal(result.results[0].status, 'wrong_identity_detected');
+  assert.equal(result.results[0].verificationStatus, 'wrong_identity_detected');
 });
 
 test('saveFastListImport leaves unresolved rows out of live mutation', async () => {
@@ -429,6 +502,12 @@ test('saveFastListImport leaves unresolved rows out of live mutation', async () 
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -490,6 +569,12 @@ test('saveFastListImport does not save mutation-review excluded rows', async () 
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -522,6 +607,12 @@ test('saveFastListImport marks non-manual mutation-review exclusions as follow-u
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -554,6 +645,12 @@ test('saveFastListImport skips duplicate Sales Navigator URLs after the first li
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -599,6 +696,12 @@ test('saveFastListImport stops after rate-limit failure instead of burning remai
     liveSave: true,
     maxRetries: 0,
     rateLimitBackoffMs: 250,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     wait(ms) {
       waitedMs += ms;
     },
@@ -632,7 +735,7 @@ test('saveFastListImport stops after rate-limit failure instead of burning remai
 
   assert.equal(attempts, 2);
   assert.equal(waitedMs, 250);
-  assert.deepEqual(progress, ['saved', 'failed_rate_limit', 'skipped_rate_limit_cooldown']);
+  assert.deepEqual(progress, ['saved_and_verified', 'failed_rate_limit', 'skipped_rate_limit_cooldown']);
   assert.equal(result.status, 'completed_with_followup');
   assert.equal(result.failed, 1);
   assert.equal(result.rateLimitSkipped, 1);

--- a/tests/lead-list-snapshot.test.js
+++ b/tests/lead-list-snapshot.test.js
@@ -19,17 +19,17 @@ test('buildLeadListSnapshotFromArtifact converts fast-import artifacts into conn
         title: 'Senior Platform Owner',
         accountName: 'Example Semiconductor Co',
         salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
-        status: 'saved',
+        status: 'saved_and_verified',
       },
       {
         fullName: 'Duplicate Example Saved Lead',
         salesNavigatorUrl: 'https://www.linkedin.com/in/not-sales-nav',
-        status: 'saved',
+        status: 'saved_and_verified',
       },
       {
         fullName: 'Example Pending Lead',
         salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/456',
-        status: 'already_saved',
+        status: 'already_saved_verified',
         note: 'already saved before run',
       },
     ],
@@ -69,7 +69,7 @@ test('buildLeadListSnapshotFromArtifact ignores explicit failed import result ro
       {
         fullName: 'Saved Lead',
         salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/saved',
-        status: 'saved',
+        status: 'saved_and_verified',
       },
       {
         fullName: 'Manual Review Lead',


### PR DESCRIPTION
## Summary
- add stable Sales Navigator lead identity helpers for URL/lead-id based matching
- stop treating click-only list saves as confirmed membership
- verify live saves against list readback before counting `confirmedSaved`
- keep artifact fallback connect sources limited to verified save statuses

Closes #36.

## Tests
- npm test -- tests/fast-list-import.test.js tests/lead-list-snapshot.test.js
- npm test -- tests/fast-list-import.test.js tests/playwright-driver.test.js tests/lead-list-snapshot.test.js tests/account-batch.test.js tests/connect-executor.test.js
- npm run test:release-readiness
- npm test
- git diff --check
