### PR TITLE
Add SDR research entrypoint and transparent found/saved reporting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,17 +39,27 @@ Wait for confirmation before continuing.
 
 ### Step 2 — Run account coverage
 
-**Always use `account-coverage`, never `test-account-search`.**
+**For normal SDR requests, use `sdr-research`, never `test-account-search`.**
 
 `test-account-search` is a setup smoke-test capped at 5 results. It is not for SDR use. `account-coverage` runs 21 keyword sweeps per account and returns 30-60 qualified leads.
 
-Run accounts sequentially — they share the same browser profile and will conflict in parallel:
+Run the friendly SDR wrapper first. It keeps the persistent browser session, researches accounts sequentially, and can create one Sales Navigator list when live-save is explicitly requested:
 
 ```bash
-npm run account-coverage -- --account-name="Account Name" --driver=playwright
+npm run sdr-research -- --accounts="Account A, Account B, Account C" --driver=playwright
 ```
 
-While each account runs, tell the SDR what's happening in plain language:
+If the SDR asked for a Sales Navigator list, add `--live-save` and let the command create the list:
+
+```bash
+npm run sdr-research -- \
+  --accounts="Account A, Account B, Account C" \
+  --list-name="SDR Research - Account A Account B Account C" \
+  --driver=playwright \
+  --live-save
+```
+
+While it runs, tell the SDR what's happening in plain language:
 
 - "Searching for contacts at [Account]..."
 - "Found [N] contacts at [Account]. Moving on to [next account]..."
@@ -59,28 +69,19 @@ Never show raw CLI output, sweep names, bucket names, or internal flags.
 
 ### Step 3 — Create the Sales Navigator list
 
-When an SDR asks for a "LinkedIn list", "Sales Nav list", or says "add them to a list" — always create it live in the browser. Showing a table in chat is not the deliverable.
+When an SDR asks for a "LinkedIn list", "Sales Nav list", or says "add them to a list" — use `sdr-research --live-save`. Showing a table in chat is not the deliverable.
 
 Derive the list name automatically from SDR name + accounts + date if not specified. Never ask for the list name unless genuinely unclear.
 
-Always include `--allow-list-create` — do not wait for the list to exist first:
-
-```bash
-npm run import-coverage -- \
-  --accounts="account-slug-a,account-slug-b,account-slug-c" \
-  --list-name="[SDR Name] - [Account A] / [Account B] / [Account C]" \
-  --driver=playwright \
-  --live-save \
-  --allow-list-create
-```
-
-Account slugs are the lowercase, hyphenated versions of the account names (e.g. "Thales Group" → `thales-group`).
+`sdr-research` sets the safe list-create flag automatically when `--live-save` is present. Do not use connect flags with this command; it rejects them by design.
 
 ### Step 4 — Close with a clear next step
 
 After the list is created, tell the SDR:
 
 - How many contacts were saved and across which accounts
+- How many strong contacts were found but not auto-saved, and why
+- Whether any account needs company-scope review
 - That the list is now live in Sales Navigator under the exact name used
 - Which contacts to start with — the `direct_observability` bucket first (DevOps leads, Platform Engineers, Infrastructure Architects)
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ Print the current release contract:
 npm run print-mvp-release-contract
 ```
 
+## SDR Quick Action
+
+For day-to-day SDR testing, start here. Give the tool three to five accounts and let it research, explain the result, and optionally create the Sales Navigator list.
+
+Dry-safe research:
+
+```bash
+npm run sdr-research -- --accounts="Thales Group, Skello, Oodrive"
+```
+
+Research and create/update one Sales Navigator list:
+
+```bash
+npm run sdr-research -- \
+  --accounts="Thales Group, Skello, Oodrive" \
+  --list-name="SDR Research - Thales Skello Oodrive" \
+  --live-save
+```
+
+This command never sends connection invitations. It uses the persistent browser session, creates the list only when `--live-save` is explicit, and reports what was found, saved, not saved, and what needs review.
+
 ## Environment Setup
 
 Create a local `.env` from `.env.example` if you need live integrations:
@@ -134,6 +155,8 @@ npm run run-background-territory-loop -- --driver=playwright --limit=1
 ```
 
 ### Research Several Accounts Into One List
+
+For SDRs, prefer `npm run sdr-research`. Use the lower-level batch command only when you need advanced options.
 
 Use `--consolidate-list-name` when you want one shared Sales Navigator list instead of one list per account:
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "autoresearch:gate": "node src/cli.js print-autoresearch-gate",
     "autoresearch:supervisor": "node src/cli.js print-autoresearch-supervisor",
     "autoresearch:speed": "node src/cli.js autoresearch-speed-eval",
+    "sdr-research": "node src/cli.js sdr-research",
     "parallel-account-research": "node src/cli.js parallel-account-research",
     "parallel-research:stress": "node automation/parallel-research-stress.js",
     "parallel-research:stack-readiness": "node automation/parallel-research-stack-readiness.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,6 +21,7 @@ const {
   writePriorityModelArtifact,
 } = require('./core/priority-score');
 const {
+  annotateCoverageCandidatesForListSelection,
   loadAccountCoverageConfig,
   buildSweepTemplates,
   loadPriorityModel,
@@ -62,12 +63,18 @@ const {
 const {
   applyGeoFocusToCandidates,
   buildAccountBatchListName,
+  deriveSdrCoverageStatus,
   limitBatchCandidates,
   parseAccountNames,
   renderAccountBatchListNameTemplate,
+  summarizeSdrResearchOutcome,
   writeAccountBatchArtifact,
   writeAccountBatchReport,
 } = require('./core/account-batch');
+const {
+  buildSdrResearchBatchValues,
+  renderSdrResearchIntro,
+} = require('./core/sdr-workflow');
 const {
   attachSweepCacheState,
   buildResearchPipelineArtifact,
@@ -289,6 +296,9 @@ async function main() {
         break;
       case 'run-account-batch':
         await handleRunAccountBatch(getRepository(), values, logger);
+        break;
+      case 'sdr-research':
+        await handleSdrResearch(getRepository(), values, logger);
         break;
       case 'pilot-live-save-batch':
         await handlePilotLiveSaveBatch(values, logger);
@@ -3371,11 +3381,28 @@ async function handleRunAccountBatch(repository, values, logger) {
         },
       });
       const coverageArtifactPath = writeAccountCoverageArtifact(accountName, coverageRun.result);
+      const selectionOptions = {
+        reportOnlyOutOfNetwork: getBoolean(values, 'reportOnlyOutOfNetwork', 'report-only-out-of-network'),
+      };
+      const annotatedCoverageCandidates = annotateCoverageCandidatesForListSelection(coverageRun.result, selectionOptions);
       const listCandidates = applyGeoFocusToCandidates(
-        selectCoverageListCandidates(coverageRun.result),
+        annotatedCoverageCandidates.filter((candidate) => candidate.selectedForList),
         pilotConfig?.geoFocus || null,
       );
       const selectedForListSave = limitBatchCandidates(listCandidates, maxListSavesPerAccount);
+      const selectedForListSaveKeys = new Set(selectedForListSave.map(buildCandidateReportKey));
+      const notSavedReasonCounts = {};
+      for (const candidate of annotatedCoverageCandidates) {
+        if (!candidate.selectedForList) {
+          incrementReasonCount(notSavedReasonCounts, candidate.listSelectionReason);
+        } else if (liveSave && !selectedForListSaveKeys.has(buildCandidateReportKey(candidate))) {
+          incrementReasonCount(notSavedReasonCounts, 'not_selected_due_to_batch_cap');
+        }
+      }
+      const strongButNotAutoSavedCandidates = annotatedCoverageCandidates
+        .filter((candidate) => candidate.listSelectionReason === 'strong_but_not_auto_saved')
+        .slice(0, 10)
+        .map((candidate) => toSdrReportCandidate(candidate));
       const saveResults = [];
       const connectResults = [];
 
@@ -3397,12 +3424,14 @@ async function handleRunAccountBatch(repository, values, logger) {
               fullName: candidate.fullName,
               status: saveResult.status,
               note: saveResult.note || null,
+              title: candidate.title || null,
             });
           } catch (error) {
             saveResults.push({
               fullName: candidate.fullName,
               status: 'failed',
               note: summarizeErrorMessage(error.message),
+              title: candidate.title || null,
             });
           }
         }
@@ -3495,8 +3524,29 @@ async function handleRunAccountBatch(repository, values, logger) {
         listName,
         coverageArtifactPath,
         candidateCount: coverageRun.result.candidateCount,
+        resolutionStatus: coverageRun.result.resolutionStatus || null,
+        attemptedSweepsCount: coverageRun.templates.length,
+        failedSweepsCount: coverageRun.sweepErrors.length,
+        coverageStatus: deriveSdrCoverageStatus({
+          attemptedSweepsCount: coverageRun.templates.length,
+          failedSweepsCount: coverageRun.sweepErrors.length,
+          resolutionStatus: coverageRun.result.resolutionStatus || null,
+        }),
         listCandidateCount: listCandidates.length,
         selectedForListSaveCount: selectedForListSave.length,
+        strongButNotAutoSavedCount: strongButNotAutoSavedCandidates.length,
+        strongButNotAutoSavedCandidates,
+        notSavedReasonCounts,
+        sdrSummary: summarizeSdrResearchOutcome({
+          candidateCount: coverageRun.result.candidateCount,
+          listCandidateCount: listCandidates.length,
+          selectedForListSaveCount: selectedForListSave.length,
+          strongButNotAutoSavedCount: strongButNotAutoSavedCandidates.length,
+          attemptedSweepsCount: coverageRun.templates.length,
+          failedSweepsCount: coverageRun.sweepErrors.length,
+          resolutionStatus: coverageRun.result.resolutionStatus || null,
+          saveResults,
+        }),
         saveResults,
         connectResults,
       });
@@ -3534,6 +3584,42 @@ async function handleRunAccountBatch(repository, values, logger) {
   } finally {
     await driver.close().catch(() => {});
   }
+}
+
+async function handleSdrResearch(repository, values, logger) {
+  const startedAt = new Date().toISOString();
+  const batchValues = buildSdrResearchBatchValues(values, { startedAt });
+  const accountNames = parseAccountNames(batchValues['account-names']);
+  logger.info(renderSdrResearchIntro({
+    accountNames,
+    listName: batchValues['consolidate-list-name'],
+    liveSave: getBoolean(batchValues, 'liveSave', 'live-save'),
+    researchMode: getString(batchValues, 'research-mode') || 'persona-led',
+    speedProfile: getString(batchValues, 'speed-profile') || 'balanced',
+  }).trim());
+  await handleRunAccountBatch(repository, batchValues, logger);
+}
+
+function buildCandidateReportKey(candidate = {}) {
+  return String(candidate.salesNavigatorUrl || candidate.profileUrl || `${candidate.fullName || ''}|${candidate.title || ''}`)
+    .trim()
+    .toLowerCase();
+}
+
+function incrementReasonCount(counts, reason) {
+  const key = reason || 'not_selected';
+  counts[key] = (counts[key] || 0) + 1;
+}
+
+function toSdrReportCandidate(candidate, nextAction = 'review_strong_not_saved') {
+  return {
+    fullName: candidate.fullName || 'Unknown lead',
+    title: candidate.title || null,
+    coverageBucket: candidate.coverageBucket || null,
+    reason: candidate.listSelectionReason || null,
+    nextAction,
+    salesNavigatorUrl: candidate.salesNavigatorUrl || candidate.profileUrl || null,
+  };
 }
 
 async function handlePilotLiveSaveBatch(values, logger) {
@@ -3996,6 +4082,7 @@ Usage:
   node src/cli.js print-autoresearch-supervisor [--artifact=runtime/artifacts/autoresearch/mvp-autoresearch.json]
   node src/cli.js autoresearch-speed-eval --baseline=runtime/artifacts/autoresearch/baseline.json --candidate=runtime/artifacts/autoresearch/candidate.json [--min-speedup-percent=25]
   node src/cli.js parallel-account-research --accounts="Account A, Account B" [--research-mode=persona-led|exhaustive|keyword] [--local-concurrency=4] [--coverage-config=config/account-coverage/default.json] [--run-id=my-run]
+  node src/cli.js sdr-research --accounts="Account A, Account B, Account C" [--list-name="SDR Research List"] [--driver=playwright] [--exhaustive] [--live-save]
   node src/cli.js run-account-batch --account-names="Account A, Account B, Account C" [--driver=playwright|hybrid] [--list-prefix="MVP"] [--consolidate-list-name="Research List"] [--list-name-template="Research {date} {start_time} ({accounts})"] [--adaptive-sweep-pruning] [--live-save] [--live-connect] [--allow-unverified-connect-continue]
   node src/cli.js pilot-live-save-batch --account-names="Account A,Account B" [--driver=playwright] [--list-prefix="Pilot"] [--max-list-saves-per-account=3]
   node src/cli.js pilot-connect-batch --account-names="Example Connect Eligible Account" [--driver=playwright] [--pilot-config=config/pilot/default.json] [--list-prefix="Pilot"] [--max-connects-per-account=1] --live-connect [--allow-unverified-connect-continue]

--- a/src/core/account-batch.js
+++ b/src/core/account-batch.js
@@ -182,6 +182,73 @@ function summarizeBatchResult(result) {
   };
 }
 
+function deriveSdrCoverageStatus({
+  attemptedSweepsCount = 0,
+  failedSweepsCount = 0,
+  resolutionStatus = null,
+} = {}) {
+  if (resolutionStatus === 'needs_company_resolution') {
+    return 'needs_company_scope_review';
+  }
+  const attempted = Number(attemptedSweepsCount || 0);
+  const failed = Number(failedSweepsCount || 0);
+  if (attempted > 0 && failed >= attempted) {
+    return 'needs_company_scope_review';
+  }
+  if (attempted > 0 && failed / attempted >= 0.3) {
+    return 'needs_company_scope_review';
+  }
+  if (failed > 0) {
+    return 'completed_with_sweep_warnings';
+  }
+  return 'completed';
+}
+
+function summarizeSdrResearchOutcome(result = {}) {
+  const saveResults = result.saveResults
+    || (result.status ? [{ fullName: result.fullName || 'Unknown lead', status: result.status, note: result.note || null }] : []);
+  const verifiedSaveStatuses = new Set(['saved_and_verified', 'already_saved_verified']);
+  const clickedUnverifiedStatuses = new Set(['saved', 'already_saved', 'results_row_fallback_saved', 'save_clicked_unverified']);
+  const failedSaveStatuses = new Set(['failed', 'failed_runtime', 'failed_rate_limit', 'failed_network', 'failed_ui_state', 'missing_after_save', 'wrong_identity_detected']);
+  const manualReviewStatuses = new Set(['manual_review', 'save_ui_manual_review']);
+  const coverageStatus = result.coverageStatus || deriveSdrCoverageStatus({
+    attemptedSweepsCount: result.attemptedSweepsCount,
+    failedSweepsCount: result.failedSweepsCount,
+    resolutionStatus: result.resolutionStatus,
+  });
+  const summary = {
+    found: Number(result.candidateCount || 0),
+    selectedForList: Number(result.listCandidateCount || 0),
+    selectedForLiveSave: Number(result.selectedForListSaveCount || 0),
+    savedVerified: saveResults.filter((item) => verifiedSaveStatuses.has(item.status)).length,
+    saveClickedUnverified: saveResults.filter((item) => clickedUnverifiedStatuses.has(item.status)).length,
+    failedSave: saveResults.filter((item) => failedSaveStatuses.has(item.status)).length,
+    manualReview: saveResults.filter((item) => manualReviewStatuses.has(item.status)).length,
+    strongButNotAutoSaved: Number(result.strongButNotAutoSavedCount || 0),
+    notAutoSaved: Math.max(0, Number(result.candidateCount || 0) - Number(result.listCandidateCount || 0)),
+    attemptedSweeps: Number(result.attemptedSweepsCount || 0),
+    failedSweeps: Number(result.failedSweepsCount || 0),
+    coverageStatus,
+    nextActions: [],
+  };
+  if (summary.coverageStatus === 'needs_company_scope_review') {
+    summary.nextActions.push('retry_company_scope');
+  }
+  if (summary.strongButNotAutoSaved > 0) {
+    summary.nextActions.push('review_strong_not_saved');
+  }
+  if (summary.saveClickedUnverified > 0) {
+    summary.nextActions.push('verify_list_membership');
+  }
+  if (summary.failedSave > 0 || summary.manualReview > 0) {
+    summary.nextActions.push('manual_review');
+  }
+  if (summary.nextActions.length === 0) {
+    summary.nextActions.push('no_action');
+  }
+  return summary;
+}
+
 function deriveConnectOperatorGuidance(item = {}) {
   const status = String(item.status || '').trim().toLowerCase();
   const note = String(item.note || '').trim().toLowerCase();
@@ -285,6 +352,7 @@ function renderAccountBatchReportMarkdown(payload) {
 
   for (const result of payload.results || []) {
     const summary = summarizeBatchResult(result);
+    const sdrSummary = result.sdrSummary || summarizeSdrResearchOutcome(result);
     lines.push(`## ${result.accountName}`);
     lines.push(`- List: \`${result.listName}\``);
     if (result.coverageArtifactPath) {
@@ -299,6 +367,12 @@ function renderAccountBatchReportMarkdown(payload) {
     if (result.selectedForListSaveCount !== undefined) {
       lines.push(`- Selected for live save: \`${result.selectedForListSaveCount}\``);
     }
+    lines.push(`- SDR summary: found=\`${sdrSummary.found}\` | selected=\`${sdrSummary.selectedForList}\` | saved_verified=\`${sdrSummary.savedVerified}\` | save_unverified=\`${sdrSummary.saveClickedUnverified}\` | failed_save=\`${sdrSummary.failedSave}\` | manual_review=\`${sdrSummary.manualReview}\` | not_auto_saved=\`${sdrSummary.notAutoSaved}\``);
+    lines.push(`- Coverage status: \`${sdrSummary.coverageStatus}\``);
+    if (sdrSummary.attemptedSweeps > 0) {
+      lines.push(`- Sweeps: \`${sdrSummary.attemptedSweeps - sdrSummary.failedSweeps}/${sdrSummary.attemptedSweeps} succeeded\``);
+    }
+    lines.push(`- Next action: \`${(sdrSummary.nextActions || ['no_action']).join(', ')}\``);
     lines.push(`- Save success: \`${summary.saveSuccessCount}\``);
     lines.push(`- Save failed: \`${summary.saveFailureCount}\``);
     if (summary.connectAttemptCount > 0) {
@@ -367,6 +441,35 @@ function renderAccountBatchReportMarkdown(payload) {
       }
       lines.push('');
     }
+
+    const strongNotSaved = (result.strongButNotAutoSavedCandidates || []).slice(0, 10);
+    if (strongNotSaved.length > 0) {
+      lines.push(`### Strong but not auto-saved`);
+      for (const item of strongNotSaved) {
+        const noteParts = [];
+        if (item.title) {
+          noteParts.push(item.title);
+        }
+        if (item.reason) {
+          noteParts.push(`reason=${item.reason}`);
+        }
+        if (item.nextAction) {
+          noteParts.push(`next=${item.nextAction}`);
+        }
+        const note = noteParts.length > 0 ? ` - ${noteParts.join(' | ')}` : '';
+        lines.push(`- ${item.fullName}: \`${item.coverageBucket || 'unknown'}\`${note}`);
+      }
+      lines.push('');
+    }
+
+    const notSavedReasons = result.notSavedReasonCounts || {};
+    if (Object.keys(notSavedReasons).length > 0) {
+      lines.push(`### Not Saved Reasons`);
+      for (const [reason, count] of Object.entries(notSavedReasons)) {
+        lines.push(`- ${reason}: \`${count}\``);
+      }
+      lines.push('');
+    }
   }
 
   return `${lines.join('\n').trim()}\n`;
@@ -393,11 +496,13 @@ module.exports = {
   buildAccountBatchReportPath,
   buildAccountBatchListName,
   formatAccountBatchDuration,
+  deriveSdrCoverageStatus,
   limitBatchCandidates,
   parseAccountNames,
   renderAccountBatchReportMarkdown,
   renderAccountBatchListNameTemplate,
   deriveConnectOperatorGuidance,
+  summarizeSdrResearchOutcome,
   writeAccountBatchArtifact,
   writeAccountBatchReport,
 };

--- a/src/core/account-coverage.js
+++ b/src/core/account-coverage.js
@@ -1233,6 +1233,19 @@ function classifyCoverageListSelection(candidate, options = {}) {
   const title = normalizeSelectionText(candidate.title || '');
   const seniority = String(candidate.seniority || '').toLowerCase();
   const roleFamily = String(candidate.roleFamily || '').toLowerCase();
+  const reportOnlyOutOfNetwork = Boolean(options.reportOnlyOutOfNetwork || options.excludeOutOfNetwork);
+
+  if (
+    reportOnlyOutOfNetwork
+    && candidate.outOfNetwork
+    && includeBuckets.has(candidate.coverageBucket)
+  ) {
+    return {
+      selected: false,
+      reason: 'strong_but_not_auto_saved',
+      rank: 0,
+    };
+  }
 
   if (candidate.coverageBucket === 'direct_observability') {
     if (/\b(platform|architecture|architect)\b/.test(title) && !hasTechnicalAmbiguousQualifier(title)) {
@@ -1334,7 +1347,7 @@ function classifyCoverageListSelection(candidate, options = {}) {
   };
 }
 
-function selectCoverageListCandidates(result, options = {}) {
+function annotateCoverageCandidatesForListSelection(result, options = {}) {
   return (result?.candidates || [])
     .map((candidate) => {
       const selection = classifyCoverageListSelection(candidate, options);
@@ -1345,7 +1358,11 @@ function selectCoverageListCandidates(result, options = {}) {
         topScoreComponents: summarizeTopScoreComponents(candidate.scoreBreakdown),
         selectedForList: selection.selected,
       };
-    })
+    });
+}
+
+function selectCoverageListCandidates(result, options = {}) {
+  return annotateCoverageCandidatesForListSelection(result, options)
     .filter((candidate) => candidate.selectedForList)
     .sort((left, right) => {
       const rankDiff = (right.listSelectionRank || 0) - (left.listSelectionRank || 0);
@@ -1397,6 +1414,7 @@ function writeAccountCoverageArtifact(accountName, coverageResult) {
 }
 
 module.exports = {
+  annotateCoverageCandidatesForListSelection,
   applyDeepReviewResult,
   buildSweepTemplates,
   classifyCoverageBucket,

--- a/src/core/sdr-workflow.js
+++ b/src/core/sdr-workflow.js
@@ -1,0 +1,81 @@
+const { parseAccountNames, renderAccountBatchListNameTemplate } = require('./account-batch');
+
+function buildSdrResearchListName(accountNames = [], {
+  listName = null,
+  startedAt = new Date().toISOString(),
+} = {}) {
+  const explicit = String(listName || '').trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  return renderAccountBatchListNameTemplate('SDR Research {date} {start_time} ({accounts})', {
+    accountNames,
+    startedAt,
+    endedAt: startedAt,
+  });
+}
+
+function buildSdrResearchBatchValues(values = {}, {
+  startedAt = new Date().toISOString(),
+} = {}) {
+  const accountNames = parseAccountNames(values.accounts || values['account-names'] || values['account-name']);
+  if (accountNames.length === 0) {
+    throw new Error('sdr-research requires --accounts="Account A, Account B, Account C"');
+  }
+  if (values['live-connect'] || values.liveConnect || values['allow-background-connects']) {
+    throw new Error('sdr-research never sends connects; use a reviewed connect command separately');
+  }
+
+  const listName = buildSdrResearchListName(accountNames, {
+    listName: values['list-name'],
+    startedAt,
+  });
+  const exhaustive = Boolean(values.exhaustive || values['research-mode'] === 'exhaustive');
+
+  return {
+    ...values,
+    'account-names': accountNames.join(', '),
+    'consolidate-list-name': listName,
+    'allow-list-create': values['allow-list-create'] ?? Boolean(values['live-save'] || values.liveSave),
+    driver: values.driver || 'playwright',
+    'session-mode': values['session-mode'] || 'persistent',
+    'coverage-config': values['coverage-config'] || 'config/account-coverage/default.json',
+    'research-mode': exhaustive ? 'exhaustive' : (values['research-mode'] || 'persona-led'),
+    'speed-profile': exhaustive ? 'exhaustive' : (values['speed-profile'] || 'balanced'),
+    'research-concurrency': values['research-concurrency'] || '1',
+    'reuse-sweep-cache': values['reuse-sweep-cache'] ?? true,
+    'report-only-out-of-network': values['report-only-out-of-network'] ?? true,
+  };
+}
+
+function renderSdrResearchIntro({
+  accountNames = [],
+  listName,
+  liveSave = false,
+  researchMode = 'persona-led',
+  speedProfile = 'balanced',
+} = {}) {
+  const lines = [];
+  lines.push('# SDR Research Run');
+  lines.push('');
+  lines.push(`- Accounts: \`${accountNames.join(', ')}\``);
+  lines.push(`- Target list: \`${listName}\``);
+  lines.push(`- Research mode: \`${researchMode}\``);
+  lines.push(`- Speed profile: \`${speedProfile}\``);
+  lines.push(`- Live save: \`${liveSave ? 'yes' : 'no'}\``);
+  lines.push('- Connects: `never in this command`');
+  lines.push('');
+  if (liveSave) {
+    lines.push('This will create or update the Sales Navigator list after the browser research selects safe candidates.');
+  } else {
+    lines.push('This is dry-safe. It will research and write review artifacts, but it will not save leads to Sales Navigator.');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = {
+  buildSdrResearchBatchValues,
+  buildSdrResearchListName,
+  renderSdrResearchIntro,
+};

--- a/tests/account-batch.test.js
+++ b/tests/account-batch.test.js
@@ -8,12 +8,14 @@ const {
   buildAccountBatchArtifactPath,
   buildAccountBatchReportPath,
   buildAccountBatchListName,
+  deriveSdrCoverageStatus,
   deriveConnectOperatorGuidance,
   formatAccountBatchDuration,
   limitBatchCandidates,
   parseAccountNames,
   renderAccountBatchReportMarkdown,
   renderAccountBatchListNameTemplate,
+  summarizeSdrResearchOutcome,
 } = require('../src/core/account-batch');
 const { ACCOUNT_BATCH_ARTIFACTS_DIR } = require('../src/lib/paths');
 
@@ -131,8 +133,94 @@ test('renderAccountBatchReportMarkdown includes pilot-friendly save summaries', 
   assert.match(markdown, /List name template: `Research \{date\}`/);
   assert.match(markdown, /Max list saves per account: `3`/);
   assert.match(markdown, /Selected for live save: `3`/);
+  assert.match(markdown, /SDR summary: found=`20` \| selected=`8` \| saved_verified=`0` \| save_unverified=`1` \| failed_save=`1` \| manual_review=`0` \| not_auto_saved=`12`/);
+  assert.match(markdown, /Coverage status: `completed`/);
+  assert.match(markdown, /Next action: `verify_list_membership, manual_review`/);
   assert.match(markdown, /Philipp Weidinger: `saved`/);
   assert.match(markdown, /Ralf Koppitz: `failed` - selector issue/);
+});
+
+test('summarizeSdrResearchOutcome explains found vs saved gaps for SDRs', () => {
+  const summary = summarizeSdrResearchOutcome({
+    candidateCount: 30,
+    listCandidateCount: 6,
+    selectedForListSaveCount: 6,
+    strongButNotAutoSavedCount: 4,
+    attemptedSweepsCount: 20,
+    failedSweepsCount: 8,
+    saveResults: [
+      { status: 'saved_and_verified' },
+      { status: 'saved' },
+      { status: 'failed' },
+    ],
+  });
+
+  assert.deepEqual(summary, {
+    found: 30,
+    selectedForList: 6,
+    selectedForLiveSave: 6,
+    savedVerified: 1,
+    saveClickedUnverified: 1,
+    failedSave: 1,
+    manualReview: 0,
+    strongButNotAutoSaved: 4,
+    notAutoSaved: 24,
+    attemptedSweeps: 20,
+    failedSweeps: 8,
+    coverageStatus: 'needs_company_scope_review',
+    nextActions: ['retry_company_scope', 'review_strong_not_saved', 'verify_list_membership', 'manual_review'],
+  });
+});
+
+test('deriveSdrCoverageStatus separates clean runs from scope-review runs', () => {
+  assert.equal(deriveSdrCoverageStatus({ attemptedSweepsCount: 20, failedSweepsCount: 0 }), 'completed');
+  assert.equal(deriveSdrCoverageStatus({ attemptedSweepsCount: 20, failedSweepsCount: 2 }), 'completed_with_sweep_warnings');
+  assert.equal(deriveSdrCoverageStatus({ attemptedSweepsCount: 20, failedSweepsCount: 8 }), 'needs_company_scope_review');
+  assert.equal(deriveSdrCoverageStatus({ resolutionStatus: 'needs_company_resolution' }), 'needs_company_scope_review');
+});
+
+test('renderAccountBatchReportMarkdown shows strong report-only candidates and not-saved reasons', () => {
+  const markdown = renderAccountBatchReportMarkdown({
+    generatedAt: '2026-05-05T10:00:00Z',
+    driver: 'playwright',
+    liveSave: true,
+    liveConnect: false,
+    accountNames: ['Skello'],
+    results: [
+      {
+        accountName: 'Skello',
+        listName: 'SDR Research Skello',
+        candidateCount: 30,
+        listCandidateCount: 6,
+        selectedForListSaveCount: 6,
+        attemptedSweepsCount: 20,
+        failedSweepsCount: 8,
+        strongButNotAutoSavedCount: 2,
+        saveResults: [],
+        strongButNotAutoSavedCandidates: [
+          {
+            fullName: 'Nicolas di Giuseppe',
+            title: 'Senior Engineering Manager - AI & Scheduling Squads',
+            coverageBucket: 'direct_observability',
+            reason: 'strong_but_not_auto_saved',
+            nextAction: 'review_strong_not_saved',
+          },
+        ],
+        notSavedReasonCounts: {
+          strong_but_not_auto_saved: 2,
+          below_icp_selection_threshold: 22,
+        },
+      },
+    ],
+  });
+
+  assert.match(markdown, /SDR summary: found=`30` \| selected=`6`/);
+  assert.match(markdown, /Coverage status: `needs_company_scope_review`/);
+  assert.match(markdown, /Sweeps: `12\/20 succeeded`/);
+  assert.match(markdown, /Next action: `retry_company_scope, review_strong_not_saved`/);
+  assert.match(markdown, /### Strong but not auto-saved/);
+  assert.match(markdown, /Nicolas di Giuseppe: `direct_observability` - Senior Engineering Manager - AI & Scheduling Squads \| reason=strong_but_not_auto_saved \| next=review_strong_not_saved/);
+  assert.match(markdown, /strong_but_not_auto_saved: `2`/);
 });
 
 test('renderAccountBatchReportMarkdown supports smoke-style artifacts with direct status fields', () => {

--- a/tests/account-coverage.test.js
+++ b/tests/account-coverage.test.js
@@ -6,6 +6,7 @@ const { readJson } = require('../src/lib/json');
 const { resolveProjectPath } = require('../src/lib/paths');
 const { buildPriorityModelV1 } = require('../src/core/priority-score');
 const {
+  annotateCoverageCandidatesForListSelection,
   applyDeepReviewResult,
   buildSweepTemplates,
   buildCoverageLanguageSplits,
@@ -498,11 +499,52 @@ test('selectCoverageListCandidates force-includes CIO CTO and microservices buil
     ],
   }, { minScore: 50 });
 
-  assert.deepEqual(selected.map((candidate) => candidate.fullName), ['Microservices Lead', 'Chief Data Analytics', 'Company CIO']);
+  assert.deepEqual(selected.map((candidate) => candidate.fullName), ['Microservices Lead', 'Out Of Network Chief Data', 'Chief Data Analytics', 'Company CIO']);
   assert.deepEqual(selected.map((candidate) => candidate.listSelectionReason), [
     'microservices_observability_path',
     'executive_cto_cio_always_include',
     'executive_cto_cio_always_include',
+    'executive_cto_cio_always_include',
+  ]);
+});
+
+test('report-only out-of-network mode surfaces strong candidates without selecting them', () => {
+  const annotated = annotateCoverageCandidatesForListSelection({
+    candidates: [
+      {
+        fullName: 'Out Of Network SRE',
+        title: 'Head of SRE',
+        coverageBucket: 'direct_observability',
+        roleFamily: 'site_reliability',
+        score: 70,
+        outOfNetwork: true,
+      },
+      {
+        fullName: 'Reachable Platform',
+        title: 'Director of Platform Engineering',
+        coverageBucket: 'direct_observability',
+        roleFamily: 'platform_engineering',
+        score: 64,
+        outOfNetwork: false,
+      },
+    ],
+  }, { reportOnlyOutOfNetwork: true });
+
+  assert.deepEqual(annotated.map((candidate) => ({
+    fullName: candidate.fullName,
+    selectedForList: candidate.selectedForList,
+    reason: candidate.listSelectionReason,
+  })), [
+    {
+      fullName: 'Out Of Network SRE',
+      selectedForList: false,
+      reason: 'strong_but_not_auto_saved',
+    },
+    {
+      fullName: 'Reachable Platform',
+      selectedForList: true,
+      reason: 'direct_observability_always_include',
+    },
   ]);
 });
 

--- a/tests/sdr-workflow.test.js
+++ b/tests/sdr-workflow.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildSdrResearchBatchValues,
+  buildSdrResearchListName,
+  renderSdrResearchIntro,
+} = require('../src/core/sdr-workflow');
+
+test('buildSdrResearchListName creates a simple deterministic SDR list name', () => {
+  const name = buildSdrResearchListName(['Thales Group', 'Skello', 'Oodrive'], {
+    startedAt: '2026-05-05T09:15:00.000Z',
+  });
+
+  assert.equal(name, 'SDR Research 2026-05-05 0915 (Thales Group, Skello +1)');
+});
+
+test('buildSdrResearchBatchValues maps simple SDR input onto the guarded account batch flow', () => {
+  const values = buildSdrResearchBatchValues({
+    accounts: 'Thales Group, Skello, Oodrive',
+    'list-name': 'Polly Score Accounts - Guillaume Nolot',
+    'live-save': true,
+  }, {
+    startedAt: '2026-05-05T09:15:00.000Z',
+  });
+
+  assert.equal(values['account-names'], 'Thales Group, Skello, Oodrive');
+  assert.equal(values['consolidate-list-name'], 'Polly Score Accounts - Guillaume Nolot');
+  assert.equal(values.driver, 'playwright');
+  assert.equal(values['session-mode'], 'persistent');
+  assert.equal(values['coverage-config'], 'config/account-coverage/default.json');
+  assert.equal(values['research-mode'], 'persona-led');
+  assert.equal(values['speed-profile'], 'balanced');
+  assert.equal(values['research-concurrency'], '1');
+  assert.equal(values['live-save'], true);
+  assert.equal(values['allow-list-create'], true);
+  assert.equal(values['reuse-sweep-cache'], true);
+  assert.equal(values['report-only-out-of-network'], true);
+});
+
+test('buildSdrResearchBatchValues supports exhaustive mode without exposing internal sweep flags', () => {
+  const values = buildSdrResearchBatchValues({
+    accounts: 'FnacDarty',
+    exhaustive: true,
+  });
+
+  assert.equal(values['research-mode'], 'exhaustive');
+  assert.equal(values['speed-profile'], 'exhaustive');
+});
+
+test('buildSdrResearchBatchValues refuses connect flags', () => {
+  assert.throws(
+    () => buildSdrResearchBatchValues({
+      accounts: 'Thales Group',
+      'live-connect': true,
+    }),
+    /never sends connects/,
+  );
+});
+
+test('renderSdrResearchIntro makes live-save and connect behavior explicit', () => {
+  const markdown = renderSdrResearchIntro({
+    accountNames: ['Thales Group', 'Skello'],
+    listName: 'Polly Score Accounts - Guillaume Nolot',
+    liveSave: true,
+  });
+
+  assert.match(markdown, /Live save: `yes`/);
+  assert.match(markdown, /Connects: `never in this command`/);
+  assert.match(markdown, /create or update the Sales Navigator list/);
+});


### PR DESCRIPTION
## Summary\n- Adds official `npm run sdr-research` SDR entrypoint with persistent session defaults, live-save list creation, and connect flags blocked\n- Adds SDR-facing found/selected/saved/not-saved report summaries, sweep health, next actions, and strong report-only candidate sections\n- Documents the simplified SDR flow in README and CLAUDE.md\n\nCloses #42\n\n## Tests\n- npm test\n- npm run test:release-readiness\n- git diff --check