### PR TITLE
Simplify SDR-facing language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Startup Guide
 
-When this repository is loaded into Codex, Cursor, Claude Code, or a similar coding agent, start with a friendly setup check before attempting browser-backed Sales Navigator work.
+When this repository is loaded into Codex, Cursor, Claude Code, or a similar coding agent, start with a friendly setup check before doing Sales Navigator work.
 
 ## First Message Pattern
 
@@ -8,13 +8,21 @@ Use this posture:
 
 > You are setting up Sales Navigator Research Assistant. I will first check the local install, dependencies, and browser login state. Dry-safe research can run before Sales Navigator login, but writing to real Sales Navigator lists or sending connection invitations requires an explicit operator action and a visible authenticated browser session.
 
+For SDRs, prefer this simpler version:
+
+> I will quickly check whether the tool is installed and whether LinkedIn is logged in. If something is missing, I will guide you through it. I will not save leads or send connection requests unless you explicitly ask me to.
+
 Then run:
 
 ```bash
 npm run doctor
 ```
 
-If dependencies are missing, offer to run:
+If setup is missing, say this in plain language:
+
+> I need to install the project files and run the checks once. After that, we can log in to LinkedIn and start researching accounts.
+
+Then offer to run:
 
 ```bash
 npm install
@@ -22,17 +30,17 @@ npm test
 npm run test:release-readiness
 ```
 
-If LinkedIn/Sales Navigator is not authenticated, explain the two safe paths:
+If LinkedIn/Sales Navigator is not logged in, explain the two safe paths:
 
-- A) Produce a research Markdown/calling-list artifact now; Sales Navigator push happens after setup.
-- B) Finish setup first with `npm run bootstrap-session -- --driver=playwright --wait-minutes=10`, then run the browser-backed workflow.
+- A) Prepare the research file now; create the Sales Navigator list after setup.
+- B) Finish setup and login first, then create the Sales Navigator list directly.
 
 ## Safety Defaults
 
-- Do not run `--live-save`, `--live-connect`, or background connect commands unless the operator explicitly asks for that live action.
-- Treat `runtime/`, `.env`, browser profiles, cookies, storage state, screenshots, logs, and local databases as local-only.
-- Prefer dry-safe commands for first runs.
-- If browser/session state is missing, do not present that as a failure. It is a normal bootstrap step.
+- Do not save leads or send connection requests unless the user explicitly asks for that live action.
+- Treat `runtime/`, `.env`, browser profiles, cookies, screenshots, logs, and local databases as local-only.
+- Prefer research-only runs for first tests.
+- If LinkedIn login is missing, do not present that as a failure. It is a normal setup step.
 
 ## Agent Operating Context
 
@@ -43,7 +51,7 @@ If LinkedIn/Sales Navigator is not authenticated, explain the two safe paths:
 - Use `docs/agents/multi-agent-pr-stack.md` when splitting Parallel Research or agent-orchestration work across stacked PRs.
 - Use `docs/testing/parallel-research-stress-verification.md` before claiming Parallel Research stability, speed, or merge readiness.
 
-## Recommended First Commands
+## Recommended First Commands For Agents
 
 ```bash
 npm run doctor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,27 @@
 # Claude Code Startup Guide
 
-This repository contains Sales Navigator Research Assistant, a supervised browser-backed research tool. Start every new local setup by running:
+This repo contains Sales Navigator Research Assistant. It helps SDRs turn account names into useful Sales Navigator lead lists.
+
+Start every new setup by running:
 
 ```bash
 npm run doctor
 ```
 
-Explain the result in plain language before attempting browser-backed workflows. Dry-safe research and artifact generation can run without LinkedIn login. Real Sales Navigator list saves or connection invitations require explicit operator approval and a visible authenticated browser session.
+Explain the result in plain language. Do not use setup jargon. Research can be prepared before LinkedIn login, but real Sales Navigator list saves or connection requests need the user to approve the action and be logged in.
 
 If setup is incomplete, offer two safe paths:
 
-- A) Produce a research Markdown/calling-list artifact now; Sales Navigator push happens after setup.
-- B) Finish setup first with `npm install`, tests, and `npm run bootstrap-session -- --driver=playwright --wait-minutes=10`.
+- A) Prepare the research file now; push to Sales Navigator after setup.
+- B) Finish setup first, then create the Sales Navigator list.
 
-Never run `--live-save`, `--live-connect`, or background connect commands unless the operator explicitly requests that live action.
+Never save leads or send connection requests unless the user explicitly asks for that live action.
 
 ## SDR Workflow — How to Handle Lead Requests
 
 The SDRs using this tool are not technical. They speak in plain language: "give me leads for these accounts" or "build me a LinkedIn list for Thales, Skello and Oodrive." Your job is to translate that into the right actions automatically — no technical questions, no command explanations, no jargon.
 
-### Step 1 — Session check (silent, always first)
+### Step 1 — Check LinkedIn Login Silently
 
 Before anything else, silently verify the LinkedIn session:
 
@@ -27,9 +29,9 @@ Before anything else, silently verify the LinkedIn session:
 npm run check-driver-session -- --driver=playwright --session-mode=persistent
 ```
 
-If authenticated: proceed without mentioning it.
+If logged in: proceed without mentioning it.
 
-If not authenticated: tell the SDR in plain language — "Your LinkedIn session has expired. Please log in again — I'll wait." Then run:
+If not logged in: tell the SDR in plain language — "Your LinkedIn login has expired. Please log in again — I'll wait." Then run:
 
 ```bash
 npm run bootstrap-session -- --driver=playwright --wait-minutes=10
@@ -37,25 +39,24 @@ npm run bootstrap-session -- --driver=playwright --wait-minutes=10
 
 Wait for confirmation before continuing.
 
-### Step 2 — Run account coverage
+### Step 2 — Research The Accounts
 
 **For normal SDR requests, use `sdr-research`, never `test-account-search`.**
 
-`test-account-search` is a setup smoke-test capped at 5 results. It is not for SDR use. `account-coverage` runs 21 keyword sweeps per account and returns 30-60 qualified leads.
+`test-account-search` is only a tiny setup check. It is not for SDR work.
 
-Run the friendly SDR wrapper first. It keeps the persistent browser session, researches accounts sequentially, and can create one Sales Navigator list when live-save is explicitly requested:
+Run the friendly SDR command. It researches the accounts one by one and can create one Sales Navigator list when the SDR asks for it:
 
 ```bash
-npm run sdr-research -- --accounts="Account A, Account B, Account C" --driver=playwright
+npm run sdr-research -- --accounts="Account A, Account B, Account C"
 ```
 
-If the SDR asked for a Sales Navigator list, add `--live-save` and let the command create the list:
+If the SDR asked for a Sales Navigator list, add `--live-save`:
 
 ```bash
 npm run sdr-research -- \
   --accounts="Account A, Account B, Account C" \
   --list-name="SDR Research - Account A Account B Account C" \
-  --driver=playwright \
   --live-save
 ```
 
@@ -65,7 +66,7 @@ While it runs, tell the SDR what's happening in plain language:
 - "Found [N] contacts at [Account]. Moving on to [next account]..."
 - "All accounts done. Saving the list to Sales Navigator now."
 
-Never show raw CLI output, sweep names, bucket names, or internal flags.
+Never show raw terminal output, sweep names, bucket names, or internal flags.
 
 ### Step 3 — Create the Sales Navigator list
 
@@ -73,29 +74,29 @@ When an SDR asks for a "LinkedIn list", "Sales Nav list", or says "add them to a
 
 Derive the list name automatically from SDR name + accounts + date if not specified. Never ask for the list name unless genuinely unclear.
 
-`sdr-research` sets the safe list-create flag automatically when `--live-save` is present. Do not use connect flags with this command; it rejects them by design.
+`sdr-research` handles list creation automatically when `--live-save` is present. Do not use this command for connection requests.
 
 ### Step 4 — Close with a clear next step
 
 After the list is created, tell the SDR:
 
 - How many contacts were saved and across which accounts
-- How many strong contacts were found but not auto-saved, and why
+- How many strong contacts were found but not saved automatically, and why
 - Whether any account needs company-scope review
 - That the list is now live in Sales Navigator under the exact name used
-- Which contacts to start with — the `direct_observability` bucket first (DevOps leads, Platform Engineers, Infrastructure Architects)
+- Which contacts to start with: DevOps, platform, cloud, infrastructure, and engineering leaders first.
 
 Example closing message:
 
 > "Done. 69 contacts saved to 'Grafana - Guillaume Nolot - Thales Skello Oodrive'. Open the list in Sales Navigator and start with the DevOps and Platform contacts — those are your strongest entry points."
 
-Never end with raw stats or log output. Always end with a concrete action the SDR can take immediately.
+Never end with raw stats or log output. Always end with one concrete next step the SDR can take immediately.
 
-### Bucketing logic (internal → SDR-facing)
+### Internal Labels Translated For SDRs
 
-- `direct_observability` → primary contacts, start here
-- `technical_adjacent` → valid outreach targets, second priority
-- `likely_noise` → exclude silently, never show to SDR
+- `direct_observability` → strongest contacts, start here.
+- `technical_adjacent` → still useful, second priority.
+- `likely_noise` → not useful enough, do not show unless asked.
 
 ### Output format when showing contacts in chat
 

--- a/README.md
+++ b/README.md
@@ -4,52 +4,49 @@
   <img src="docs/assets/grots-linkedin.jpg" alt="Sales Navigator Research Assistant hero image" width="900">
 </p>
 
-Supervised research assistant for LinkedIn Sales Navigator workflows.
+Sales Navigator Research Assistant helps SDRs build better LinkedIn Sales Navigator lead lists faster.
 
-The app helps an SDR/operator move from territory accounts to relevant technical stakeholders, reviewable lead candidates, and guarded Sales Navigator list workflows. It is designed for supervised use: research and reporting can run in dry-safe mode, while any live Sales Navigator action requires explicit operator intent.
+Give it a few accounts. It researches the right technical people, explains who it found, and can create a Sales Navigator list when you explicitly ask it to.
 
 ## What It Does
 
-- Resolves territory accounts into reliable LinkedIn/Sales Navigator company targets.
-- Runs account coverage sweeps for observability, platform, cloud, infrastructure, and related personas.
-- Classifies accounts and runs as `productive`, `mixed`, `sparse`, `noisy`, `all_sweeps_failed`, or environment-blocked.
-- Imports external lead lists quickly and buckets people into `resolved_safe_to_save`, `needs_company_alias_retry`, and `manual_review`.
-- Plans Sales Navigator lead-list updates and only performs live list saves when explicitly run with live-save flags.
-- Models guarded connect workflows for supervised testing and maps attempts into deterministic operator statuses.
-- Produces JSON and Markdown artifacts for review, handoff, and release-readiness checks.
+- Finds relevant people at target accounts: DevOps, platform, cloud, infrastructure, engineering leaders, and related personas.
+- Creates Sales Navigator lead lists when you explicitly ask it to save leads.
+- Explains the result in plain language: found, saved, not saved, and what needs review.
+- Helps with messy company names by trying to find the right LinkedIn company page.
+- Imports calling lists from files and helps match those names to Sales Navigator profiles.
+- Keeps risky actions guarded, especially list saves and connection requests.
 
 ## Safety Model
 
-The default posture is intentionally conservative.
+The tool is intentionally cautious.
 
-- No live list saves happen unless a command is run with `--live-save`.
-- No connection invitations are sent by dry-safe or background workflows.
-- Supervised connect test commands require explicit live-connect flags and should only be used by an authorized operator.
-- Background/autoresearch flows are dry-safe and must not send invitations or mutate LinkedIn lists.
-- Runtime data, browser profiles, cookies, sessions, logs, screenshots, and local databases live under ignored paths.
-- Salesforce credentials, BigQuery credentials, LinkedIn session state, and any API keys must be provided through local environment variables or local-only files, never committed.
+- It does not save leads to a real Sales Navigator list unless you explicitly ask for live save.
+- It does not send connection requests from the normal SDR research command.
+- If LinkedIn asks for an email address before connecting, the tool skips that prospect.
+- Login/session files, cookies, screenshots, and credentials stay local and must not be committed.
+- If the tool is unsure about a company or person, it asks for review instead of guessing silently.
 
-## MVP Scope
+## Current Scope
 
-Ready or close to ready:
+Works well today:
 
-- Account discovery and coverage sweeps.
-- Company resolution and alias/target handling for difficult account names.
-- Safe list creation/list-save workflows with visible Sales Navigator verification.
-- Fast lead-list import from Markdown calling lists.
-- Deterministic connect status modeling.
-- Operator reports, release summaries, and local dashboard tooling.
+- Researching accounts and finding relevant technical stakeholders.
+- Creating reviewed Sales Navigator lead lists.
+- Explaining why some leads were not saved.
+- Handling many difficult company-name cases.
+- Importing name lists and matching people to Sales Navigator profiles.
 
-Still guarded:
+Still intentionally guarded:
 
-- Broad fully automatic connect across all LinkedIn UI variations.
-- Fully unattended background territory machine over large account batches.
-- SDR self-serve UX beyond CLI/runbook/operator-dashboard flows.
-- Automatic handling of uncertain company scope or low-confidence people matches.
+- Broad automatic connection requests.
+- Large unattended background runs.
+- Unclear company matches.
+- Low-confidence people matches.
 
 ## Quick Start
 
-Run the local readiness check first:
+Check that the tool is ready:
 
 ```bash
 npm run doctor
@@ -61,19 +58,19 @@ Install dependencies:
 npm install
 ```
 
-Run the full regression suite:
+For contributors: run all tests:
 
 ```bash
 npm test
 ```
 
-Run release-readiness tests:
+For contributors: run release-readiness checks:
 
 ```bash
 npm run test:release-readiness
 ```
 
-Print the operator dashboard:
+Print the current operator dashboard:
 
 ```bash
 npm run print-mvp-operator-dashboard
@@ -87,9 +84,9 @@ npm run print-mvp-release-contract
 
 ## SDR Quick Action
 
-For day-to-day SDR testing, start here. Give the tool three to five accounts and let it research, explain the result, and optionally create the Sales Navigator list.
+For day-to-day SDR testing, start here. Give the tool three to five accounts and let it work.
 
-Dry-safe research:
+Research only:
 
 ```bash
 npm run sdr-research -- --accounts="Thales Group, Skello, Oodrive"
@@ -104,17 +101,17 @@ npm run sdr-research -- \
   --live-save
 ```
 
-This command never sends connection invitations. It uses the persistent browser session, creates the list only when `--live-save` is explicit, and reports what was found, saved, not saved, and what needs review.
+This command never sends connection invitations. It reports what it found, what it saved, what it skipped, and what needs review.
 
 ## Environment Setup
 
-Create a local `.env` from `.env.example` if you need live integrations:
+Create a local `.env` from `.env.example` only if you need Salesforce, BigQuery, or other live integrations:
 
 ```bash
 cp .env.example .env
 ```
 
-Only fill in values on your own machine or runner. Do not commit `.env`, browser sessions, cookies, storage state, or runtime artifacts.
+Only fill in values on your own machine. Do not commit `.env`, browser sessions, cookies, screenshots, or local result files.
 
 ## First Run In An Agent
 
@@ -124,31 +121,31 @@ If you open this repo in Codex, Cursor, Claude Code, or a similar agent, the fir
 npm run doctor
 ```
 
-If dependencies or login are missing, that is normal. Dry-safe research can still be prepared after install, but real Sales Navigator list writes require a visible authenticated browser session via:
+If install or LinkedIn login is missing, that is normal. The agent should help you set it up. Real Sales Navigator list writes require a visible LinkedIn login:
 
 ```bash
 npm run bootstrap-session -- --driver=playwright --wait-minutes=10
 ```
 
-See [docs/first-run-onboarding.md](docs/first-run-onboarding.md), [AGENTS.md](AGENTS.md), and [CLAUDE.md](CLAUDE.md) for agent-specific startup guidance.
+See [docs/first-run-onboarding.md](docs/first-run-onboarding.md), [AGENTS.md](AGENTS.md), and [CLAUDE.md](CLAUDE.md) for startup guidance.
 
 ## Common Workflows
 
-### Check Browser Session
+### Check LinkedIn Login
 
 ```bash
 npm run check-driver-session -- --driver=playwright --session-mode=persistent
 ```
 
-### Bootstrap A Visible Session
+### Log In Again If Needed
 
-Use this when the browser profile needs a manual login or checkpoint repair:
+Use this when LinkedIn needs a fresh manual login:
 
 ```bash
 npm run bootstrap-session -- --driver=playwright --wait-minutes=10
 ```
 
-### Dry-Run Territory/Account Research
+### Background Account Research
 
 ```bash
 npm run run-background-territory-loop -- --driver=playwright --limit=1
@@ -156,7 +153,7 @@ npm run run-background-territory-loop -- --driver=playwright --limit=1
 
 ### Research Several Accounts Into One List
 
-For SDRs, prefer `npm run sdr-research`. Use the lower-level batch command only when you need advanced options.
+For SDRs, prefer `npm run sdr-research`. The commands below are advanced.
 
 Use `--consolidate-list-name` when you want one shared Sales Navigator list instead of one list per account:
 
@@ -178,19 +175,19 @@ node src/cli.js run-account-batch \
   --live-save
 ```
 
-### Resolve A Difficult Company
+### Resolve A Difficult Company Name
 
 ```bash
 node src/cli.js resolve-company --account-name="Example Company"
 ```
 
-### Retry Company Resolution Failures
+### Retry Accounts With Company-Name Problems
 
 ```bash
 node src/cli.js run-company-resolution-retries --limit=3 --driver=hybrid --max-candidates=25
 ```
 
-### Fast Resolve A Calling List
+### Match A Calling List To Sales Navigator
 
 ```bash
 npm run fast-resolve-leads -- \
@@ -200,7 +197,7 @@ npm run fast-resolve-leads -- \
   --max-candidates=4
 ```
 
-### Dry Plan A List Import
+### Preview A List Import
 
 ```bash
 npm run fast-list-import -- \
@@ -210,7 +207,7 @@ npm run fast-list-import -- \
 
 ### Retry Only Failed List Saves
 
-If a live save run hit a temporary UI/rate-limit problem, retry only the failed rows instead of reprocessing the whole source:
+If a save run hit a temporary LinkedIn issue, retry only the failed people instead of reprocessing the whole file:
 
 ```bash
 node src/cli.js retry-failed-fast-list-import \
@@ -219,11 +216,11 @@ node src/cli.js retry-failed-fast-list-import \
   --live-save
 ```
 
-The retry command includes rows with `failed_runtime`, `failed_rate_limit`, `failed_network`, `failed_ui_state`, and `skipped_rate_limit_cooldown`.
+The retry command is for temporary save problems, not for people the tool already marked as bad matches.
 
-### Live Save A Safe Resolved List
+### Save A Reviewed Calling List
 
-Only run this intentionally after reviewing the dry plan:
+Only run this intentionally after reviewing the preview:
 
 ```bash
 npm run fast-list-import -- \
@@ -234,32 +231,27 @@ npm run fast-list-import -- \
   --allow-list-create
 ```
 
-## Project Structure
+## Project Structure For Contributors
 
-- `src/cli.js`: command-line entry point.
-- `src/core/`: orchestration, company resolution, connect handling, list import, background runner, reports.
-- `src/drivers/`: Playwright, Browser Harness, hybrid, and mock drivers.
-- `src/adapters/`: read-only Salesforce and BigQuery adapters.
-- `config/`: ICP, pilot policy, account aliases, coverage, runner, scoring, and mode configs.
-- `docs/`: runbooks, release contract, MVP status, and operator guidance.
-- `tests/`: Node test suite.
-- `runtime/`: local-only state and artifacts; ignored by Git.
-- `automation/`: local helper wrappers for browser/harness workflows.
-- `vendor/browser-harness/`: vendored Browser Harness helper package.
+- `src/`: the tool logic.
+- `config/`: persona rules, account aliases, and safety settings.
+- `docs/`: setup notes, operating notes, and release notes.
+- `tests/`: automated checks for contributors.
+- `runtime/`: local-only browser/login/results data. This is ignored by Git.
 
 ## Usage And Compliance
 
-This tool controls a real browser and can interact with Sales Navigator UI when explicitly configured to do so. Operators are responsible for using it only with accounts, systems, and workflows they are authorized to access, and for following applicable platform terms, internal security policies, and customer-data handling rules.
+This tool controls a real browser. Use it only with LinkedIn, Salesforce, and company systems you are allowed to access.
 
-This repository is intentionally conservative: dry-safe research is the default, live mutations are opt-in, and uncertain company or person matches are routed to review instead of being silently acted on.
+The tool is intentionally conservative: research is safe by default, real Sales Navigator changes require explicit approval, and uncertain company or person matches are sent to review instead of guessed.
 
 ## Sharing This Repo
 
 This repository is intended to be safe to share as source code, but every operator is responsible for their local runtime state.
 
-- Keep `runtime/`, `.env`, browser profiles, screenshots, cookies, storage state, logs, and local databases out of Git.
+- Keep `runtime/`, `.env`, browser profiles, screenshots, cookies, logs, and local databases out of Git.
 - Use `.env.example` as a template; do not commit real Salesforce, BigQuery, LinkedIn, or browser-session credentials.
-- Treat live Sales Navigator workflows as supervised operations. Dry-safe commands are the default; live mutations require explicit flags.
+- Treat real Sales Navigator list saves and connection requests as supervised actions.
 - Review LinkedIn/Sales Navigator terms, internal security policy, and customer data-handling requirements before wider rollout.
 
 ## License
@@ -268,15 +260,15 @@ This repository is not open source. It is shared under a proprietary internal ev
 
 ## Release Readiness Definition
 
-The first release target is a supervised MVP, not a broad autonomous release. It is release-ready when:
+The first release target is a supervised MVP, not a fully automatic broad rollout. It is release-ready when:
 
-- Discovery reliably finds relevant technical stakeholders.
-- Save-to-list flows are stable and visibly verifiable in Sales Navigator.
-- Known connect UI shapes end in deterministic statuses instead of generic failures.
-- `email_required` is treated as a normal skip state.
-- Guarded account classes remain guarded unless supervised evidence proves otherwise.
-- Operators can use reports and dashboards without reading raw logs.
-- Background runs produce useful dry-safe evidence and separate environment failures from account logic failures.
+- Account research reliably finds relevant technical people.
+- List saves are stable and can be checked in Sales Navigator.
+- Connection-request attempts end in clear outcomes.
+- Email-required prospects are skipped.
+- Guarded accounts stay guarded until reviewed.
+- SDRs can understand the report without reading logs.
+- Background research produces useful findings without hiding browser/login problems.
 
 ## GitHub Publishing Checklist
 

--- a/docs/first-run-onboarding.md
+++ b/docs/first-run-onboarding.md
@@ -1,12 +1,12 @@
 # First Run Onboarding
 
-Sales Navigator Research Assistant is a local, supervised tool. It can plan and research in dry-safe mode before login, but it cannot write to a real Sales Navigator list until the local machine has dependencies installed and a visible LinkedIn/Sales Navigator session is authenticated.
+Sales Navigator Research Assistant runs on the user's machine and controls their own browser. It can prepare research before LinkedIn login, but it cannot create a real Sales Navigator list until setup is finished and the user is logged in.
 
 ## Friendly First Message
 
-Use this when a new SDR/operator opens the repo in an agent:
+Use this when a new SDR opens the repo in an agent:
 
-> You are setting up Sales Navigator Research Assistant. I will first check your local install, dependencies, and browser login state. Dry-safe research can run immediately once dependencies are installed. Real Sales Navigator list saves or connect actions require an explicit operator decision and a visible authenticated browser session.
+> I will quickly check whether the tool is installed and whether LinkedIn is logged in. If something is missing, I will guide you through it. I will not save leads or send connection requests unless you explicitly ask me to.
 
 Then run:
 
@@ -18,7 +18,7 @@ npm run doctor
 
 Say:
 
-> The repo is here, but dependencies are not installed yet. I can install them, run the test suite, and then we can bootstrap your browser session.
+> The repo is here, but the tool is not installed yet. I can install it, run the checks, and then help you log in to LinkedIn.
 
 Run:
 
@@ -32,14 +32,14 @@ npm run test:release-readiness
 
 Say:
 
-> Dry-safe research can still run, but I cannot write to a real Sales Navigator list until we bootstrap a visible browser session.
+> I can prepare research, but I cannot create a real Sales Navigator list until LinkedIn is logged in.
 
 Offer two safe paths:
 
-- A) Produce a research Markdown/calling-list artifact now; Sales Navigator push happens after setup.
-- B) Finish setup first with `npm run bootstrap-session -- --driver=playwright --wait-minutes=10`, then run the browser-backed workflow.
+- A) Prepare the research file now; create the Sales Navigator list later.
+- B) Log in first, then create the Sales Navigator list directly.
 
-## What Must Stay Explicit
+## Actions That Must Stay Explicit
 
 - `--live-save`
 - `--live-connect`
@@ -47,3 +47,7 @@ Offer two safe paths:
 - removing leads from live lists
 
 These actions should never happen as part of a first-run setup or unattended bootstrap.
+
+In SDR-facing language, say:
+
+> I can research accounts safely. Saving leads or sending connection requests is a separate action and I will ask before doing it.

--- a/docs/operator-quickstart.md
+++ b/docs/operator-quickstart.md
@@ -1,8 +1,8 @@
-# Operator Quickstart
+# SDR Quickstart
 
-This is the shortest safe path for a supervised SDR/operator.
+This is the shortest safe path for an SDR who wants leads from Sales Navigator.
 
-## 1. Install And Test
+## 1. Install And Check The Tool
 
 ```bash
 npm install
@@ -10,42 +10,71 @@ npm test
 npm run test:release-readiness
 ```
 
-## 2. Check Browser Session
+## 2. Check LinkedIn Login
 
 ```bash
 npm run check-driver-session -- --driver=playwright --session-mode=persistent
 ```
 
-If the session is not authenticated, repair it visibly:
+If LinkedIn is not logged in, open a visible browser and log in:
 
 ```bash
 npm run bootstrap-session -- --driver=playwright --wait-minutes=10
 ```
 
-## 3. Run Dry-Safe Research
+## 3. Research Accounts
+
+For normal SDR work, use this:
+
+```bash
+npm run sdr-research -- --accounts="Thales Group, Skello, Oodrive"
+```
+
+To also create/update a Sales Navigator list:
+
+```bash
+npm run sdr-research -- \
+  --accounts="Thales Group, Skello, Oodrive" \
+  --list-name="SDR Research - Thales Skello Oodrive" \
+  --live-save
+```
+
+This command does not send connection requests.
+
+## 4. Advanced Single-Account Research
+
+Use this only when you need a lower-level account check:
 
 ```bash
 npm run account-coverage -- --driver=playwright --account-name="Example Account"
 ```
 
-Sales Navigator uses the same LinkedIn account/session as the operator's browser. During business hours, avoid heavy manual Sales Navigator usage while sweeps run, or add a small delay between sweeps:
+Sales Navigator uses the same LinkedIn login as the user's browser. During business hours, avoid heavy manual Sales Navigator usage while the tool researches accounts.
 
 ```bash
 npm run account-coverage -- --driver=playwright --account-name="Example Account" --inter-sweep-delay-ms=3000
 ```
 
-If LinkedIn shows `Too many requests`, the driver pauses, retries once, and reports the account as `rate_limited` if LinkedIn still asks for more time.
+If LinkedIn shows "Too many requests", the tool pauses and reports that LinkedIn asked for more time.
 
-or for a queue:
+For a small background queue:
 
 ```bash
 npm run run-background-territory-loop -- --driver=playwright --limit=1
 ```
 
-## 4. Review Reports
+## 5. Read The Report
 
-Read JSON/Markdown artifacts under `runtime/artifacts/`. Treat `manual_review`, `needs_company_resolution`, `needs_company_alias_retry`, `environment_blocked`, and `email_required` as stop/review states.
+The report should answer:
 
-## 5. Live Actions
+- How many people were found?
+- How many were saved?
+- Who was strong but not saved automatically?
+- Does the company name need review?
+- What should the SDR do next?
 
-Only run live-save or live-connect commands intentionally after reviewing the dry-safe report. Never add live mutation flags to unattended loops.
+If the report says `manual_review`, `needs_company_resolution`, `environment_blocked`, or `email_required`, stop and review instead of forcing the action.
+
+## 6. Live Actions
+
+Only save leads or send connection requests when the SDR explicitly asks for that action. Never add live-action flags to unattended background runs.

--- a/docs/operator-summary.md
+++ b/docs/operator-summary.md
@@ -1,6 +1,6 @@
-# Operator Summary
+# SDR Operator Summary
 
-This repository contains a supervised Sales Navigator SDR workflow platform.
+This tool helps SDRs turn account names into reviewed Sales Navigator lead lists.
 
 ## Start Here
 
@@ -12,16 +12,16 @@ npm run print-mvp-operator-dashboard
 
 ## Safe Daily Flow
 
-1. Check the browser session.
-2. Run account coverage or a small background loop.
-3. Review the generated Markdown report.
-4. Save only reviewed, resolved leads.
-5. Keep connect actions supervised and policy-gated.
+1. Check that LinkedIn is logged in.
+2. Give the tool three to five accounts.
+3. Review the report.
+4. Save reviewed leads to Sales Navigator.
+5. Send connection requests only when explicitly approved.
 
 ## What To Watch
 
-- `needs_company_resolution`: resolve the LinkedIn company target before retrying.
-- `manual_review`: inspect the candidate or UI shape before acting.
-- `environment_blocked`: repair browser/session/harness health.
+- `needs_company_resolution`: the company name is unclear. Check the right LinkedIn company page before retrying.
+- `manual_review`: the tool is not confident enough. Review before acting.
+- `environment_blocked`: browser or login setup needs fixing.
 - `email_required`: skip the prospect.
-- `connect_unavailable`: review whether the profile is structurally unavailable or temporarily unrendered.
+- `connect_unavailable`: the tool cannot safely send a connection request for this profile.

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -1,18 +1,18 @@
 # Supervised MVP Release Contract
 
-The first release target is a supervised MVP, not a broad autonomous Sales Navigator automation product.
+The first release is a supervised SDR assistant, not a fully automatic LinkedIn machine.
 
 ## Defaults
 
-- `lists-first` is the default operating model.
-- Background research is dry-safe by default.
-- Live list saves require `--live-save`.
-- Connect actions require explicit supervised live-connect command paths.
-- Background connects are disabled unless explicitly configured and approved.
+- Build lists first.
+- Background research should not change Sales Navigator.
+- Real list saves must be explicitly requested.
+- Connection requests must be explicitly supervised.
+- Background connection requests stay off unless separately approved.
 
 ## Final Connect States
 
-Every connect attempt should end in one of these operator states:
+Every connection request attempt should end in one clear state:
 
 - `sent`
 - `already_sent`
@@ -22,20 +22,20 @@ Every connect attempt should end in one of these operator states:
 - `manual_review`
 - `skipped_by_policy`
 
-`email_required` means skip the prospect. Do not research emails, do not retry in the same run, and do not treat this as a bug.
+`email_required` means skip the prospect. Do not search for emails and do not retry in the same run.
 
 ## Account Scope
 
-Company resolution must prefer exact or high-confidence LinkedIn/Sales Navigator targets. Low-confidence company matches should stop as review states instead of silently sweeping the wrong entity.
+The tool should use the right LinkedIn company page. If it is unsure, it should stop for review instead of researching the wrong company.
 
 ## Runner States
 
-Environment failures must stay separate from account logic:
+Browser/login problems must stay separate from account quality:
 
-- `environment_blocked` means browser/session/harness health prevented the run.
-- `timed_out` is an account-level coverage outcome.
-- `all_sweeps_failed` means account scoping or filters likely need company resolution.
+- `environment_blocked`: browser or login setup blocked the run.
+- `timed_out`: this account took too long.
+- `all_sweeps_failed`: the company name or Sales Navigator filter probably needs review.
 
 ## Release-Ready Definition
 
-The MVP is release-ready when discovery, company resolution, list planning, guarded list save, deterministic connect statuses, operator reports, and dry-safe background evidence work without requiring raw-log interpretation.
+The MVP is release-ready when an SDR can research accounts, create reviewed lists, understand the report, and know what to do next without reading raw logs.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "license": "UNLICENSED",
-  "description": "Supervised Sales Navigator research assistant with pluggable browser drivers, SQLite state, and operator review dashboard.",
+  "description": "Supervised Sales Navigator assistant for researching accounts and creating reviewed SDR lead lists.",
   "main": "src/cli.js",
   "scripts": {
     "sync-territory": "node src/cli.js sync-territory",


### PR DESCRIPTION
## Summary\n- Rewrites the first visible README/agent/operator docs in simpler SDR language\n- Moves technical terms behind plain explanations like LinkedIn login, research accounts, save reviewed leads, and review next steps\n- Keeps deeper contributor commands available, but labels them as advanced\n\n## Checks\n- npm run test:release-readiness\n- git diff --check