### PR TITLE
Expose SDR report counts for incomplete sweeps

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3535,6 +3535,7 @@ async function handleRunAccountBatch(repository, values, logger) {
         listCandidateCount: listCandidates.length,
         selectedForListSaveCount: selectedForListSave.length,
         strongButNotAutoSavedCount: strongButNotAutoSavedCandidates.length,
+        outOfNetworkCount: strongButNotAutoSavedCandidates.length,
         strongButNotAutoSavedCandidates,
         notSavedReasonCounts,
         sdrSummary: summarizeSdrResearchOutcome({
@@ -3542,6 +3543,7 @@ async function handleRunAccountBatch(repository, values, logger) {
           listCandidateCount: listCandidates.length,
           selectedForListSaveCount: selectedForListSave.length,
           strongButNotAutoSavedCount: strongButNotAutoSavedCandidates.length,
+          outOfNetworkCount: strongButNotAutoSavedCandidates.length,
           attemptedSweepsCount: coverageRun.templates.length,
           failedSweepsCount: coverageRun.sweepErrors.length,
           resolutionStatus: coverageRun.result.resolutionStatus || null,

--- a/src/core/account-batch.js
+++ b/src/core/account-batch.js
@@ -225,6 +225,7 @@ function summarizeSdrResearchOutcome(result = {}) {
     failedSave: saveResults.filter((item) => failedSaveStatuses.has(item.status)).length,
     manualReview: saveResults.filter((item) => manualReviewStatuses.has(item.status)).length,
     strongButNotAutoSaved: Number(result.strongButNotAutoSavedCount || 0),
+    outOfNetwork: Number(result.outOfNetworkCount ?? result.strongButNotAutoSavedCount ?? 0),
     notAutoSaved: Math.max(0, Number(result.candidateCount || 0) - Number(result.listCandidateCount || 0)),
     attemptedSweeps: Number(result.attemptedSweepsCount || 0),
     failedSweeps: Number(result.failedSweepsCount || 0),
@@ -367,7 +368,7 @@ function renderAccountBatchReportMarkdown(payload) {
     if (result.selectedForListSaveCount !== undefined) {
       lines.push(`- Selected for live save: \`${result.selectedForListSaveCount}\``);
     }
-    lines.push(`- SDR summary: found=\`${sdrSummary.found}\` | selected=\`${sdrSummary.selectedForList}\` | saved_verified=\`${sdrSummary.savedVerified}\` | save_unverified=\`${sdrSummary.saveClickedUnverified}\` | failed_save=\`${sdrSummary.failedSave}\` | manual_review=\`${sdrSummary.manualReview}\` | not_auto_saved=\`${sdrSummary.notAutoSaved}\``);
+    lines.push(`- SDR summary: found=\`${sdrSummary.found}\` | selected=\`${sdrSummary.selectedForList}\` | saved_verified=\`${sdrSummary.savedVerified}\` | save_unverified=\`${sdrSummary.saveClickedUnverified}\` | failed_save=\`${sdrSummary.failedSave}\` | manual_review=\`${sdrSummary.manualReview}\` | out_of_network=\`${sdrSummary.outOfNetwork}\` | failed_sweeps=\`${sdrSummary.failedSweeps}\` | not_auto_saved=\`${sdrSummary.notAutoSaved}\``);
     lines.push(`- Coverage status: \`${sdrSummary.coverageStatus}\``);
     if (sdrSummary.attemptedSweeps > 0) {
       lines.push(`- Sweeps: \`${sdrSummary.attemptedSweeps - sdrSummary.failedSweeps}/${sdrSummary.attemptedSweeps} succeeded\``);

--- a/tests/account-batch.test.js
+++ b/tests/account-batch.test.js
@@ -133,7 +133,7 @@ test('renderAccountBatchReportMarkdown includes pilot-friendly save summaries', 
   assert.match(markdown, /List name template: `Research \{date\}`/);
   assert.match(markdown, /Max list saves per account: `3`/);
   assert.match(markdown, /Selected for live save: `3`/);
-  assert.match(markdown, /SDR summary: found=`20` \| selected=`8` \| saved_verified=`0` \| save_unverified=`1` \| failed_save=`1` \| manual_review=`0` \| not_auto_saved=`12`/);
+  assert.match(markdown, /SDR summary: found=`20` \| selected=`8` \| saved_verified=`0` \| save_unverified=`1` \| failed_save=`1` \| manual_review=`0` \| out_of_network=`0` \| failed_sweeps=`0` \| not_auto_saved=`12`/);
   assert.match(markdown, /Coverage status: `completed`/);
   assert.match(markdown, /Next action: `verify_list_membership, manual_review`/);
   assert.match(markdown, /Philipp Weidinger: `saved`/);
@@ -164,6 +164,7 @@ test('summarizeSdrResearchOutcome explains found vs saved gaps for SDRs', () => 
     failedSave: 1,
     manualReview: 0,
     strongButNotAutoSaved: 4,
+    outOfNetwork: 4,
     notAutoSaved: 24,
     attemptedSweeps: 20,
     failedSweeps: 8,
@@ -214,7 +215,7 @@ test('renderAccountBatchReportMarkdown shows strong report-only candidates and n
     ],
   });
 
-  assert.match(markdown, /SDR summary: found=`30` \| selected=`6`/);
+  assert.match(markdown, /SDR summary: found=`30` \| selected=`6` .* out_of_network=`2` \| failed_sweeps=`8`/);
   assert.match(markdown, /Coverage status: `needs_company_scope_review`/);
   assert.match(markdown, /Sweeps: `12\/20 succeeded`/);
   assert.match(markdown, /Next action: `retry_company_scope, review_strong_not_saved`/);


### PR DESCRIPTION
## Summary\n- Adds explicit `out_of_network` and `failed_sweeps` counts to the SDR summary line\n- Carries the report-only out-of-network count through account-batch artifacts\n- Tightens the Skello-style report tests to match issue #42 acceptance criteria\n\nCloses #42\n\n## Tests\n- npm test -- tests/account-batch.test.js tests/sdr-workflow.test.js tests/account-coverage.test.js\n- npm run test:release-readiness\n- git diff --check