### PR TITLE
Harden connect verification fail-closed

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -701,6 +701,7 @@ async function handleFastListImport(values, logger) {
         maxRetries,
         runId,
         existingLeadUrls: existingSnapshot?.rows?.map((row) => row.salesNavigatorUrl) || [],
+        readLeadListSnapshot: (targetListName) => readLeadListSnapshotStrict(driver, targetListName || importPlan.listName),
         onProgress(row) {
           logger.info(`${row.status} | ${row.accountName || 'Unknown account'} | ${row.fullName || 'Unknown lead'}${row.attempt ? ` | attempt=${row.attempt}` : ''}`);
         },
@@ -788,6 +789,7 @@ async function handleRetryFailedFastListImport(values, logger) {
         maxRetries,
         runId,
         existingLeadUrls: existingSnapshot?.rows?.map((row) => row.salesNavigatorUrl) || [],
+        readLeadListSnapshot: (targetListName) => readLeadListSnapshotStrict(driver, targetListName || importPlan.listName),
         onProgress(row) {
           logger.info(`${row.status} | ${row.accountName || 'Unknown account'} | ${row.fullName || 'Unknown lead'}${row.attempt ? ` | attempt=${row.attempt}` : ''}`);
         },
@@ -882,6 +884,7 @@ async function handleImportCoverage(values, logger) {
         maxRetries,
         runId,
         existingLeadUrls: existingSnapshot?.rows?.map((row) => row.salesNavigatorUrl) || [],
+        readLeadListSnapshot: (targetListName) => readLeadListSnapshotStrict(driver, targetListName || importPlan.listName),
         onProgress(row) {
           logger.info(`${row.status} | ${row.accountName || 'Unknown account'} | ${row.fullName || 'Unknown lead'}${row.attempt ? ` | attempt=${row.attempt}` : ''}`);
         },
@@ -1301,10 +1304,7 @@ function recordConnectEventIfKnown(repository, rowOrCandidate, approvalId, actio
 
 async function readLeadListSnapshot(driver, listName) {
   try {
-    if (typeof driver.runHarnessJson === 'function') {
-      return await readLeadListSnapshotViaHarness(driver, listName);
-    }
-    return await readLeadListSnapshotViaPlaywright(driver, listName);
+    return await readLeadListSnapshotStrict(driver, listName);
   } catch (error) {
     const artifactSnapshot = readLatestLeadListArtifactSnapshot(listName);
     if (artifactSnapshot) {
@@ -1312,6 +1312,13 @@ async function readLeadListSnapshot(driver, listName) {
     }
     throw error;
   }
+}
+
+async function readLeadListSnapshotStrict(driver, listName) {
+  if (typeof driver.runHarnessJson === 'function') {
+    return await readLeadListSnapshotViaHarness(driver, listName);
+  }
+  return await readLeadListSnapshotViaPlaywright(driver, listName);
 }
 
 function readLeadListSnapshotViaHarness(driver, listName) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -105,6 +105,10 @@ const {
 } = require('./core/budget');
 const { reconcileState } = require('./core/reconciler');
 const { maybeFallbackToLeadPageConnect } = require('./core/connect-fallback');
+const {
+  summarizeConnectResults,
+  verifyConnectResult,
+} = require('./core/connect-verification');
 const { isConnectMenuActionLabel } = require('./core/connect-menu');
 const { writeConnectEvidenceSprint } = require('./core/connect-evidence');
 const { readLatestLeadListArtifactSnapshot } = require('./core/lead-list-snapshot');
@@ -1066,6 +1070,7 @@ async function handleConnectLeadList(repository, values, logger) {
   const driverName = getString(values, 'driver') || 'playwright';
   const listName = getString(values, 'list-name');
   const limit = Number(getString(values, 'limit') || Number.MAX_SAFE_INTEGER);
+  const allowUnverifiedConnectContinue = getBoolean(values, 'allow-unverified-connect-continue');
   if (!listName) {
     throw new Error('connect-lead-list requires --list-name');
   }
@@ -1125,7 +1130,9 @@ async function handleConnectLeadList(repository, values, logger) {
       .slice(0, Math.min(limit, budget.remainingToday));
 
     const results = [];
-    for (const row of pendingRows) {
+    let unprocessed = 0;
+    for (let index = 0; index < pendingRows.length; index += 1) {
+      const row = pendingRows[index];
       const knownCandidateId = resolveKnownCandidateId(repository, row);
       const candidateId = knownCandidateId || row.salesNavigatorUrl || row.fullName;
       if (knownCandidateId && repository.hasSentConnect(knownCandidateId)) {
@@ -1151,24 +1158,41 @@ async function handleConnectLeadList(repository, values, logger) {
           : driverName === 'browser-harness'
           ? sendConnectFromLeadListRow(driver, listName, row)
           : await sendConnectFromLeadListRowViaPlaywright(driver, snapshot.listUrl || listName, row);
-        const result = await maybeFallbackToLeadPageConnect({
+        const connectResult = await maybeFallbackToLeadPageConnect({
           initialResult,
           driver,
           row,
           accountKey: listName,
           runId: 'connect-lead-list-row-fallback',
         });
+        const result = await verifyConnectResult({
+          candidate: row,
+          result: connectResult,
+          readSnapshot: () => readLeadListSnapshotStrict(driver, snapshot.listUrl || listName),
+        });
 
         recordConnectEventIfKnown(repository, row, null, 'connect', result.status, {
           listName,
           fullName: row.fullName,
           note: result.note || null,
+          verifiedConnect: result.verifiedConnect || false,
+          verificationStatus: result.verificationStatus || null,
         });
         results.push({
           name: row.fullName,
           status: result.status,
           note: result.note || null,
+          verifiedConnect: result.verifiedConnect || false,
+          verificationStatus: result.verificationStatus || null,
         });
+        if (result.status === 'manual_review' && !allowUnverifiedConnectContinue) {
+          unprocessed = pendingRows.length - index - 1;
+          break;
+        }
+        if (result.status === 'rate_limited') {
+          unprocessed = pendingRows.length - index - 1;
+          break;
+        }
       } catch (error) {
         results.push({
           name: row.fullName,
@@ -1188,10 +1212,11 @@ async function handleConnectLeadList(repository, values, logger) {
     logger.info(`Daily pacing target: ${budget.recommendedTodayLimit}`);
     logger.info(`Total leads: ${finalSnapshot.rows.length}`);
     logger.info(`Already invited before run: ${snapshot.rows.filter((row) => row.invitationSent || row.connectionSent).length}`);
-    logger.info(`Attempted this run: ${pendingRows.length}`);
+    logger.info(`Attempted this run: ${results.length}`);
     results.forEach((result) => {
-      logger.info(`${result.name} | ${result.status}${result.note ? ` | ${result.note}` : ''}`);
+      logger.info(`${result.name} | ${result.status}${result.verificationStatus ? ` | verification=${result.verificationStatus}` : ''}${result.note ? ` | ${result.note}` : ''}`);
     });
+    logger.info(`Connect verification summary: ${JSON.stringify(summarizeConnectResults(results, unprocessed))}`);
     if (snapshot.source === 'artifact_fallback') {
       logger.info(`Visible list verification: skipped because Sales Nav list lookup fell back to artifact ${snapshot.artifactPath || 'unknown'}`);
     } else {
@@ -2463,6 +2488,7 @@ async function handleSendApproved(repository, values, logger) {
       ...run,
       weeklyCap: budgetPolicy.weeklyCap,
       connectBudgetPolicy: budgetPolicy,
+      allowUnverifiedConnectContinue: getBoolean(values, 'allow-unverified-connect-continue'),
     },
     limit: Number(getString(values, 'limit') || 25),
   });
@@ -3266,6 +3292,7 @@ async function handleRunAccountBatch(repository, values, logger) {
   const consolidatedListName = explicitConsolidatedListName || templateConsolidatedListName || null;
   const liveSave = getBoolean(values, 'liveSave', 'live-save');
   const liveConnect = getBoolean(values, 'liveConnect', 'live-connect');
+  const allowUnverifiedConnectContinue = getBoolean(values, 'allow-unverified-connect-continue');
   const pilotConfig = getString(values, 'pilot-config') ? loadPilotConfig(getString(values, 'pilot-config')) : null;
   const driverName = getString(values, 'driver') || 'playwright';
   const peopleSearchUrl = getString(values, 'people-search-url') || 'https://www.linkedin.com/sales/search/people?viewAllFilters=true';
@@ -3383,7 +3410,8 @@ async function handleRunAccountBatch(repository, values, logger) {
 
       const connectCandidates = liveSave ? selectedForListSave : listCandidates;
       if (liveConnect && connectCandidates.length > 0) {
-        for (const candidate of connectCandidates) {
+        for (let connectIndex = 0; connectIndex < connectCandidates.length; connectIndex += 1) {
+          const candidate = connectCandidates[connectIndex];
           const candidateId = candidate.salesNavigatorUrl || candidate.profileUrl || candidate.fullName;
           const remainingToday = budget.remainingToday - sentThisRun;
           const remainingWeek = budget.remainingThisWeek - sentThisRun;
@@ -3405,28 +3433,53 @@ async function handleRunAccountBatch(repository, values, logger) {
           }
 
           try {
-            const connectResult = await driver.sendConnect(
+            const rawConnectResult = await driver.sendConnect(
               candidate,
               { runId: 'run-account-batch', accountKey: accountName, dryRun: false },
             );
+            const connectResult = await verifyConnectResult({
+              candidate,
+              result: rawConnectResult,
+              readSnapshot: liveSave ? () => readLeadListSnapshotStrict(driver, listName) : null,
+            });
             repository.insertConnectEvent(candidateId, null, 'connect', connectResult.status, {
               accountName,
               listName,
               fullName: candidate.fullName,
               note: connectResult.note || null,
+              verifiedConnect: connectResult.verifiedConnect || false,
+              verificationStatus: connectResult.verificationStatus || null,
             });
-            if (connectResult.status === 'sent') {
+            if (connectResult.status === 'sent' && connectResult.verifiedConnect) {
               sentThisRun += 1;
             }
             connectResults.push({
               fullName: candidate.fullName,
               status: connectResult.status,
               note: connectResult.note || null,
+              verifiedConnect: connectResult.verifiedConnect || false,
+              verificationStatus: connectResult.verificationStatus || null,
               connectPath: connectResult.connectPath || null,
               fallbackTriggeredBy: connectResult.fallbackTriggeredBy || null,
               initialStatus: connectResult.initialStatus || null,
               initialNote: connectResult.initialNote || null,
             });
+            if (connectResult.status === 'manual_review' && !allowUnverifiedConnectContinue) {
+              connectResults.push(...connectCandidates.slice(connectIndex + 1).map((remaining) => ({
+                fullName: remaining.fullName,
+                status: 'unprocessed',
+                note: 'Skipped because a prior connect outcome was unverified and fail-closed mode is active.',
+              })));
+              break;
+            }
+            if (connectResult.status === 'rate_limited') {
+              connectResults.push(...connectCandidates.slice(connectIndex + 1).map((remaining) => ({
+                fullName: remaining.fullName,
+                status: 'unprocessed',
+                note: 'Skipped because LinkedIn showed a rate-limit signal.',
+              })));
+              break;
+            }
           } catch (error) {
             connectResults.push({
               fullName: candidate.fullName,
@@ -3625,6 +3678,7 @@ async function handlePilotConnectBatch(repository, values, logger) {
   const maxConnectsPerAccount = Number(getString(values, 'max-connects-per-account') || 1);
   const driverName = getString(values, 'driver') || 'playwright';
   const pilotConfig = loadPilotConfig(getString(values, 'pilot-config'));
+  const allowUnverifiedConnectContinue = getBoolean(values, 'allow-unverified-connect-continue');
   const driverOptions = buildDriverOptions(values, { dryRun: false }, {
     sessionMode: 'persistent',
     headless: true,
@@ -3721,7 +3775,8 @@ async function handlePilotConnectBatch(repository, values, logger) {
       }
 
       const connectResults = [];
-      for (const row of pendingRows) {
+      for (let rowIndex = 0; rowIndex < pendingRows.length; rowIndex += 1) {
+        const row = pendingRows[rowIndex];
         const remainingToday = budget.remainingToday - sentThisRun;
         const remainingWeek = budget.remainingThisWeek - sentThisRun;
         if (remainingToday <= 0 || remainingWeek <= 0) {
@@ -3757,7 +3812,7 @@ async function handlePilotConnectBatch(repository, values, logger) {
                 },
                 { runId: 'pilot-connect-batch', accountKey: accountName, dryRun: false },
               );
-          const result = selectionSource === 'lead_list'
+          const rawResult = selectionSource === 'lead_list'
             ? await maybeFallbackToLeadPageConnect({
               initialResult,
               driver,
@@ -3765,23 +3820,50 @@ async function handlePilotConnectBatch(repository, values, logger) {
               accountKey: accountName,
             })
             : initialResult;
+          const result = await verifyConnectResult({
+            candidate: row,
+            result: rawResult,
+            readSnapshot: selectionSource === 'lead_list'
+              ? () => readLeadListSnapshotStrict(driver, listName)
+              : null,
+          });
           recordConnectEventIfKnown(repository, row, null, 'connect', result.status, {
             listName,
             fullName: row.fullName,
             note: result.note || null,
+            verifiedConnect: result.verifiedConnect || false,
+            verificationStatus: result.verificationStatus || null,
           });
-          if (result.status === 'sent') {
+          if (result.status === 'sent' && result.verifiedConnect) {
             sentThisRun += 1;
           }
           connectResults.push({
             fullName: row.fullName,
             status: result.status,
             note: result.note || null,
+            verifiedConnect: result.verifiedConnect || false,
+            verificationStatus: result.verificationStatus || null,
             connectPath: result.connectPath || null,
             fallbackTriggeredBy: result.fallbackTriggeredBy || null,
             initialStatus: result.initialStatus || null,
             initialNote: result.initialNote || null,
           });
+          if (result.status === 'manual_review' && !allowUnverifiedConnectContinue) {
+            connectResults.push(...pendingRows.slice(rowIndex + 1).map((remaining) => ({
+              fullName: remaining.fullName,
+              status: 'unprocessed',
+              note: 'Skipped because a prior connect outcome was unverified and fail-closed mode is active.',
+            })));
+            break;
+          }
+          if (result.status === 'rate_limited') {
+            connectResults.push(...pendingRows.slice(rowIndex + 1).map((remaining) => ({
+              fullName: remaining.fullName,
+              status: 'unprocessed',
+              note: 'Skipped because LinkedIn showed a rate-limit signal.',
+            })));
+            break;
+          }
         } catch (error) {
           connectResults.push({
             fullName: row.fullName,
@@ -3893,9 +3975,9 @@ Usage:
   node src/cli.js import-coverage --accounts=example-marketplace-a,example-saas-marketplace,olx-group [--bucket=direct_observability] [--min-score=40] [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create]
   node src/cli.js test-connect --driver=playwright|browser-harness|hybrid --candidate-url="https://www.linkedin.com/sales/lead/..." [--full-name="Jane Doe"] --live-connect
   node src/cli.js inspect-connect-surface --driver=playwright --candidate-url="https://www.linkedin.com/sales/lead/..." [--full-name="Jane Doe"]
-  node src/cli.js connect-lead-list --driver=playwright|browser-harness|hybrid --list-name="Territory List" [--limit=25] --live-connect
+  node src/cli.js connect-lead-list --driver=playwright|browser-harness|hybrid --list-name="Territory List" [--limit=25] --live-connect [--allow-unverified-connect-continue]
   node src/cli.js remove-lead-list-members --driver=playwright --list-name="Territory List" --names="Name A, Name B" --live-save
-  node src/cli.js send-approved-connects [--run-id=<run-id>] [--limit=25]
+  node src/cli.js send-approved-connects [--run-id=<run-id>] [--limit=25] [--allow-unverified-connect-continue]
   node src/cli.js reconcile-state
   node src/cli.js cleanup-runtime [--max-age-hours=72]
   node src/cli.js print-live-test-checklist
@@ -3914,9 +3996,9 @@ Usage:
   node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js autoresearch-speed-eval --baseline=runtime/artifacts/autoresearch/baseline.json --candidate=runtime/artifacts/autoresearch/candidate.json [--min-speedup-percent=25]
   node src/cli.js parallel-account-research --accounts="Account A, Account B" [--research-mode=persona-led|exhaustive|keyword] [--local-concurrency=4] [--coverage-config=config/account-coverage/default.json] [--run-id=my-run]
-  node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=playwright|hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--adaptive-sweep-pruning] [--live-save] [--live-connect]
+  node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=playwright|hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--adaptive-sweep-pruning] [--live-save] [--live-connect] [--allow-unverified-connect-continue]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
-  node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect
+  node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect [--allow-unverified-connect-continue]
 `);
 }
 

--- a/src/core/connect-executor.js
+++ b/src/core/connect-executor.js
@@ -1,4 +1,8 @@
 const { computeBudgetState, resolveConnectBudgetPolicy } = require('./budget');
+const {
+  summarizeConnectResults,
+  verifyConnectResult,
+} = require('./connect-verification');
 
 async function sendApprovedConnects({ repository, driver, runContext, limit = 25 }) {
   const policy = resolveConnectBudgetPolicy({
@@ -30,12 +34,20 @@ async function sendApprovedConnects({ repository, driver, runContext, limit = 25
   }
 
   const approvals = repository.getPendingApprovals(Math.min(limit, budget.remainingToday));
-  let sent = 0;
+  const results = [];
   let skipped = 0;
+  let stopReason = null;
+  let unprocessed = 0;
 
-  for (const approval of approvals) {
+  for (let index = 0; index < approvals.length; index += 1) {
+    const approval = approvals[index];
     if (repository.hasSentConnect(approval.candidateId)) {
       skipped += 1;
+      results.push({
+        candidateId: approval.candidateId,
+        status: 'duplicate_skipped',
+        note: 'already recorded as sent locally',
+      });
       repository.insertConnectEvent(approval.candidateId, approval.approvalId, 'connect', 'duplicate_skipped', {
         reason: 'already_sent',
       });
@@ -44,21 +56,49 @@ async function sendApprovedConnects({ repository, driver, runContext, limit = 25
     }
 
     try {
-      const result = await driver.sendConnect(approval, runContext);
+      const rawResult = await driver.sendConnect(approval, runContext);
+      const result = await verifyConnectResult({
+        candidate: approval,
+        result: rawResult,
+        readSnapshot: typeof driver.verifyConnectOutcome === 'function'
+          ? () => driver.verifyConnectOutcome(approval, rawResult, runContext)
+          : null,
+      });
       repository.insertConnectEvent(approval.candidateId, approval.approvalId, 'connect', result.status, result);
       repository.updateApprovalState(
         approval.approvalId,
-        result.status === 'sent' ? 'sent' : 'approved',
+        result.status === 'sent' && result.verifiedConnect ? 'sent' : 'approved',
         result.note || null,
       );
+      results.push({
+        candidateId: approval.candidateId,
+        status: result.status,
+        note: result.note || null,
+        verifiedConnect: result.verifiedConnect || false,
+        verificationStatus: result.verificationStatus || null,
+        rateLimit: result.rateLimit || null,
+      });
 
-      if (result.status === 'sent') {
-        sent += 1;
-      } else {
+      if (!(result.status === 'sent' && result.verifiedConnect)) {
         skipped += 1;
+      }
+      if (result.status === 'manual_review' && !runContext.allowUnverifiedConnectContinue) {
+        stopReason = 'stopped_unverified_connect';
+        unprocessed = approvals.length - index - 1;
+        break;
+      }
+      if (result.status === 'rate_limited') {
+        stopReason = 'stopped_rate_limit_signal';
+        unprocessed = approvals.length - index - 1;
+        break;
       }
     } catch (error) {
       skipped += 1;
+      results.push({
+        candidateId: approval.candidateId,
+        status: 'failed',
+        note: error.message,
+      });
       repository.insertConnectEvent(approval.candidateId, approval.approvalId, 'connect', 'failed', {
         message: error.message,
       });
@@ -72,12 +112,16 @@ async function sendApprovedConnects({ repository, driver, runContext, limit = 25
     }
   }
 
+  const summary = summarizeConnectResults(results, unprocessed);
   return {
     budget,
-    processed: approvals.length,
-    sent,
+    processed: results.length,
+    sent: summary.verifiedSent,
     skipped,
-    reason: approvals.length === 0 ? 'no_approved_people' : 'completed',
+    unprocessed,
+    results,
+    summary,
+    reason: approvals.length === 0 ? 'no_approved_people' : (stopReason || 'completed'),
   };
 }
 

--- a/src/core/connect-verification.js
+++ b/src/core/connect-verification.js
@@ -1,0 +1,114 @@
+const {
+  buildSalesNavigatorLeadIdentity,
+  findSalesNavigatorLeadIdentityMatch,
+} = require('./sales-nav-identity');
+
+function hasVerifiedConnectState(row = {}) {
+  const rowText = String(row.rowText || row.statusText || row.note || '').toLowerCase();
+  return Boolean(
+    row.pendingInvitation
+      || row.invitationSent
+      || row.connectionSent
+      || row.degree === 1
+      || row.degree === '1'
+      || row.networkDistance === '1st'
+      || /invitation sent|connection sent|pending|einladung gesendet|verbindung gesendet|ausstehend/.test(rowText),
+  );
+}
+
+function verifyConnectResultWithSnapshot({ candidate, result, snapshot } = {}) {
+  const status = result?.status || 'manual_review';
+  if (!['sent'].includes(status)) {
+    return {
+      ...result,
+      verifiedConnect: ['already_sent', 'already_connected'].includes(status),
+      verificationStatus: ['already_sent', 'already_connected'].includes(status) ? 'verified_noop' : (result?.verificationStatus || null),
+    };
+  }
+
+  const match = findSalesNavigatorLeadIdentityMatch(candidate, snapshot?.rows || []);
+  if (match.status === 'matched' && hasVerifiedConnectState(match.row)) {
+    return {
+      ...result,
+      status: 'sent',
+      verifiedConnect: true,
+      verificationStatus: match.row.connectionSent || match.row.degree === 1 || match.row.degree === '1'
+        ? 'verified_connected'
+        : 'verified_pending_invitation',
+      verificationMethod: 'lead_list_readback',
+      intendedLeadIdentity: buildSalesNavigatorLeadIdentity(candidate),
+      readbackLeadIdentity: match.identity,
+    };
+  }
+
+  return {
+    ...result,
+    status: 'manual_review',
+    verifiedConnect: false,
+    verificationStatus: match.status === 'same_name_wrong_identity'
+      ? 'wrong_identity_detected'
+      : 'unverified_after_connect',
+    verificationMethod: 'lead_list_readback',
+    intendedLeadIdentity: buildSalesNavigatorLeadIdentity(candidate),
+    readbackLeadIdentity: match.identity,
+    note: match.status === 'same_name_wrong_identity'
+      ? 'connect outcome unverified: same-name row has a different Sales Navigator lead identity'
+      : 'connect outcome unverified: target lead was not pending/connected in readback',
+  };
+}
+
+async function verifyConnectResult({ candidate, result, readSnapshot }) {
+  if (result?.status !== 'sent') {
+    return verifyConnectResultWithSnapshot({ candidate, result, snapshot: null });
+  }
+  if (typeof readSnapshot !== 'function') {
+    return {
+      ...result,
+      status: 'manual_review',
+      verifiedConnect: false,
+      verificationStatus: 'verification_unavailable',
+      verificationMethod: 'none',
+      intendedLeadIdentity: buildSalesNavigatorLeadIdentity(candidate),
+      note: 'connect outcome unverified: no durable readback verifier was available',
+    };
+  }
+  try {
+    return verifyConnectResultWithSnapshot({
+      candidate,
+      result,
+      snapshot: await readSnapshot(),
+    });
+  } catch (error) {
+    return {
+      ...result,
+      status: 'manual_review',
+      verifiedConnect: false,
+      verificationStatus: 'readback_failed',
+      verificationMethod: 'lead_list_readback',
+      intendedLeadIdentity: buildSalesNavigatorLeadIdentity(candidate),
+      note: `connect outcome unverified: readback failed: ${String(error.message || error)}`,
+    };
+  }
+}
+
+function summarizeConnectResults(results = [], unprocessed = 0) {
+  const count = (status) => results.filter((row) => row.status === status).length;
+  return {
+    attempted: results.length,
+    verifiedSent: results.filter((row) => row.status === 'sent' && row.verifiedConnect).length,
+    alreadyConnected: count('already_connected'),
+    alreadyPending: count('already_sent'),
+    unavailable: count('connect_unavailable'),
+    failed: count('failed'),
+    manualReviewUnverified: results.filter((row) => row.status === 'manual_review').length,
+    rateLimited: count('rate_limited'),
+    unprocessed,
+  };
+}
+
+module.exports = {
+  hasVerifiedConnectState,
+  summarizeConnectResults,
+  verifyConnectResult,
+  verifyConnectResultWithSnapshot,
+};

--- a/src/core/fast-list-import.js
+++ b/src/core/fast-list-import.js
@@ -32,6 +32,11 @@ const {
   timePhase,
 } = require('./speed-telemetry');
 const { isSalesNavigatorLeadUrl } = require('../lib/live-readiness');
+const {
+  buildSalesNavigatorLeadIdentity,
+  findSalesNavigatorLeadIdentityMatch,
+  normalizeSalesNavigatorLeadUrl,
+} = require('./sales-nav-identity');
 
 const FAST_IMPORT_ARTIFACTS_DIR = path.join(ARTIFACTS_DIR, 'fast-import');
 const LEARNED_LEAD_RESOLUTION_SUGGESTIONS_PATH = path.join(FAST_IMPORT_ARTIFACTS_DIR, 'learned-lead-resolution-suggestions.json');
@@ -1392,18 +1397,7 @@ function isMissingListCreationDisabledError(note) {
 }
 
 function normalizeLeadUrl(url) {
-  const raw = String(url || '').trim();
-  if (!raw) {
-    return '';
-  }
-  try {
-    const parsed = new URL(raw);
-    parsed.search = '';
-    parsed.hash = '';
-    return parsed.toString().replace(/\/$/, '');
-  } catch {
-    return raw.replace(/[?#].*$/, '').replace(/\/$/, '');
-  }
+  return normalizeSalesNavigatorLeadUrl(url);
 }
 
 function buildExistingLeadUrlSet(existingLeadUrls = []) {
@@ -1422,11 +1416,13 @@ async function saveFastListImport({
   stopOnRateLimit = true,
   wait = null,
   rateLimitBackoffMs = 0,
+  readLeadListSnapshot = null,
 } = {}) {
   const results = [];
   const listInfo = { listName: importPlan.listName, externalRef: null };
   const initialExistingLeadUrlSet = buildExistingLeadUrlSet(existingLeadUrls);
   const existingLeadUrlSet = new Set(initialExistingLeadUrlSet);
+  const attemptedLeadUrlSet = new Set();
   let rateLimitStop = null;
 
   if (!liveSave) {
@@ -1513,6 +1509,28 @@ async function saveFastListImport({
       continue;
     }
 
+    if (attemptedLeadUrlSet.has(normalizeLeadUrl(lead.salesNavigatorUrl))) {
+      const row = {
+        ...lead,
+        status: 'save_clicked_unverified',
+        saveRecoveryPath: 'in_run_duplicate_unverified',
+        failureCategory: 'save_unverified',
+        selectionMode: 'in_run_duplicate_unverified',
+        attempt: 0,
+        note: 'Skipped duplicate lead URL after an earlier unverified save attempt in this run.',
+        verificationStatus: 'unverified_duplicate_attempt',
+        verificationMethod: 'lead_list_readback',
+        verifiedSaved: false,
+        intendedLeadIdentity: buildSalesNavigatorLeadIdentity(lead),
+        nextAction: 'verify_list_membership_before_connect',
+      };
+      results.push(row);
+      if (typeof onProgress === 'function') {
+        onProgress(row);
+      }
+      continue;
+    }
+
     let attempt = 0;
     let saved = false;
     let lastNote = null;
@@ -1533,7 +1551,7 @@ async function saveFastListImport({
           { runId, accountKey: lead.accountName || 'fast-list-import', dryRun: false },
         );
         const normalizedSave = normalizeSaveResult(saveResult);
-        const row = {
+        let row = {
           ...lead,
           status: normalizedSave.status,
           saveRecoveryPath: normalizedSave.recoveryPath,
@@ -1541,9 +1559,19 @@ async function saveFastListImport({
           selectionMode: saveResult.selectionMode || null,
           attempt,
           note: saveResult.note || null,
+          intendedLeadIdentity: buildSalesNavigatorLeadIdentity(lead),
         };
+        row = await verifyFastListSaveRow({
+          row,
+          lead,
+          listName: importPlan.listName,
+          readLeadListSnapshot,
+        });
         results.push(row);
-        existingLeadUrlSet.add(normalizeLeadUrl(lead.salesNavigatorUrl));
+        if (row.verifiedSaved) {
+          existingLeadUrlSet.add(normalizeLeadUrl(lead.salesNavigatorUrl));
+        }
+        attemptedLeadUrlSet.add(normalizeLeadUrl(lead.salesNavigatorUrl));
         if (typeof onProgress === 'function') {
           onProgress(row);
         }
@@ -1609,6 +1637,76 @@ function normalizeSaveResult(saveResult = {}) {
   return { status: saveResult.status || 'saved', recoveryPath: saveResult.selectionMode || 'lead_page_save' };
 }
 
+async function verifyFastListSaveRow({
+  row,
+  lead,
+  listName,
+  readLeadListSnapshot,
+}) {
+  const base = {
+    ...row,
+    verifiedSaved: false,
+    verificationStatus: 'unverified',
+    verificationMethod: 'lead_list_readback',
+  };
+
+  if (typeof readLeadListSnapshot !== 'function') {
+    return {
+      ...base,
+      status: row.status === 'already_saved' ? 'already_saved' : 'save_clicked_unverified',
+      failureCategory: row.status === 'already_saved' ? null : 'save_unverified',
+      note: row.note || 'save clicked but no live list readback verifier was available',
+      nextAction: row.status === 'already_saved' ? undefined : 'verify_list_membership_before_connect',
+    };
+  }
+
+  let snapshot;
+  try {
+    snapshot = await readLeadListSnapshot(listName);
+  } catch (error) {
+    return {
+      ...base,
+      status: row.status === 'already_saved' ? 'already_saved' : 'save_clicked_unverified',
+      failureCategory: row.status === 'already_saved' ? null : 'save_readback_unavailable',
+      note: `save clicked but live list readback failed: ${String(error.message || error)}`,
+      nextAction: row.status === 'already_saved' ? undefined : 'verify_list_membership_before_connect',
+    };
+  }
+
+  const match = findSalesNavigatorLeadIdentityMatch(lead, snapshot?.rows || []);
+  if (match.status === 'matched') {
+    return {
+      ...base,
+      status: row.status === 'already_saved' ? 'already_saved_verified' : 'saved_and_verified',
+      verifiedSaved: true,
+      verificationStatus: 'verified',
+      readbackLeadIdentity: match.identity,
+      note: row.note || 'verified in target Sales Navigator list',
+    };
+  }
+
+  if (match.status === 'same_name_wrong_identity') {
+    return {
+      ...base,
+      status: 'wrong_identity_detected',
+      verificationStatus: 'wrong_identity_detected',
+      failureCategory: 'wrong_identity_detected',
+      readbackLeadIdentity: match.identity,
+      note: 'same-name row found in target list, but Sales Navigator lead identity does not match intended lead',
+      nextAction: 'manual_review_before_connect',
+    };
+  }
+
+  return {
+    ...base,
+    status: 'save_clicked_unverified',
+    verificationStatus: 'missing_after_save',
+    failureCategory: 'missing_after_save',
+    note: 'save clicked but intended Sales Navigator lead identity was missing from target list readback',
+    nextAction: 'retry_or_manual_review_list_membership',
+  };
+}
+
 function classifySaveFailure(note) {
   const message = String(note || '');
   if (/too many requests|rate.?limit|throttl|429|please wait before trying again|try again later/i.test(message)) {
@@ -1657,15 +1755,16 @@ function buildFastListImportResult(payload) {
   const failed = results.filter((row) => failedStatuses.has(row.status)).length;
   const unresolved = results.filter((row) => row.status === 'unresolved').length;
   const manualReview = results.filter((row) => row.status === 'manual_review').length;
+  const unverified = results.filter((row) => ['save_clicked_unverified', 'wrong_identity_detected'].includes(row.status)).length;
   const mutationReviewExcluded = results.filter((row) => row.saveRecoveryPath === 'mutation_review_exclusion').length;
-  const confirmedSaved = results.filter((row) => ['saved', 'results_row_fallback_saved'].includes(row.status)).length;
-  const alreadySaved = results.filter((row) => row.status === 'already_saved').length;
-  const snapshotSkipped = results.filter((row) => row.status === 'already_saved' && row.saveRecoveryPath === 'snapshot_preflight').length;
+  const confirmedSaved = results.filter((row) => row.status === 'saved_and_verified').length;
+  const alreadySaved = results.filter((row) => ['already_saved', 'already_saved_verified'].includes(row.status)).length;
+  const snapshotSkipped = results.filter((row) => ['already_saved', 'already_saved_verified'].includes(row.status) && row.saveRecoveryPath === 'snapshot_preflight').length;
   const rateLimitSkipped = results.filter((row) => row.status === 'skipped_rate_limit_cooldown').length;
   const failureBreakdown = summarizeSaveFailureBreakdown(results);
   return {
     ...payload,
-    status: failed || unresolved || manualReview || mutationReviewExcluded || rateLimitSkipped ? 'completed_with_followup' : 'completed',
+    status: failed || unresolved || manualReview || unverified || mutationReviewExcluded || rateLimitSkipped ? 'completed_with_followup' : 'completed',
     saved: confirmedSaved,
     confirmedSaved,
     alreadySaved,
@@ -1674,9 +1773,10 @@ function buildFastListImportResult(payload) {
     failed,
     unresolved,
     manualReview,
+    unverified,
     mutationReviewExcluded,
     failureBreakdown,
-    nextAction: deriveFastListImportNextAction({ failed, unresolved, manualReview, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }),
+    nextAction: deriveFastListImportNextAction({ failed, unresolved, manualReview, unverified, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }),
   };
 }
 
@@ -1687,6 +1787,10 @@ function summarizeSaveFailureBreakdown(results = []) {
         ? 'unresolved'
         : row.status === 'skipped_rate_limit_cooldown'
           ? 'rate_limit_cooldown'
+          : row.status === 'save_clicked_unverified'
+            ? (row.verificationStatus || 'save_unverified')
+            : row.status === 'wrong_identity_detected'
+              ? 'wrong_identity_detected'
           : null
     );
     if (!key) {
@@ -1697,9 +1801,12 @@ function summarizeSaveFailureBreakdown(results = []) {
   }, {});
 }
 
-function deriveFastListImportNextAction({ failed, unresolved, manualReview, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }) {
+function deriveFastListImportNextAction({ failed, unresolved, manualReview, unverified, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }) {
   if (failureBreakdown?.rate_limit || rateLimitSkipped) {
     return 'wait_10_min_and_retry_failed';
+  }
+  if (unverified || failureBreakdown?.missing_after_save || failureBreakdown?.wrong_identity_detected) {
+    return 'verify_list_membership_before_connect';
   }
   if (failureBreakdown?.runtime_failure) {
     return 'rebootstrap_session_then_retry_failed';
@@ -2065,6 +2172,7 @@ module.exports = {
   inferFullNameFromLinkedInSlug,
   isRetryableSaveError,
   normalizeSaveResult,
+  verifyFastListSaveRow,
   loadCoverageImportPlan,
   loadCoverageLeadIndex,
   loadFastListImportSource,

--- a/src/core/lead-list-snapshot.js
+++ b/src/core/lead-list-snapshot.js
@@ -2,12 +2,15 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { readJson } = require('../lib/json');
 const { resolveProjectPath } = require('../lib/paths');
+const {
+  buildSalesNavigatorLeadIdentity,
+  normalizeSalesNavigatorLeadUrl,
+} = require('./sales-nav-identity');
 
 const ACCOUNT_BATCH_ARTIFACTS_DIR = resolveProjectPath('runtime/artifacts/account-batches');
 const CONFIRMED_SAVED_STATUSES = new Set([
-  'saved',
-  'already_saved',
-  'results_row_fallback_saved',
+  'saved_and_verified',
+  'already_saved_verified',
 ]);
 
 function normalizeLeadListName(value) {
@@ -63,7 +66,7 @@ function buildLeadListSnapshotFromArtifact(artifact, { listName = null, artifact
   const seen = new Set();
   const rows = [];
   for (const row of sourceRows) {
-    const salesNavigatorUrl = row.salesNavigatorUrl || row.profileUrl || row.candidate?.salesNavigatorUrl || null;
+    const salesNavigatorUrl = normalizeSalesNavigatorLeadUrl(row.salesNavigatorUrl || row.profileUrl || row.candidate?.salesNavigatorUrl || null);
     const fullName = row.fullName || row.name || row.candidate?.fullName || null;
     if (!fullName || !salesNavigatorUrl || !/linkedin\.com\/sales\/lead\//i.test(salesNavigatorUrl)) {
       continue;
@@ -77,6 +80,11 @@ function buildLeadListSnapshotFromArtifact(artifact, { listName = null, artifact
     rows.push({
       fullName,
       salesNavigatorUrl,
+      ...buildSalesNavigatorLeadIdentity({
+        ...row,
+        salesNavigatorUrl,
+        fullName,
+      }),
       rowText: [fullName, row.title, row.accountName, row.status, row.note].filter(Boolean).join(' | '),
       invitationSent: /already_sent|invitation sent|connection sent|sent/i.test(statusText),
       connectionSent: /already_connected|connected|vernetzt/i.test(statusText),

--- a/src/core/sales-nav-identity.js
+++ b/src/core/sales-nav-identity.js
@@ -1,0 +1,97 @@
+function normalizeSalesNavigatorLeadUrl(url) {
+  const raw = String(url || '').trim();
+  if (!raw) {
+    return '';
+  }
+  try {
+    const parsed = new URL(raw);
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return raw.replace(/[?#].*$/, '').replace(/\/$/, '');
+  }
+}
+
+function extractSalesNavigatorLeadId(url) {
+  const normalized = normalizeSalesNavigatorLeadUrl(url);
+  const match = normalized.match(/\/sales\/lead\/([^/?#]+)/i);
+  if (!match) {
+    return '';
+  }
+  return decodeURIComponent(match[1]).split(',')[0].trim();
+}
+
+function normalizeIdentityName(value) {
+  return String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function buildSalesNavigatorLeadIdentity(value = {}) {
+  const salesNavigatorUrl = normalizeSalesNavigatorLeadUrl(
+    value.salesNavigatorUrl
+      || value.profileUrl
+      || value.url
+      || value.candidate?.salesNavigatorUrl
+      || '',
+  );
+  return {
+    salesNavigatorUrl,
+    salesNavigatorLeadId: value.salesNavigatorLeadId
+      || value.leadId
+      || value.entityUrn
+      || extractSalesNavigatorLeadId(salesNavigatorUrl),
+    fullName: value.fullName || value.name || value.candidate?.fullName || '',
+    title: value.title || value.headline || value.candidate?.title || '',
+    accountName: value.accountName || value.company || value.candidate?.accountName || '',
+  };
+}
+
+function salesNavigatorLeadIdentitiesMatch(left = {}, right = {}) {
+  const leftIdentity = buildSalesNavigatorLeadIdentity(left);
+  const rightIdentity = buildSalesNavigatorLeadIdentity(right);
+  if (leftIdentity.salesNavigatorLeadId && rightIdentity.salesNavigatorLeadId) {
+    return leftIdentity.salesNavigatorLeadId === rightIdentity.salesNavigatorLeadId;
+  }
+  return Boolean(
+    leftIdentity.salesNavigatorUrl
+      && rightIdentity.salesNavigatorUrl
+      && leftIdentity.salesNavigatorUrl === rightIdentity.salesNavigatorUrl,
+  );
+}
+
+function findSalesNavigatorLeadIdentityMatch(target = {}, rows = []) {
+  const sameIdentity = (rows || []).find((row) => salesNavigatorLeadIdentitiesMatch(target, row));
+  if (sameIdentity) {
+    return {
+      status: 'matched',
+      row: sameIdentity,
+      identity: buildSalesNavigatorLeadIdentity(sameIdentity),
+    };
+  }
+
+  const targetName = normalizeIdentityName(target.fullName || target.name);
+  const sameName = targetName
+    ? (rows || []).find((row) => normalizeIdentityName(row.fullName || row.name) === targetName)
+    : null;
+  if (sameName) {
+    return {
+      status: 'same_name_wrong_identity',
+      row: sameName,
+      identity: buildSalesNavigatorLeadIdentity(sameName),
+    };
+  }
+
+  return {
+    status: 'missing',
+    row: null,
+    identity: null,
+  };
+}
+
+module.exports = {
+  buildSalesNavigatorLeadIdentity,
+  extractSalesNavigatorLeadId,
+  findSalesNavigatorLeadIdentityMatch,
+  normalizeSalesNavigatorLeadUrl,
+  salesNavigatorLeadIdentitiesMatch,
+};

--- a/tests/connect-executor.test.js
+++ b/tests/connect-executor.test.js
@@ -1,0 +1,198 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { sendApprovedConnects } = require('../src/core/connect-executor');
+
+function createRepository(approvals) {
+  const events = [];
+  const approvalUpdates = [];
+  return {
+    events,
+    approvalUpdates,
+    getBudgetState() {
+      return { weeklyCap: 70, weekCount: 0, dayCount: 0 };
+    },
+    getPendingApprovals(limit) {
+      return approvals.slice(0, limit);
+    },
+    hasSentConnect() {
+      return false;
+    },
+    insertConnectEvent(candidateId, approvalId, action, status, details) {
+      events.push({ candidateId, approvalId, action, status, details });
+    },
+    updateApprovalState(approvalId, state, note) {
+      approvalUpdates.push({ approvalId, state, note });
+    },
+    insertRecoveryEvent() {},
+  };
+}
+
+test('sendApprovedConnects counts sent only after durable verifier confirms pending invitation', async () => {
+  const approval = {
+    approvalId: 'a1',
+    candidateId: 'c1',
+    fullName: 'Verified Lead',
+    salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/verified-id',
+  };
+  const repository = createRepository([approval]);
+  const driver = {
+    async sendConnect() {
+      return { status: 'sent', note: 'ui clicked send' };
+    },
+    async verifyConnectOutcome() {
+      return {
+        rows: [{
+          fullName: 'Verified Lead',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/verified-id',
+          pendingInvitation: true,
+        }],
+      };
+    },
+  };
+
+  const result = await sendApprovedConnects({
+    repository,
+    driver,
+    runContext: { weeklyCap: 140 },
+  });
+
+  assert.equal(result.sent, 1);
+  assert.equal(result.summary.verifiedSent, 1);
+  assert.equal(result.results[0].status, 'sent');
+  assert.equal(result.results[0].verifiedConnect, true);
+  assert.equal(repository.approvalUpdates[0].state, 'sent');
+});
+
+test('sendApprovedConnects fails closed when sent UI cannot be verified', async () => {
+  const approvals = [
+    {
+      approvalId: 'a1',
+      candidateId: 'c1',
+      fullName: 'Unverified Lead',
+      salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/unverified-id',
+    },
+    {
+      approvalId: 'a2',
+      candidateId: 'c2',
+      fullName: 'Unprocessed Lead',
+      salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/unprocessed-id',
+    },
+  ];
+  const repository = createRepository(approvals);
+  let sends = 0;
+  const driver = {
+    async sendConnect() {
+      sends += 1;
+      return { status: 'sent', note: 'ui clicked send' };
+    },
+    async verifyConnectOutcome() {
+      return {
+        rows: [{
+          fullName: 'Unverified Lead',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/unverified-id',
+          pendingInvitation: false,
+        }],
+      };
+    },
+  };
+
+  const result = await sendApprovedConnects({
+    repository,
+    driver,
+    runContext: { weeklyCap: 140 },
+  });
+
+  assert.equal(sends, 1);
+  assert.equal(result.sent, 0);
+  assert.equal(result.processed, 1);
+  assert.equal(result.unprocessed, 1);
+  assert.equal(result.reason, 'stopped_unverified_connect');
+  assert.equal(result.results[0].status, 'manual_review');
+  assert.equal(result.summary.manualReviewUnverified, 1);
+  assert.equal(repository.approvalUpdates[0].state, 'approved');
+});
+
+test('sendApprovedConnects override continues after unverified manual review without counting it as sent', async () => {
+  const approvals = [
+    {
+      approvalId: 'a1',
+      candidateId: 'c1',
+      fullName: 'Unverified Lead',
+      salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/unverified-id',
+    },
+    {
+      approvalId: 'a2',
+      candidateId: 'c2',
+      fullName: 'Verified Lead',
+      salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/verified-id',
+    },
+  ];
+  const repository = createRepository(approvals);
+  const driver = {
+    async sendConnect(approval) {
+      return { status: 'sent', note: `ui clicked send for ${approval.fullName}` };
+    },
+    async verifyConnectOutcome(approval) {
+      return {
+        rows: [{
+          fullName: approval.fullName,
+          salesNavigatorUrl: approval.salesNavigatorUrl,
+          pendingInvitation: approval.fullName === 'Verified Lead',
+        }],
+      };
+    },
+  };
+
+  const result = await sendApprovedConnects({
+    repository,
+    driver,
+    runContext: {
+      weeklyCap: 140,
+      allowUnverifiedConnectContinue: true,
+    },
+  });
+
+  assert.equal(result.reason, 'completed');
+  assert.equal(result.processed, 2);
+  assert.equal(result.sent, 1);
+  assert.deepEqual(result.results.map((row) => row.status), ['manual_review', 'sent']);
+});
+
+test('sendApprovedConnects separates rate-limit stops from manual review', async () => {
+  const approvals = [
+    {
+      approvalId: 'a1',
+      candidateId: 'c1',
+      fullName: 'Rate Limited Lead',
+      salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/rate-limited-id',
+    },
+    {
+      approvalId: 'a2',
+      candidateId: 'c2',
+      fullName: 'Unprocessed Lead',
+      salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/unprocessed-id',
+    },
+  ];
+  const repository = createRepository(approvals);
+  const driver = {
+    async sendConnect() {
+      return {
+        status: 'rate_limited',
+        note: 'LinkedIn showed too many requests',
+        rateLimit: { matchedSignal: 'too many requests' },
+      };
+    },
+  };
+
+  const result = await sendApprovedConnects({
+    repository,
+    driver,
+    runContext: { weeklyCap: 140 },
+  });
+
+  assert.equal(result.reason, 'stopped_rate_limit_signal');
+  assert.equal(result.unprocessed, 1);
+  assert.equal(result.summary.rateLimited, 1);
+  assert.equal(result.results[0].rateLimit.matchedSignal, 'too many requests');
+});

--- a/tests/fast-list-import.test.js
+++ b/tests/fast-list-import.test.js
@@ -401,6 +401,12 @@ test('saveFastListImport retries lead-detail render failures once', async () => 
     driver,
     liveSave: true,
     maxRetries: 1,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -417,7 +423,74 @@ test('saveFastListImport retries lead-detail render failures once', async () => 
   assert.equal(attempts, 2);
   assert.equal(result.status, 'completed');
   assert.equal(result.saved, 1);
+  assert.equal(result.results[0].status, 'saved_and_verified');
   assert.equal(result.results[0].attempt, 2);
+});
+
+test('saveFastListImport downgrades click-only saves when no live readback verifier is available', async () => {
+  const result = await saveFastListImport({
+    driver: {
+      async saveCandidateToList() {
+        return { status: 'saved', selectionMode: 'existing_list' };
+      },
+    },
+    liveSave: true,
+    maxRetries: 0,
+    importPlan: {
+      listName: 'Calling List',
+      leads: [
+        {
+          accountName: 'Example Network Co',
+          fullName: 'Nora Platform',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+          resolutionStatus: 'resolved',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 'completed_with_followup');
+  assert.equal(result.confirmedSaved, 0);
+  assert.equal(result.unverified, 1);
+  assert.equal(result.results[0].status, 'save_clicked_unverified');
+  assert.equal(result.results[0].verifiedSaved, false);
+});
+
+test('saveFastListImport flags same-name wrong-identity readback', async () => {
+  const result = await saveFastListImport({
+    driver: {
+      async saveCandidateToList() {
+        return { status: 'saved', selectionMode: 'results_row_fallback' };
+      },
+    },
+    liveSave: true,
+    maxRetries: 0,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Patryk Szymczak',
+        title: 'Co-Founder',
+        accountName: 'Ci Labs',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/wrong-id',
+      }],
+    }),
+    importPlan: {
+      listName: 'Calling List',
+      leads: [
+        {
+          accountName: 'Riverty',
+          fullName: 'Patryk Szymczak',
+          title: 'IT Infrastructure Expert',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/intended-id',
+          resolutionStatus: 'resolved',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 'completed_with_followup');
+  assert.equal(result.confirmedSaved, 0);
+  assert.equal(result.results[0].status, 'wrong_identity_detected');
+  assert.equal(result.results[0].verificationStatus, 'wrong_identity_detected');
 });
 
 test('saveFastListImport leaves unresolved rows out of live mutation', async () => {
@@ -429,6 +502,12 @@ test('saveFastListImport leaves unresolved rows out of live mutation', async () 
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -490,6 +569,12 @@ test('saveFastListImport does not save mutation-review excluded rows', async () 
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -522,6 +607,12 @@ test('saveFastListImport marks non-manual mutation-review exclusions as follow-u
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -554,6 +645,12 @@ test('saveFastListImport skips duplicate Sales Navigator URLs after the first li
       },
     },
     liveSave: true,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     importPlan: {
       listName: 'Calling List',
       leads: [
@@ -599,6 +696,12 @@ test('saveFastListImport stops after rate-limit failure instead of burning remai
     liveSave: true,
     maxRetries: 0,
     rateLimitBackoffMs: 250,
+    readLeadListSnapshot: async () => ({
+      rows: [{
+        fullName: 'Nora Platform',
+        salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+      }],
+    }),
     wait(ms) {
       waitedMs += ms;
     },
@@ -632,7 +735,7 @@ test('saveFastListImport stops after rate-limit failure instead of burning remai
 
   assert.equal(attempts, 2);
   assert.equal(waitedMs, 250);
-  assert.deepEqual(progress, ['saved', 'failed_rate_limit', 'skipped_rate_limit_cooldown']);
+  assert.deepEqual(progress, ['saved_and_verified', 'failed_rate_limit', 'skipped_rate_limit_cooldown']);
   assert.equal(result.status, 'completed_with_followup');
   assert.equal(result.failed, 1);
   assert.equal(result.rateLimitSkipped, 1);

--- a/tests/lead-list-snapshot.test.js
+++ b/tests/lead-list-snapshot.test.js
@@ -19,17 +19,17 @@ test('buildLeadListSnapshotFromArtifact converts fast-import artifacts into conn
         title: 'Senior Platform Owner',
         accountName: 'Example Semiconductor Co',
         salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
-        status: 'saved',
+        status: 'saved_and_verified',
       },
       {
         fullName: 'Duplicate Example Saved Lead',
         salesNavigatorUrl: 'https://www.linkedin.com/in/not-sales-nav',
-        status: 'saved',
+        status: 'saved_and_verified',
       },
       {
         fullName: 'Example Pending Lead',
         salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/456',
-        status: 'already_saved',
+        status: 'already_saved_verified',
         note: 'already saved before run',
       },
     ],
@@ -69,7 +69,7 @@ test('buildLeadListSnapshotFromArtifact ignores explicit failed import result ro
       {
         fullName: 'Saved Lead',
         salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/saved',
-        status: 'saved',
+        status: 'saved_and_verified',
       },
       {
         fullName: 'Manual Review Lead',


### PR DESCRIPTION
## Summary
- add connect verification helpers that only count `sent` after durable readback confirms the same lead is pending/connected
- make approved-connect execution fail closed on unverified outcomes by default
- add `--allow-unverified-connect-continue` as an explicit supervised override that never reclassifies unverified rows as sent
- separate rate-limit stops from manual-review/unavailable outcomes in connect summaries

Closes #37 after #40 is merged.

## Tests
- npm test -- tests/connect-executor.test.js tests/connect-fallback.test.js tests/playwright-driver.test.js tests/account-batch.test.js
- npm test -- tests/fast-list-import.test.js tests/playwright-driver.test.js tests/lead-list-snapshot.test.js tests/account-batch.test.js tests/connect-executor.test.js
- npm run test:release-readiness
- npm test
- git diff --check
