### PR TITLE
Harden SDR research issue resolution

### DIFF
--- a/config/account-aliases/default.json
+++ b/config/account-aliases/default.json
@@ -199,6 +199,134 @@
       "territoryCountries": ["Germany"],
       "resolutionStatus": "resolved_exact",
       "resolutionNotes": "Avoid homonym matches such as unrelated broadband companies; route Example Mobility SE research to the Example Mobility LinkedIn company target."
+    },
+    "edeka": {
+      "accountSearchAliases": ["EDEKA", "EDEKA DIGITAL", "Edeka Digital", "Lunar"],
+      "companyFilterAliases": ["EDEKA", "EDEKA DIGITAL", "Edeka Digital", "EDEKA DIGITAL GmbH", "Lunar GmbH"],
+      "targets": [
+        {
+          "linkedinName": "EDEKA",
+          "targetType": "parent",
+          "territoryFit": "likely",
+          "evidence": ["curated_parent"]
+        },
+        {
+          "linkedinName": "EDEKA DIGITAL GmbH",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        },
+        {
+          "linkedinName": "Lunar GmbH",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        }
+      ],
+      "subsidiaryAliases": ["EDEKA DIGITAL", "Edeka Digital", "EDEKA DIGITAL GmbH", "Lunar GmbH"],
+      "territoryCountries": ["Germany"],
+      "resolutionStatus": "resolved_multi_target",
+      "resolutionNotes": "Parent retail brand likely has separate IT entities; sweep parent plus curated IT subsidiaries, never unrelated companies."
+    },
+    "otto": {
+      "accountSearchAliases": ["Otto Group", "Otto GmbH & Co. KGaA", "About You", "Bonprix"],
+      "companyFilterAliases": ["Otto Group", "Otto GmbH & Co. KGaA", "About You", "Bonprix"],
+      "targets": [
+        {
+          "linkedinName": "Otto Group",
+          "targetType": "parent",
+          "territoryFit": "likely",
+          "evidence": ["curated_parent"]
+        },
+        {
+          "linkedinName": "About You",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        },
+        {
+          "linkedinName": "Bonprix",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        }
+      ],
+      "subsidiaryAliases": ["About You", "Bonprix"],
+      "territoryCountries": ["Germany"],
+      "resolutionStatus": "resolved_multi_target",
+      "resolutionNotes": "Holding research should include known technology-heavy subsidiaries."
+    },
+    "schwarz": {
+      "accountSearchAliases": ["Schwarz Group", "Schwarz IT", "Lidl", "Kaufland"],
+      "companyFilterAliases": ["Schwarz Group", "Schwarz IT", "Lidl", "Kaufland"],
+      "targets": [
+        {
+          "linkedinName": "Schwarz Group",
+          "targetType": "parent",
+          "territoryFit": "likely",
+          "evidence": ["curated_parent"]
+        },
+        {
+          "linkedinName": "Schwarz IT",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        }
+      ],
+      "subsidiaryAliases": ["Schwarz IT", "Lidl", "Kaufland"],
+      "territoryCountries": ["Germany"],
+      "resolutionStatus": "resolved_multi_target",
+      "resolutionNotes": "Retail parent often has a carved-out IT organization."
+    },
+    "rewe": {
+      "accountSearchAliases": ["REWE Group", "REWE digital", "REWE Systems"],
+      "companyFilterAliases": ["REWE Group", "REWE digital", "REWE Systems"],
+      "targets": [
+        {
+          "linkedinName": "REWE Group",
+          "targetType": "parent",
+          "territoryFit": "likely",
+          "evidence": ["curated_parent"]
+        },
+        {
+          "linkedinName": "REWE digital",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        },
+        {
+          "linkedinName": "REWE Systems",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        }
+      ],
+      "subsidiaryAliases": ["REWE digital", "REWE Systems"],
+      "territoryCountries": ["Germany"],
+      "resolutionStatus": "resolved_multi_target",
+      "resolutionNotes": "Parent plus known IT entities should be reviewed together."
+    },
+    "bertelsmann": {
+      "accountSearchAliases": ["Bertelsmann", "Arvato Systems"],
+      "companyFilterAliases": ["Bertelsmann", "Arvato Systems"],
+      "targets": [
+        {
+          "linkedinName": "Bertelsmann",
+          "targetType": "parent",
+          "territoryFit": "likely",
+          "evidence": ["curated_parent"]
+        },
+        {
+          "linkedinName": "Arvato Systems",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        }
+      ],
+      "subsidiaryAliases": ["Arvato Systems"],
+      "territoryCountries": ["Germany"],
+      "resolutionStatus": "resolved_multi_target",
+      "resolutionNotes": "Bertelsmann technology research should include Arvato Systems as a likely IT subsidiary."
     }
   }
 }

--- a/docs/enterprise-company-resolution.md
+++ b/docs/enterprise-company-resolution.md
@@ -1,0 +1,60 @@
+# Enterprise Company Resolution
+
+Use this note when an account is a large parent brand but the useful IT org lives in a separate LinkedIn company page.
+
+## When To Add A Curated Target
+
+Add a curated target when a run shows one of these signs:
+
+- The parent company has many employees, but almost no relevant platform, cloud, DevOps, SRE, or engineering personas.
+- The report shows `needs_company_scope_review`.
+- The report warns about `cross_company_contamination_detected`.
+- SDR feedback says the real IT team sits under a named subsidiary.
+
+Common examples:
+
+- `EDEKA` -> `EDEKA DIGITAL GmbH`, `Lunar GmbH`
+- `Otto Group` -> `About You`, `Bonprix`
+- `Schwarz Group` -> `Schwarz IT`
+- `REWE Group` -> `REWE digital`, `REWE Systems`
+- `Bertelsmann` -> `Arvato Systems`
+
+## How To Add One
+
+Edit `config/account-aliases/default.json` and add or update the account entry:
+
+```json
+{
+  "accountSearchAliases": ["Parent Brand", "IT Subsidiary"],
+  "companyFilterAliases": ["Parent Brand", "IT Subsidiary GmbH"],
+  "targets": [
+    {
+      "linkedinName": "Parent Brand",
+      "targetType": "parent",
+      "territoryFit": "likely",
+      "evidence": ["curated_parent"]
+    },
+    {
+      "linkedinName": "IT Subsidiary GmbH",
+      "targetType": "subsidiary",
+      "territoryFit": "likely",
+      "evidence": ["curated_it_subsidiary"]
+    }
+  ],
+  "subsidiaryAliases": ["IT Subsidiary", "IT Subsidiary GmbH"],
+  "resolutionStatus": "resolved_multi_target"
+}
+```
+
+Keep the mapping conservative. If the subsidiary is not clearly related to the territory account, prefer manual review over automatic sweeps.
+
+## Operator Check
+
+After changing aliases, run:
+
+```bash
+npm run test:release-readiness
+node src/cli.js resolve-company --account-name="Account Name"
+```
+
+The resolution report should show the intended parent/subsidiary targets and should not include unrelated companies.

--- a/src/cli.js
+++ b/src/cli.js
@@ -76,6 +76,10 @@ const {
   renderSdrResearchIntro,
 } = require('./core/sdr-workflow');
 const {
+  isRetryableSaveError,
+  verifyFastListSaveRow,
+} = require('./core/fast-list-import');
+const {
   attachSweepCacheState,
   buildResearchPipelineArtifact,
   buildResearchQueue,
@@ -3302,6 +3306,7 @@ async function handleRunAccountBatch(repository, values, logger) {
   const consolidatedListName = explicitConsolidatedListName || templateConsolidatedListName || null;
   const liveSave = getBoolean(values, 'liveSave', 'live-save');
   const liveConnect = getBoolean(values, 'liveConnect', 'live-connect');
+  const skipSaveVerification = getBoolean(values, 'skipSaveVerification', 'skip-save-verification');
   const allowUnverifiedConnectContinue = getBoolean(values, 'allow-unverified-connect-continue');
   const pilotConfig = getString(values, 'pilot-config') ? loadPilotConfig(getString(values, 'pilot-config')) : null;
   const driverName = getString(values, 'driver') || 'playwright';
@@ -3359,7 +3364,9 @@ async function handleRunAccountBatch(repository, values, logger) {
     }
 
     const results = [];
-    for (const accountName of accountNames) {
+    for (let accountIndex = 0; accountIndex < accountNames.length; accountIndex += 1) {
+      const accountName = accountNames[accountIndex];
+      logger.info(`Account ${accountIndex + 1}/${accountNames.length} started: ${accountName}`);
       const listName = consolidatedListName || buildAccountBatchListName(accountName, listPrefix);
       const coverageRun = await runAccountCoverageWorkflow({
         driver,
@@ -3375,11 +3382,15 @@ async function handleRunAccountBatch(repository, values, logger) {
         reuseSweepCache,
         runId: 'run-account-batch',
         logger: {
+          info(message) {
+            logger.info(`${accountName} | ${message}`);
+          },
           warn(message) {
             logger.warn(summarizeErrorMessage(message));
           },
         },
       });
+      logger.info(`${accountName} | selection started`);
       const coverageArtifactPath = writeAccountCoverageArtifact(accountName, coverageRun.result);
       const selectionOptions = {
         reportOnlyOutOfNetwork: getBoolean(values, 'reportOnlyOutOfNetwork', 'report-only-out-of-network'),
@@ -3403,38 +3414,66 @@ async function handleRunAccountBatch(repository, values, logger) {
         .filter((candidate) => candidate.listSelectionReason === 'strong_but_not_auto_saved')
         .slice(0, 10)
         .map((candidate) => toSdrReportCandidate(candidate));
+      const notSavedExamples = annotatedCoverageCandidates
+        .filter((candidate) => !candidate.selectedForList && candidate.listSelectionReason !== 'strong_but_not_auto_saved')
+        .sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
+        .slice(0, 10)
+        .map((candidate) => toSdrReportCandidate(candidate, 'review_if_persona_looks_relevant'));
+      const manualReviewCandidates = annotatedCoverageCandidates
+        .filter((candidate) => candidate.manualReviewSuggested || candidate.listSelectionReason === 'relative_rank_manual_review')
+        .slice(0, 10)
+        .map((candidate) => toSdrReportCandidate(candidate, 'review_before_save'));
       const saveResults = [];
       const connectResults = [];
 
       if (liveSave && selectedForListSave.length > 0) {
+        logger.info(`${accountName} | live save started: ${selectedForListSave.length} leads`);
         await driver.ensureList(listName, {
           runId: 'run-account-batch',
           accountKey: accountName,
           dryRun: false,
         });
 
-        for (const candidate of selectedForListSave) {
+        for (let saveIndex = 0; saveIndex < selectedForListSave.length; saveIndex += 1) {
+          const candidate = selectedForListSave[saveIndex];
+          const saveRow = await saveBatchCandidateWithRetry({
+            driver,
+            candidate,
+            listName,
+            accountName,
+            readLeadListSnapshot: null,
+          });
+          saveResults.push(saveRow);
+          logger.info(`${accountName} | save ${saveIndex + 1}/${selectedForListSave.length}: ${candidate.fullName} -> ${saveRow.status}`);
+        }
+        if (!skipSaveVerification) {
+          logger.info(`${accountName} | list verification started`);
+          let snapshot = null;
+          let snapshotError = null;
           try {
-            const saveResult = await driver.saveCandidateToList(
-              candidate,
-              { listName, externalRef: null },
-              { runId: 'run-account-batch', accountKey: accountName, dryRun: false },
-            );
-            saveResults.push({
-              fullName: candidate.fullName,
-              status: saveResult.status,
-              note: saveResult.note || null,
-              title: candidate.title || null,
-            });
+            snapshot = await readLeadListSnapshotStrict(driver, listName);
           } catch (error) {
-            saveResults.push({
-              fullName: candidate.fullName,
-              status: 'failed',
-              note: summarizeErrorMessage(error.message),
-              title: candidate.title || null,
+            snapshotError = error;
+          }
+          for (let saveIndex = 0; saveIndex < saveResults.length; saveIndex += 1) {
+            const candidate = selectedForListSave[saveIndex];
+            saveResults[saveIndex] = await verifyFastListSaveRow({
+              row: saveResults[saveIndex],
+              lead: {
+                ...candidate,
+                accountName,
+              },
+              listName,
+              readLeadListSnapshot: async () => {
+                if (snapshotError) {
+                  throw snapshotError;
+                }
+                return snapshot;
+              },
             });
           }
         }
+        logger.info(`${accountName} | list verification ${skipSaveVerification ? 'skipped' : 'finished'}`);
       }
 
       const connectCandidates = liveSave ? selectedForListSave : listCandidates;
@@ -3525,6 +3564,8 @@ async function handleRunAccountBatch(repository, values, logger) {
         coverageArtifactPath,
         candidateCount: coverageRun.result.candidateCount,
         resolutionStatus: coverageRun.result.resolutionStatus || null,
+        companyScope: coverageRun.result.companyScope || null,
+        relativeRankFallbackApplied: annotatedCoverageCandidates.some((candidate) => candidate.relativeRankFallbackApplied),
         attemptedSweepsCount: coverageRun.templates.length,
         failedSweepsCount: coverageRun.sweepErrors.length,
         coverageStatus: deriveSdrCoverageStatus({
@@ -3537,6 +3578,8 @@ async function handleRunAccountBatch(repository, values, logger) {
         strongButNotAutoSavedCount: strongButNotAutoSavedCandidates.length,
         outOfNetworkCount: strongButNotAutoSavedCandidates.length,
         strongButNotAutoSavedCandidates,
+        notSavedExamples,
+        manualReviewCandidates,
         notSavedReasonCounts,
         sdrSummary: summarizeSdrResearchOutcome({
           candidateCount: coverageRun.result.candidateCount,
@@ -3547,6 +3590,7 @@ async function handleRunAccountBatch(repository, values, logger) {
           attemptedSweepsCount: coverageRun.templates.length,
           failedSweepsCount: coverageRun.sweepErrors.length,
           resolutionStatus: coverageRun.result.resolutionStatus || null,
+          relativeRankFallbackApplied: annotatedCoverageCandidates.some((candidate) => candidate.relativeRankFallbackApplied),
           saveResults,
         }),
         saveResults,
@@ -3602,6 +3646,77 @@ async function handleSdrResearch(repository, values, logger) {
   await handleRunAccountBatch(repository, batchValues, logger);
 }
 
+async function saveBatchCandidateWithRetry({
+  driver,
+  candidate,
+  listName,
+  accountName,
+  readLeadListSnapshot = null,
+  maxRetries = 2,
+} = {}) {
+  let lastMessage = null;
+  for (let attempt = 1; attempt <= maxRetries + 1; attempt += 1) {
+    try {
+      const saveResult = await driver.saveCandidateToList(
+        candidate,
+        { listName, externalRef: null },
+        { runId: 'run-account-batch', accountKey: accountName, dryRun: false },
+      );
+      const baseRow = {
+        fullName: candidate.fullName,
+        status: saveResult.status || 'saved',
+        note: saveResult.note || null,
+        title: candidate.title || null,
+        selectionMode: saveResult.selectionMode || null,
+        score: candidate.score ?? null,
+        scoreBreakdown: candidate.scoreBreakdown || null,
+        coverageBucket: candidate.coverageBucket || null,
+        personaTier: candidate.personaTier || null,
+        salesNavigatorUrl: candidate.salesNavigatorUrl || candidate.profileUrl || null,
+        attempt,
+      };
+      return await verifyFastListSaveRow({
+        row: baseRow,
+        lead: {
+          ...candidate,
+          accountName,
+        },
+        listName,
+        readLeadListSnapshot,
+      });
+    } catch (error) {
+      lastMessage = summarizeErrorMessage(error.message);
+      if (attempt <= maxRetries && isRetryableSaveError(lastMessage)) {
+        const backoffMs = 500 * attempt;
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        continue;
+      }
+      return {
+        fullName: candidate.fullName,
+        title: candidate.title || null,
+        status: isRetryableSaveError(lastMessage) ? 'manual_review' : 'failed',
+        note: lastMessage,
+        failureCategory: isRetryableSaveError(lastMessage) ? 'save_ui_manual_review' : 'failed_runtime',
+        nextAction: isRetryableSaveError(lastMessage) ? 'manual_review_before_retry' : 'inspect_runtime_error',
+        score: candidate.score ?? null,
+        scoreBreakdown: candidate.scoreBreakdown || null,
+        coverageBucket: candidate.coverageBucket || null,
+        personaTier: candidate.personaTier || null,
+        salesNavigatorUrl: candidate.salesNavigatorUrl || candidate.profileUrl || null,
+        attempt,
+      };
+    }
+  }
+  return {
+    fullName: candidate.fullName,
+    title: candidate.title || null,
+    status: 'manual_review',
+    note: lastMessage || 'save retry exhausted',
+    failureCategory: 'save_ui_manual_review',
+    nextAction: 'manual_review_before_retry',
+  };
+}
+
 function buildCandidateReportKey(candidate = {}) {
   return String(candidate.salesNavigatorUrl || candidate.profileUrl || `${candidate.fullName || ''}|${candidate.title || ''}`)
     .trim()
@@ -3618,6 +3733,10 @@ function toSdrReportCandidate(candidate, nextAction = 'review_strong_not_saved')
     fullName: candidate.fullName || 'Unknown lead',
     title: candidate.title || null,
     coverageBucket: candidate.coverageBucket || null,
+    personaTier: candidate.personaTier || null,
+    score: candidate.score ?? null,
+    scoreBreakdown: candidate.scoreBreakdown || null,
+    topScoreComponents: candidate.topScoreComponents || null,
     reason: candidate.listSelectionReason || null,
     nextAction,
     salesNavigatorUrl: candidate.salesNavigatorUrl || candidate.profileUrl || null,

--- a/src/core/account-batch.js
+++ b/src/core/account-batch.js
@@ -171,11 +171,12 @@ function summarizeBatchResult(result) {
   const saveResults = result.saveResults
     || (result.status ? [{ fullName: result.fullName || 'Unknown lead', status: result.status, note: result.note || null }] : []);
   const connectResults = result.connectResults || [];
-  const failedSaveStatuses = new Set(['failed', 'failed_runtime', 'failed_rate_limit', 'failed_network', 'failed_ui_state']);
+  const successSaveStatuses = new Set(['saved', 'already_saved', 'results_row_fallback_saved', 'saved_and_verified', 'already_saved_verified']);
+  const failedSaveStatuses = new Set(['failed', 'failed_runtime', 'failed_rate_limit', 'failed_network', 'failed_ui_state', 'missing_after_save', 'wrong_identity_detected']);
   return {
     saveAttemptCount: saveResults.length,
-    saveSuccessCount: saveResults.filter((item) => ['saved', 'already_saved', 'results_row_fallback_saved'].includes(item.status)).length,
-    saveFailureCount: saveResults.filter((item) => failedSaveStatuses.has(item.status)).length,
+    saveSuccessCount: saveResults.filter((item) => successSaveStatuses.has(item.status)).length,
+    saveFailureCount: saveResults.filter((item) => failedSaveStatuses.has(item.status) || failedSaveStatuses.has(item.failureCategory)).length,
     connectAttemptCount: connectResults.length,
     connectSentCount: connectResults.filter((item) => item.status === 'sent').length,
     connectFailureCount: connectResults.filter((item) => item.status === 'failed').length,
@@ -187,7 +188,7 @@ function deriveSdrCoverageStatus({
   failedSweepsCount = 0,
   resolutionStatus = null,
 } = {}) {
-  if (resolutionStatus === 'needs_company_resolution') {
+  if (resolutionStatus === 'needs_company_resolution' || resolutionStatus === 'needs_company_scope_review') {
     return 'needs_company_scope_review';
   }
   const attempted = Number(attemptedSweepsCount || 0);
@@ -222,11 +223,12 @@ function summarizeSdrResearchOutcome(result = {}) {
     selectedForLiveSave: Number(result.selectedForListSaveCount || 0),
     savedVerified: saveResults.filter((item) => verifiedSaveStatuses.has(item.status)).length,
     saveClickedUnverified: saveResults.filter((item) => clickedUnverifiedStatuses.has(item.status)).length,
-    failedSave: saveResults.filter((item) => failedSaveStatuses.has(item.status)).length,
+    failedSave: saveResults.filter((item) => failedSaveStatuses.has(item.status) || failedSaveStatuses.has(item.failureCategory)).length,
     manualReview: saveResults.filter((item) => manualReviewStatuses.has(item.status)).length,
     strongButNotAutoSaved: Number(result.strongButNotAutoSavedCount || 0),
     outOfNetwork: Number(result.outOfNetworkCount ?? result.strongButNotAutoSavedCount ?? 0),
     notAutoSaved: Math.max(0, Number(result.candidateCount || 0) - Number(result.listCandidateCount || 0)),
+    relativeRankFallbackApplied: Boolean(result.relativeRankFallbackApplied),
     attemptedSweeps: Number(result.attemptedSweepsCount || 0),
     failedSweeps: Number(result.failedSweepsCount || 0),
     coverageStatus,
@@ -244,10 +246,55 @@ function summarizeSdrResearchOutcome(result = {}) {
   if (summary.failedSave > 0 || summary.manualReview > 0) {
     summary.nextActions.push('manual_review');
   }
+  if (summary.relativeRankFallbackApplied) {
+    summary.nextActions.push('review_relative_rank_candidates');
+  }
   if (summary.nextActions.length === 0) {
     summary.nextActions.push('no_action');
   }
   return summary;
+}
+
+function isSaveDiscrepancy(item = {}) {
+  return new Set([
+    'save_clicked_unverified',
+    'missing_after_save',
+    'wrong_identity_detected',
+    'save_unverified_unknown',
+  ]).has(item.status) || new Set([
+    'missing_after_save',
+    'wrong_identity_detected',
+    'save_readback_unavailable',
+    'save_unverified',
+  ]).has(item.failureCategory);
+}
+
+function formatScoreContext(item = {}) {
+  const parts = [];
+  if (item.score !== undefined && item.score !== null) {
+    parts.push(`score=${item.score}`);
+  }
+  if (item.coverageBucket) {
+    parts.push(`bucket=${item.coverageBucket}`);
+  }
+  if (item.personaTier) {
+    parts.push(`tier=${item.personaTier}`);
+  }
+  const components = item.topScoreComponents
+    || summarizeTopScoreComponents(item.scoreBreakdown);
+  if (components.length > 0) {
+    parts.push(`score_breakdown=${components.map((entry) => `${entry.component}:${entry.value}`).join(',')}`);
+  }
+  return parts;
+}
+
+function summarizeTopScoreComponents(scoreBreakdown, limit = 3) {
+  const components = scoreBreakdown?.components || {};
+  return Object.entries(components)
+    .filter(([, value]) => Number(value) !== 0)
+    .map(([component, value]) => ({ component, value: Number(value) }))
+    .sort((left, right) => Math.abs(right.value) - Math.abs(left.value))
+    .slice(0, limit);
 }
 
 function deriveConnectOperatorGuidance(item = {}) {
@@ -370,6 +417,12 @@ function renderAccountBatchReportMarkdown(payload) {
     }
     lines.push(`- SDR summary: found=\`${sdrSummary.found}\` | selected=\`${sdrSummary.selectedForList}\` | saved_verified=\`${sdrSummary.savedVerified}\` | save_unverified=\`${sdrSummary.saveClickedUnverified}\` | failed_save=\`${sdrSummary.failedSave}\` | manual_review=\`${sdrSummary.manualReview}\` | out_of_network=\`${sdrSummary.outOfNetwork}\` | failed_sweeps=\`${sdrSummary.failedSweeps}\` | not_auto_saved=\`${sdrSummary.notAutoSaved}\``);
     lines.push(`- Coverage status: \`${sdrSummary.coverageStatus}\``);
+    if (result.companyScope?.warning) {
+      lines.push(`- Company scope warning: \`${result.companyScope.warning}\` (${(result.companyScope.unrelatedCompanies || []).join(', ') || 'unknown company'})`);
+    }
+    if (result.relativeRankFallbackApplied) {
+      lines.push('- Manual review fallback: `top candidates shown because no candidate passed the normal save threshold`');
+    }
     if (sdrSummary.attemptedSweeps > 0) {
       lines.push(`- Sweeps: \`${sdrSummary.attemptedSweeps - sdrSummary.failedSweeps}/${sdrSummary.attemptedSweeps} succeeded\``);
     }
@@ -404,6 +457,7 @@ function renderAccountBatchReportMarkdown(payload) {
         if (item.note) {
           noteParts.push(item.note);
         }
+        noteParts.push(...formatScoreContext(item));
         const note = noteParts.length > 0 ? ` - ${noteParts.join(' | ')}` : '';
         lines.push(`- ${item.fullName}: \`${item.status}\`${note}`);
       }
@@ -443,6 +497,33 @@ function renderAccountBatchReportMarkdown(payload) {
       lines.push('');
     }
 
+    const saveDiscrepancies = (result.saveResults || []).filter(isSaveDiscrepancy).slice(0, 10);
+    if (saveDiscrepancies.length > 0) {
+      lines.push(`### Save Discrepancies`);
+      for (const item of saveDiscrepancies) {
+        const noteParts = [];
+        if (item.title) {
+          noteParts.push(item.title);
+        }
+        if (item.failureCategory) {
+          noteParts.push(`reason=${item.failureCategory}`);
+        }
+        if (item.verificationStatus) {
+          noteParts.push(`verification=${item.verificationStatus}`);
+        }
+        if (item.nextAction) {
+          noteParts.push(`next=${item.nextAction}`);
+        }
+        if (item.note) {
+          noteParts.push(item.note);
+        }
+        noteParts.push(...formatScoreContext(item));
+        const note = noteParts.length > 0 ? ` - ${noteParts.join(' | ')}` : '';
+        lines.push(`- ${item.fullName}: \`${item.status}\`${note}`);
+      }
+      lines.push('');
+    }
+
     const strongNotSaved = (result.strongButNotAutoSavedCandidates || []).slice(0, 10);
     if (strongNotSaved.length > 0) {
       lines.push(`### Strong but not auto-saved`);
@@ -457,6 +538,7 @@ function renderAccountBatchReportMarkdown(payload) {
         if (item.nextAction) {
           noteParts.push(`next=${item.nextAction}`);
         }
+        noteParts.push(...formatScoreContext(item));
         const note = noteParts.length > 0 ? ` - ${noteParts.join(' | ')}` : '';
         lines.push(`- ${item.fullName}: \`${item.coverageBucket || 'unknown'}\`${note}`);
       }
@@ -468,6 +550,48 @@ function renderAccountBatchReportMarkdown(payload) {
       lines.push(`### Not Saved Reasons`);
       for (const [reason, count] of Object.entries(notSavedReasons)) {
         lines.push(`- ${reason}: \`${count}\``);
+      }
+      lines.push('');
+    }
+
+    const notSavedExamples = (result.notSavedExamples || []).slice(0, 10);
+    if (notSavedExamples.length > 0) {
+      lines.push(`### Not Saved Examples`);
+      for (const item of notSavedExamples) {
+        const noteParts = [];
+        if (item.title) {
+          noteParts.push(item.title);
+        }
+        if (item.reason) {
+          noteParts.push(`reason=${item.reason}`);
+        }
+        if (item.nextAction) {
+          noteParts.push(`next=${item.nextAction}`);
+        }
+        noteParts.push(...formatScoreContext(item));
+        const note = noteParts.length > 0 ? ` - ${noteParts.join(' | ')}` : '';
+        lines.push(`- ${item.fullName}: \`${item.coverageBucket || 'unknown'}\`${note}`);
+      }
+      lines.push('');
+    }
+
+    const reviewCandidates = (result.manualReviewCandidates || []).slice(0, 10);
+    if (reviewCandidates.length > 0) {
+      lines.push(`### Review Before Saving`);
+      for (const item of reviewCandidates) {
+        const noteParts = [];
+        if (item.title) {
+          noteParts.push(item.title);
+        }
+        if (item.reason) {
+          noteParts.push(`reason=${item.reason}`);
+        }
+        if (item.nextAction) {
+          noteParts.push(`next=${item.nextAction}`);
+        }
+        noteParts.push(...formatScoreContext(item));
+        const note = noteParts.length > 0 ? ` - ${noteParts.join(' | ')}` : '';
+        lines.push(`- ${item.fullName}: \`${item.coverageBucket || 'unknown'}\`${note}`);
       }
       lines.push('');
     }

--- a/src/core/account-coverage.js
+++ b/src/core/account-coverage.js
@@ -62,8 +62,27 @@ function findAccountAliasEntry(aliasConfig, accountName) {
   const normalizedTarget = normalizeAccountAliasKey(accountName);
   const matchingKey = Object.keys(accounts).find((key) => (
     normalizeAccountAliasKey(key) === normalizedTarget
+    || accountAliasEntryMatchesName(accounts[key], normalizedTarget)
   ));
   return matchingKey ? accounts[matchingKey] : {};
+}
+
+function accountAliasEntryMatchesName(entry = {}, normalizedTarget = '') {
+  if (!normalizedTarget) {
+    return false;
+  }
+  const values = [
+    ...(entry.accountSearchAliases || []),
+    ...(entry.companyFilterAliases || []),
+    ...(entry.parentAliases || []),
+    ...(entry.subsidiaryAliases || []),
+    ...(entry.targets || []).flatMap((target) => [
+      target.linkedinName,
+      target.name,
+      target.companyName,
+    ]),
+  ].filter(Boolean);
+  return values.some((value) => normalizeAccountAliasKey(value) === normalizedTarget);
 }
 
 function loadPriorityModel() {
@@ -389,6 +408,94 @@ function inferLiveScopedTargets(activeAccount, accountName, candidates = []) {
     .slice(0, 3);
 }
 
+function normalizeCompanyScopeLabel(value) {
+  return normalizeAccountAliasKey(value);
+}
+
+function companyScopeLabelsMatch(left, right) {
+  const normalizedLeft = normalizeCompanyScopeLabel(left);
+  const normalizedRight = normalizeCompanyScopeLabel(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  if (normalizedLeft === normalizedRight) {
+    return true;
+  }
+  const leftTokens = new Set(normalizedLeft.split(/\s+/).filter((token) => token.length >= 3));
+  const rightTokens = new Set(normalizedRight.split(/\s+/).filter((token) => token.length >= 3));
+  const overlap = [...leftTokens].filter((token) => rightTokens.has(token));
+  return overlap.length > 0 && (
+    normalizedLeft.includes(normalizedRight)
+    || normalizedRight.includes(normalizedLeft)
+    || overlap.length >= Math.min(2, leftTokens.size, rightTokens.size)
+  );
+}
+
+function buildAllowedCompanyScopeLabels({
+  accountName,
+  aliasEntry = {},
+  companyResolution = {},
+  activeAccount = {},
+} = {}) {
+  return [
+    accountName,
+    activeAccount?.salesNav?.selectedCompanyLabel,
+    activeAccount?.salesNav?.selectedCompanyName,
+    activeAccount?.salesNav?.companyName,
+    ...(activeAccount?.salesNav?.companyTargets || []).map((target) => target.linkedinName),
+    ...(companyResolution.targets || []).map((target) => target.linkedinName),
+    ...(aliasEntry.accountSearchAliases || []),
+    ...(aliasEntry.companyFilterAliases || []),
+    ...(aliasEntry.parentAliases || []),
+    ...(aliasEntry.subsidiaryAliases || []),
+    ...(aliasEntry.targets || []).map((target) => target.linkedinName || target.name || target.companyName),
+  ]
+    .map((label) => String(label || '').replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .filter((label, index, all) => all.findIndex((entry) => normalizeCompanyScopeLabel(entry) === normalizeCompanyScopeLabel(label)) === index);
+}
+
+function assessCompanyScopeIntegrity({
+  accountName,
+  aliasEntry = {},
+  companyResolution = {},
+  activeAccount = {},
+  candidates = [],
+} = {}) {
+  const allowedLabels = buildAllowedCompanyScopeLabels({
+    accountName,
+    aliasEntry,
+    companyResolution,
+    activeAccount,
+  });
+  const related = [];
+  const unrelated = [];
+  for (const candidate of candidates || []) {
+    const company = String(candidate.company || candidate.accountName || '').replace(/\s+/g, ' ').trim();
+    if (!company) {
+      related.push(candidate);
+      continue;
+    }
+    const allowed = allowedLabels.some((label) => companyScopeLabelsMatch(company, label));
+    (allowed ? related : unrelated).push(candidate);
+  }
+  const unrelatedCompanies = [...new Set(unrelated.map((candidate) => candidate.company).filter(Boolean))].slice(0, 10);
+  const selectedTargets = allowedLabels.slice(0, 5);
+  const contaminationDetected = unrelated.length > 0 && related.length > 0;
+  const allCandidatesUnrelated = unrelated.length > 0 && related.length === 0;
+  return {
+    contaminationDetected,
+    allCandidatesUnrelated,
+    allowedLabels,
+    selectedTargets,
+    unrelatedCandidateCount: unrelated.length,
+    relatedCandidateCount: related.length,
+    unrelatedCompanies,
+    keptCandidates: allCandidatesUnrelated ? [] : related,
+    warning: contaminationDetected || allCandidatesUnrelated ? 'cross_company_contamination_detected' : null,
+  };
+}
+
 function summarizeCompanyResolutionForCoverage({
   companyResolution,
   companyResolutionArtifact,
@@ -397,6 +504,7 @@ function summarizeCompanyResolutionForCoverage({
   accountName,
   finalResult,
   rawResults,
+  companyScopeAssessment = null,
 }) {
   const selectedTargets = companyResolution.targets.map((target) => target.linkedinName);
   const liveScoped = hasSuccessfulLiveSweepEvidence(rawResults);
@@ -408,11 +516,23 @@ function summarizeCompanyResolutionForCoverage({
   );
 
   if (liveScoped && resolverWasUncertain && Number(finalResult?.candidateCount || 0) > 0) {
+    if (companyScopeAssessment?.warning) {
+      return {
+        status: 'needs_manual_company_review',
+        confidence: 0.6,
+        recommendedAction: 'review_company_scope_before_sweeps',
+        selectedTargets: companyScopeAssessment.selectedTargets || inferLiveScopedTargets(activeAccount, accountName, finalResult.candidates || []),
+        artifactPath: companyResolutionArtifact.artifactPath,
+        reportPath: companyResolutionArtifact.reportPath,
+        evidence: ['live_people_sweep_returned_candidates', companyScopeAssessment.warning],
+      };
+    }
+    const liveTargets = inferLiveScopedTargets(activeAccount, accountName, finalResult.candidates || []);
     return {
       status: 'resolved_by_live_scope',
-      confidence: 1,
+      confidence: liveTargets.length === 1 ? 0.9 : 0.75,
       recommendedAction: 'run_people_sweeps',
-      selectedTargets: inferLiveScopedTargets(activeAccount, accountName, finalResult.candidates || []),
+      selectedTargets: liveTargets,
       artifactPath: companyResolutionArtifact.artifactPath,
       reportPath: companyResolutionArtifact.reportPath,
       evidence: ['live_people_sweep_returned_candidates'],
@@ -842,6 +962,9 @@ async function runAccountCoverageWorkflow({
     aliasConfig,
     priorCoverage,
   }), { now });
+  if (logger && typeof logger.info === 'function') {
+    logger.info(`Company scope checked for ${accountName}: ${companyResolution.status}`);
+  }
   const companyResolutionArtifact = await timePhase(timings, 'company_resolution_artifact', async () =>
     writeCompanyResolutionArtifact(companyResolution), { now });
   const account = {
@@ -897,6 +1020,9 @@ async function runAccountCoverageWorkflow({
       break;
     }
     const template = templates[templateIndex];
+    if (logger && typeof logger.info === 'function') {
+      logger.info(`Sweep ${templateIndex + 1}/${templates.length} started: ${template.id}`);
+    }
 
     if (
       shouldAdaptiveSkipRestSweep({
@@ -939,6 +1065,9 @@ async function runAccountCoverageWorkflow({
           seenCandidateKeys.add(key);
         }
         registerSweepAdds(uniqueNew, template.id);
+        if (logger && typeof logger.info === 'function') {
+          logger.info(`Sweep ${templateIndex + 1}/${templates.length} finished: ${template.id} | candidates=${cacheHit.candidates.length} | new=${uniqueNew} | cache=hit`);
+        }
       }, {
         now,
         meta: {
@@ -982,6 +1111,9 @@ async function runAccountCoverageWorkflow({
           seenCandidateKeys.add(key);
         }
         registerSweepAdds(uniqueNew, template.id);
+        if (logger && typeof logger.info === 'function') {
+          logger.info(`Sweep ${templateIndex + 1}/${templates.length} finished: ${template.id} | candidates=${candidates.length} | new=${uniqueNew}`);
+        }
         if (reuseSweepCache) {
           writeSweepCache(sweepCacheDir, cacheKey, {
             accountName,
@@ -1052,6 +1184,28 @@ async function runAccountCoverageWorkflow({
       ...result,
       ...(sweepErrors.length > 0 ? { sweepErrors } : {}),
     };
+  const companyScopeAssessment = assessCompanyScopeIntegrity({
+    accountName,
+    aliasEntry,
+    companyResolution,
+    activeAccount,
+    candidates: finalResult.candidates || [],
+  });
+  if (companyScopeAssessment.warning) {
+    finalResult.companyScope = {
+      status: 'needs_company_scope_review',
+      warning: companyScopeAssessment.warning,
+      unrelatedCandidateCount: companyScopeAssessment.unrelatedCandidateCount,
+      relatedCandidateCount: companyScopeAssessment.relatedCandidateCount,
+      unrelatedCompanies: companyScopeAssessment.unrelatedCompanies,
+      allowedLabels: companyScopeAssessment.allowedLabels,
+    };
+    finalResult.candidates = companyScopeAssessment.keptCandidates;
+    finalResult.candidateCount = finalResult.candidates.length;
+    finalResult.personaCoverage = summarizePersonaCoverage(finalResult.candidates);
+    finalResult.resolutionStatus = 'needs_company_scope_review';
+    finalResult.coverageError = `${companyScopeAssessment.warning}: ${companyScopeAssessment.unrelatedCompanies.join(', ')}`;
+  }
   finalResult.companyResolution = summarizeCompanyResolutionForCoverage({
     companyResolution,
     companyResolutionArtifact,
@@ -1060,6 +1214,7 @@ async function runAccountCoverageWorkflow({
     accountName,
     finalResult,
     rawResults,
+    companyScopeAssessment,
   });
   if (needsCompanyResolution) {
     finalResult.resolutionStatus = 'needs_company_resolution';
@@ -1348,7 +1503,7 @@ function classifyCoverageListSelection(candidate, options = {}) {
 }
 
 function annotateCoverageCandidatesForListSelection(result, options = {}) {
-  return (result?.candidates || [])
+  const annotated = (result?.candidates || [])
     .map((candidate) => {
       const selection = classifyCoverageListSelection(candidate, options);
       return {
@@ -1359,6 +1514,33 @@ function annotateCoverageCandidatesForListSelection(result, options = {}) {
         selectedForList: selection.selected,
       };
     });
+  const minScore = Number.isFinite(Number(options.minScore))
+    ? Number(options.minScore)
+    : 25;
+  const selectedCount = annotated.filter((candidate) => candidate.selectedForList).length;
+  const maxScore = Math.max(...annotated.map((candidate) => Number(candidate.score || 0)), 0);
+  if (options.relativeRankFallback !== false && annotated.length > 0 && selectedCount === 0 && maxScore < minScore) {
+    const fallbackLimit = Number.isFinite(Number(options.relativeRankFallbackLimit))
+      ? Number(options.relativeRankFallbackLimit)
+      : 10;
+    const fallbackKeys = new Set(
+      annotated
+        .filter((candidate) => Number(candidate.score || 0) > 0)
+        .sort((left, right) => Number(right.score || 0) - Number(left.score || 0))
+        .slice(0, fallbackLimit)
+        .map(normalizeCandidateKey),
+    );
+    return annotated.map((candidate) => fallbackKeys.has(normalizeCandidateKey(candidate))
+      ? {
+        ...candidate,
+        listSelectionReason: 'relative_rank_manual_review',
+        manualReviewSuggested: true,
+        relativeRankFallbackApplied: true,
+        selectedForList: false,
+      }
+      : candidate);
+  }
+  return annotated;
 }
 
 function selectCoverageListCandidates(result, options = {}) {

--- a/src/core/company-resolution.js
+++ b/src/core/company-resolution.js
@@ -48,8 +48,31 @@ function findCompanyAliasEntry(aliasConfig, accountName) {
   }
 
   const normalizedTarget = normalizeCompanyName(accountName);
-  const matchingKey = Object.keys(accounts).find((key) => normalizeCompanyName(key) === normalizedTarget);
+  const matchingKey = Object.keys(accounts).find((key) => {
+    if (normalizeCompanyName(key) === normalizedTarget) {
+      return true;
+    }
+    return companyAliasEntryMatchesName(accounts[key], normalizedTarget);
+  });
   return matchingKey ? accounts[matchingKey] : {};
+}
+
+function companyAliasEntryMatchesName(entry = {}, normalizedTarget = '') {
+  if (!normalizedTarget) {
+    return false;
+  }
+  const values = [
+    ...(entry.accountSearchAliases || []),
+    ...(entry.companyFilterAliases || []),
+    ...(entry.parentAliases || []),
+    ...(entry.subsidiaryAliases || []),
+    ...(entry.targets || []).flatMap((target) => [
+      target.linkedinName,
+      target.name,
+      target.companyName,
+    ]),
+  ].filter(Boolean);
+  return values.some((value) => normalizeCompanyName(value) === normalizedTarget);
 }
 
 function loadCompanyAliasConfig(configPath = null) {
@@ -103,6 +126,7 @@ function buildCompanyResolution({
   const resolvedAliasConfig = aliasConfig || loadCompanyAliasConfig();
   const resolvedLearnedRegistry = learnedRegistry || loadLearnedCompanyTargets();
   const name = String(accountName || account?.accountName || account?.name || '').trim();
+  const searchDiagnostics = buildCompanyResolutionSearchDiagnostics(name);
   const aliasEntry = findCompanyAliasEntry(resolvedAliasConfig, name);
   const learnedEntry = findCompanyAliasEntry(resolvedLearnedRegistry, name);
   const evidence = [];
@@ -176,8 +200,34 @@ function buildCompanyResolution({
     generatedAt: now.toISOString(),
     recommendedAction,
     evidence,
+    searchVariantsTried: searchDiagnostics.variants,
+    manualSearchUrls: searchDiagnostics.urls,
     targets: selectedTargets.map(normalizeTargetForArtifact),
     allCandidates: targets.slice(0, 10).map(normalizeTargetForArtifact),
+  };
+}
+
+function buildCompanyResolutionSearchDiagnostics(accountName) {
+  const raw = String(accountName || '').replace(/\s+/g, ' ').trim();
+  const titleCase = raw.toLowerCase().replace(/\b[a-z]/g, (letter) => letter.toUpperCase());
+  const slug = raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  const variants = [...new Set([
+    raw,
+    titleCase,
+    raw.toUpperCase(),
+    slug,
+  ].filter(Boolean))];
+  const primary = variants[0] || '';
+  return {
+    variants,
+    urls: {
+      linkedinCompanySearchUrl: primary
+        ? `https://www.linkedin.com/search/results/companies/?keywords=${encodeURIComponent(primary)}`
+        : null,
+      salesNavigatorCompanySearchUrl: primary
+        ? `https://www.linkedin.com/sales/search/company?keywords=${encodeURIComponent(primary)}`
+        : null,
+    },
   };
 }
 
@@ -389,6 +439,15 @@ function renderCompanyResolutionMarkdown(resolution = {}) {
   lines.push(`- Confidence: \`${resolution.confidence ?? 0}\``);
   lines.push(`- Recommended action: \`${resolution.recommendedAction || 'unknown'}\``);
   lines.push(`- Evidence: \`${(resolution.evidence || []).join(', ') || 'none'}\``);
+  if ((resolution.searchVariantsTried || []).length > 0) {
+    lines.push(`- Search variants tried: \`${resolution.searchVariantsTried.join(', ')}\``);
+  }
+  if (resolution.manualSearchUrls?.linkedinCompanySearchUrl) {
+    lines.push(`- Manual LinkedIn company search: ${resolution.manualSearchUrls.linkedinCompanySearchUrl}`);
+  }
+  if (resolution.manualSearchUrls?.salesNavigatorCompanySearchUrl) {
+    lines.push(`- Manual Sales Navigator company search: ${resolution.manualSearchUrls.salesNavigatorCompanySearchUrl}`);
+  }
   lines.push('');
   lines.push('## Targets');
   if ((resolution.targets || []).length === 0) {
@@ -471,6 +530,7 @@ module.exports = {
   classifyCompanyResolutionStatus,
   companyNameFromLinkedInUrl,
   findCompanyAliasEntry,
+  buildCompanyResolutionSearchDiagnostics,
   findLatestCompanyResolutionArtifact,
   getCompanyResolutionRecommendedAction,
   loadCompanyAliasConfig,

--- a/src/core/scoring.js
+++ b/src/core/scoring.js
@@ -20,6 +20,12 @@ function classifyNonIcpTitleReason(value) {
   if (/\b(global travel retail|commercial integration|business development|client relations|international client relations|workforce management)\b/.test(text)) {
     return 'non_icp_commercial_or_operations_function';
   }
+  if (
+    /\b(value engineering|value consulting|master data management|stammdaten|mdm|data protection|datenschutz|it law|legal|corporate security|forensics|forensik|safety|compliance officer)\b/.test(text)
+    && !/\b(observability|observabilitat|monitoring|platform|plattform|sre|site reliability|devops)\b/.test(text)
+  ) {
+    return 'false_positive_buyer_function';
+  }
 
   return null;
 }
@@ -56,6 +62,7 @@ function detectRoleFamily(candidate, icpConfig = {}) {
   if (/\b(chief (data|analytics|ai|artificial intelligence)(\s*&\s*|\s+and\s+)?(analytics|ai|artificial intelligence)? officer|chief data\s*&\s*analytics officer|head of (ai|artificial intelligence)|director of (ai|artificial intelligence)|vp (of )?(ai|artificial intelligence|data|analytics))\b/.test(text)) return 'executive_engineering';
   if (matchesAnyText(text, multilingual.platformOperator)) return 'platform_engineering';
   if (/\b(platform engineering|director of platform engineering|head of cloud|head of platform|cloud technology|platform operations|technology foundation operations)\b/.test(text)) return 'platform_engineering';
+  if (/\b(abteilungsleiter|bereichsleiter|geschaftsbereichsleiter|hauptabteilungsleiter|teamleiter)\b/.test(text) && /\b(platforms?|plattform|cloud|infrastructure|infrastruktur|sre|site reliability|devops|monitoring|observability|observabilitat)\b/.test(text)) return 'platform_engineering';
   if (/\b(chief information officer|chief technology officer|chief data officer|cio|cto|cdo|directeur technique|directrice technique|directeur des systemes d'information|directrice des systemes d'information|dsi|directeur informatique|directrice informatique|director tecnico|directora tecnica|director de tecnologia|directora de tecnologia|direttore tecnico|direttrice tecnica|direttore tecnologia|direttrice tecnologia)\b/.test(text)) return 'executive_engineering';
   if (/\b(mlops|aiops|dataops|ai platform|data platform|plateforme de donnees|plataforma de datos|datenplattform|data piattaforma|piattaforma dati)\b/.test(text)) return 'data';
   if (/microservices?.*(engineer|architect|developer)|(engineer|architect|developer).*microservices?/.test(text)) return 'platform_engineering';
@@ -87,6 +94,8 @@ function detectSeniority(candidate, icpConfig = {}) {
   if (/vice president|\bvp\b/.test(text)) return 'vp';
   if (matchesAnyText(text, multilingual.seniorityDirector)) return 'director';
   if (/director|directeur|directrice|direktor|direktorin|direttore|direttrice|directora/.test(text)) return 'director';
+  if (/\b(abteilungsleiter|bereichsleiter|geschaftsbereichsleiter|hauptabteilungsleiter)\b/.test(text)) return 'director';
+  if (/\b(teamleiter)\b/.test(text)) return 'lead';
   if (/head|leiter|leiterin|jefe|responsable|responsabili?e/.test(text)) return 'head';
   if (/manager|gestionnaire/.test(text)) return 'manager';
   if (/staff/.test(text)) return 'staff';

--- a/tests/account-batch.test.js
+++ b/tests/account-batch.test.js
@@ -120,8 +120,38 @@ test('renderAccountBatchReportMarkdown includes pilot-friendly save summaries', 
         listCandidateCount: 8,
         selectedForListSaveCount: 3,
         saveResults: [
-          { fullName: 'Philipp Weidinger', status: 'saved' },
+          {
+            fullName: 'Philipp Weidinger',
+            status: 'saved_and_verified',
+            score: 64,
+            coverageBucket: 'direct_observability',
+            personaTier: 'operator',
+            scoreBreakdown: { components: { roleScore: 18, seniorityScore: 16, observabilityScore: 24 } },
+          },
           { fullName: 'Ralf Koppitz', status: 'failed', note: 'selector issue' },
+          {
+            fullName: 'Missing Save',
+            title: 'Platform Lead',
+            status: 'save_clicked_unverified',
+            failureCategory: 'missing_after_save',
+            verificationStatus: 'missing_after_save',
+            nextAction: 'retry_or_manual_review_list_membership',
+            note: 'save clicked but missing from list',
+            score: 58,
+            coverageBucket: 'direct_observability',
+            personaTier: 'operator',
+          },
+        ],
+        notSavedExamples: [
+          {
+            fullName: 'Dropped Candidate',
+            title: 'IT Platform Specialist',
+            coverageBucket: 'technical_adjacent',
+            score: 24,
+            reason: 'below_icp_selection_threshold',
+            nextAction: 'review_if_persona_looks_relevant',
+            scoreBreakdown: { components: { roleScore: 16, seniorityScore: 8 } },
+          },
         ],
         connectResults: [],
       },
@@ -133,11 +163,15 @@ test('renderAccountBatchReportMarkdown includes pilot-friendly save summaries', 
   assert.match(markdown, /List name template: `Research \{date\}`/);
   assert.match(markdown, /Max list saves per account: `3`/);
   assert.match(markdown, /Selected for live save: `3`/);
-  assert.match(markdown, /SDR summary: found=`20` \| selected=`8` \| saved_verified=`0` \| save_unverified=`1` \| failed_save=`1` \| manual_review=`0` \| out_of_network=`0` \| failed_sweeps=`0` \| not_auto_saved=`12`/);
+  assert.match(markdown, /SDR summary: found=`20` \| selected=`8` \| saved_verified=`1` \| save_unverified=`1` \| failed_save=`2` \| manual_review=`0` \| out_of_network=`0` \| failed_sweeps=`0` \| not_auto_saved=`12`/);
   assert.match(markdown, /Coverage status: `completed`/);
   assert.match(markdown, /Next action: `verify_list_membership, manual_review`/);
-  assert.match(markdown, /Philipp Weidinger: `saved`/);
+  assert.match(markdown, /Philipp Weidinger: `saved_and_verified` - score=64 \| bucket=direct_observability \| tier=operator \| score_breakdown=observabilityScore:24,roleScore:18,seniorityScore:16/);
   assert.match(markdown, /Ralf Koppitz: `failed` - selector issue/);
+  assert.match(markdown, /### Save Discrepancies/);
+  assert.match(markdown, /Missing Save: `save_clicked_unverified` - Platform Lead \| reason=missing_after_save \| verification=missing_after_save \| next=retry_or_manual_review_list_membership/);
+  assert.match(markdown, /### Not Saved Examples/);
+  assert.match(markdown, /Dropped Candidate: `technical_adjacent` - IT Platform Specialist \| reason=below_icp_selection_threshold \| next=review_if_persona_looks_relevant \| score=24/);
 });
 
 test('summarizeSdrResearchOutcome explains found vs saved gaps for SDRs', () => {
@@ -166,6 +200,7 @@ test('summarizeSdrResearchOutcome explains found vs saved gaps for SDRs', () => 
     strongButNotAutoSaved: 4,
     outOfNetwork: 4,
     notAutoSaved: 24,
+    relativeRankFallbackApplied: false,
     attemptedSweeps: 20,
     failedSweeps: 8,
     coverageStatus: 'needs_company_scope_review',
@@ -196,6 +231,11 @@ test('renderAccountBatchReportMarkdown shows strong report-only candidates and n
         selectedForListSaveCount: 6,
         attemptedSweepsCount: 20,
         failedSweepsCount: 8,
+        relativeRankFallbackApplied: true,
+        companyScope: {
+          warning: 'cross_company_contamination_detected',
+          unrelatedCompanies: ['Deutsche Bank'],
+        },
         strongButNotAutoSavedCount: 2,
         saveResults: [],
         strongButNotAutoSavedCandidates: [
@@ -203,8 +243,22 @@ test('renderAccountBatchReportMarkdown shows strong report-only candidates and n
             fullName: 'Nicolas di Giuseppe',
             title: 'Senior Engineering Manager - AI & Scheduling Squads',
             coverageBucket: 'direct_observability',
+            score: 72,
+            personaTier: 'operator',
+            scoreBreakdown: { components: { roleScore: 18, seniorityScore: 12, observabilityScore: 24 } },
             reason: 'strong_but_not_auto_saved',
             nextAction: 'review_strong_not_saved',
+          },
+        ],
+        manualReviewCandidates: [
+          {
+            fullName: 'Relative Rank Candidate',
+            title: 'IT Platform Specialist',
+            coverageBucket: 'broad_it_stakeholder',
+            score: 24,
+            reason: 'relative_rank_manual_review',
+            nextAction: 'review_before_save',
+            scoreBreakdown: { components: { roleScore: 16, seniorityScore: 8 } },
           },
         ],
         notSavedReasonCounts: {
@@ -217,11 +271,15 @@ test('renderAccountBatchReportMarkdown shows strong report-only candidates and n
 
   assert.match(markdown, /SDR summary: found=`30` \| selected=`6` .* out_of_network=`2` \| failed_sweeps=`8`/);
   assert.match(markdown, /Coverage status: `needs_company_scope_review`/);
+  assert.match(markdown, /Company scope warning: `cross_company_contamination_detected` \(Deutsche Bank\)/);
+  assert.match(markdown, /Manual review fallback: `top candidates shown because no candidate passed the normal save threshold`/);
   assert.match(markdown, /Sweeps: `12\/20 succeeded`/);
-  assert.match(markdown, /Next action: `retry_company_scope, review_strong_not_saved`/);
+  assert.match(markdown, /Next action: `retry_company_scope, review_strong_not_saved, review_relative_rank_candidates`/);
   assert.match(markdown, /### Strong but not auto-saved/);
-  assert.match(markdown, /Nicolas di Giuseppe: `direct_observability` - Senior Engineering Manager - AI & Scheduling Squads \| reason=strong_but_not_auto_saved \| next=review_strong_not_saved/);
+  assert.match(markdown, /Nicolas di Giuseppe: `direct_observability` - Senior Engineering Manager - AI & Scheduling Squads \| reason=strong_but_not_auto_saved \| next=review_strong_not_saved \| score=72 \| bucket=direct_observability \| tier=operator/);
   assert.match(markdown, /strong_but_not_auto_saved: `2`/);
+  assert.match(markdown, /### Review Before Saving/);
+  assert.match(markdown, /Relative Rank Candidate: `broad_it_stakeholder` - IT Platform Specialist \| reason=relative_rank_manual_review \| next=review_before_save \| score=24/);
 });
 
 test('renderAccountBatchReportMarkdown supports smoke-style artifacts with direct status fields', () => {

--- a/tests/account-coverage.test.js
+++ b/tests/account-coverage.test.js
@@ -748,6 +748,33 @@ test('selectCoverageListCandidates broadly keeps technical-adjacent ICP personas
   ]);
 });
 
+test('annotateCoverageCandidatesForListSelection surfaces relative-rank manual review when nothing passes threshold', () => {
+  const annotated = annotateCoverageCandidatesForListSelection({
+    candidates: [
+      {
+        fullName: 'Low Score Platform',
+        title: 'Platform Analyst',
+        coverageBucket: 'likely_noise',
+        roleFamily: 'platform_engineering',
+        score: 24,
+      },
+      {
+        fullName: 'Lower Score IT',
+        title: 'IT Specialist',
+        coverageBucket: 'likely_noise',
+        roleFamily: 'infrastructure',
+        score: 12,
+      },
+    ],
+  }, { minScore: 50, relativeRankFallbackLimit: 1 });
+
+  assert.equal(annotated[0].selectedForList, false);
+  assert.equal(annotated[0].listSelectionReason, 'relative_rank_manual_review');
+  assert.equal(annotated[0].manualReviewSuggested, true);
+  assert.equal(annotated[0].relativeRankFallbackApplied, true);
+  assert.equal(annotated[1].listSelectionReason, 'bucket_not_included');
+});
+
 test('consolidateCoverageCandidates adds buyer operator user coverage warnings', () => {
   const coverageConfig = readJson(resolveProjectPath('config', 'account-coverage', 'default.json'));
   const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
@@ -1009,9 +1036,62 @@ test('runAccountCoverageWorkflow upgrades failed company resolution when live sw
 
   assert.equal(run.result.candidateCount, 1);
   assert.equal(run.result.companyResolution.status, 'resolved_by_live_scope');
-  assert.equal(run.result.companyResolution.confidence, 1);
+  assert.equal(run.result.companyResolution.confidence, 0.9);
   assert.equal(run.result.companyResolution.recommendedAction, 'run_people_sweeps');
   assert.deepEqual(run.result.companyResolution.selectedTargets, ['Live Scoped Unknown Account']);
+});
+
+test('runAccountCoverageWorkflow filters cross-company contamination before list selection', async () => {
+  const coverageConfig = {
+    broadCrawl: { enabled: true, maxCandidates: 3 },
+    sweeps: [],
+  };
+  const icpConfig = readJson(resolveProjectPath('config', 'icp', 'default-observability.json'));
+
+  const driver = {
+    async openAccountSearch() {},
+    async enumerateAccounts(accounts) {
+      return accounts;
+    },
+    async openPeopleSearch() {},
+    async applySearchTemplate() {},
+    async scrollAndCollectCandidates() {
+      return [
+        {
+          fullName: 'EDEKA Platform Lead',
+          title: 'Head of Platform Engineering',
+          company: 'EDEKA DIGITAL GmbH',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/edeka-platform',
+        },
+        {
+          fullName: 'Wrong Bank Lead',
+          title: 'Head of Platform Engineering',
+          company: 'Deutsche Bank',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/wrong-bank',
+        },
+        {
+          fullName: 'Wrong Club Lead',
+          title: 'Head of Platform Engineering',
+          company: 'Dynamics e.V.',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/wrong-club',
+        },
+      ];
+    },
+  };
+
+  const run = await runAccountCoverageWorkflow({
+    driver,
+    accountName: 'EDEKA',
+    coverageConfig,
+    icpConfig,
+    priorityModel: null,
+  });
+
+  assert.equal(run.result.companyScope.warning, 'cross_company_contamination_detected');
+  assert.equal(run.result.resolutionStatus, 'needs_company_scope_review');
+  assert.deepEqual(run.result.companyScope.unrelatedCompanies, ['Deutsche Bank', 'Dynamics e.V.']);
+  assert.deepEqual(run.result.candidates.map((candidate) => candidate.fullName), ['EDEKA Platform Lead']);
+  assert.equal(run.result.companyResolution.selectedTargets.includes('Deutsche Bank'), false);
 });
 
 test('runAccountCoverageWorkflow falls back to the last successful artifact when live coverage is empty', async () => {
@@ -1310,6 +1390,11 @@ test('findAccountAliasEntry tolerates legal suffix and punctuation variants', ()
   assert.equal(
     findAccountAliasEntry(config, 'Example Broadcast Studio').companyFilterAliases[0],
     'Example Broadcaster',
+  );
+  assert.equal(
+    findAccountAliasEntry(config, 'EDEKA DIGITAL').targets
+      .some((target) => target.linkedinName === 'EDEKA DIGITAL GmbH'),
+    true,
   );
 });
 

--- a/tests/company-resolution.test.js
+++ b/tests/company-resolution.test.js
@@ -34,6 +34,16 @@ test('findCompanyAliasEntry tolerates legal suffix and punctuation variants', ()
   );
 });
 
+test('findCompanyAliasEntry matches configured target and subsidiary aliases', () => {
+  const aliasConfig = readJson(resolveProjectPath('config', 'account-aliases', 'default.json'));
+
+  assert.equal(
+    findCompanyAliasEntry(aliasConfig, 'EDEKA DIGITAL').targets
+      .some((target) => target.linkedinName === 'EDEKA DIGITAL GmbH'),
+    true,
+  );
+});
+
 test('buildCompanyResolution resolves seeded hard accounts', () => {
   const aliasConfig = readJson(resolveProjectPath('config', 'account-aliases', 'default.json'));
   const mediaGroup = buildCompanyResolution({
@@ -54,6 +64,21 @@ test('buildCompanyResolution resolves seeded hard accounts', () => {
   assert.ok(mediaGroup.confidence >= 0.85);
   assert.equal(logisticsGroup.status, 'resolved_exact');
   assert.equal(logisticsGroup.targets[0].linkedinName, 'Example Logistics');
+});
+
+test('buildCompanyResolution resolves EDEKA DIGITAL through curated subsidiary target', () => {
+  const aliasConfig = readJson(resolveProjectPath('config', 'account-aliases', 'default.json'));
+  const resolution = buildCompanyResolution({
+    accountName: 'EDEKA DIGITAL',
+    source: 'territory',
+    aliasConfig,
+    now: new Date('2026-05-05T17:00:00.000Z'),
+  });
+
+  assert.notEqual(resolution.status, 'all_resolution_failed');
+  assert.equal(resolution.targets.some((target) => target.linkedinName === 'EDEKA DIGITAL GmbH'), true);
+  assert.ok(resolution.searchVariantsTried.includes('EDEKA DIGITAL'));
+  assert.match(resolution.manualSearchUrls.linkedinCompanySearchUrl, /linkedin\.com\/search\/results\/companies/);
 });
 
 test('buildCompanyResolution marks low-confidence manual-review accounts', () => {
@@ -86,6 +111,8 @@ test('writeCompanyResolutionArtifact writes JSON and Markdown reports', () => {
 
   assert.equal(json.status, 'all_resolution_failed');
   assert.match(markdown, /Company Resolution Report/);
+  assert.match(markdown, /Search variants tried/);
+  assert.match(markdown, /Manual LinkedIn company search/);
   assert.match(renderCompanyResolutionMarkdown(json), /Recommended action/);
   assert.equal(summarizeCompanyResolutionArtifacts(tempDir).failed, 1);
 });

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -256,6 +256,55 @@ test('scoreCandidate keeps qualified technical architecture and platform roles e
   }
 });
 
+test('scoreCandidate recognizes German seniority titles when paired with platform signals', () => {
+  const candidates = [
+    ['Abteilungsleiter Platforms', 'director'],
+    ['Bereichsleiter Cloud Infrastruktur', 'director'],
+    ['Leiter Plattform und Monitoring', 'head', 'site_reliability'],
+    ['Hauptabteilungsleiter DevOps', 'director'],
+    ['Teamleiter Site Reliability', 'lead'],
+    ['Geschäftsbereichsleiter Cloud Platform', 'director'],
+  ];
+
+  for (const [title, seniority, expectedRoleFamily = 'platform_engineering'] of candidates) {
+    const result = scoreCandidate({
+      title,
+      headline: 'Owns production platform reliability and infrastructure',
+    }, icpConfig);
+
+    assert.equal(result.eligible, true, title);
+    assert.equal(result.roleFamily, expectedRoleFamily, title);
+    assert.equal(result.seniority, seniority, title);
+    assert.ok(result.score >= icpConfig.saveToListThreshold, `${title} score ${result.score}`);
+  }
+});
+
+test('scoreCandidate demotes buyer-looking false positives unless they carry observability signals', () => {
+  const falsePositiveTitles = [
+    'Director Value Engineering',
+    'Director Master Data Management',
+    'Head of Data Protection & IT Law',
+    'VP Corporate Security, Safety & Forensics',
+    'Compliance Officer',
+  ];
+
+  for (const title of falsePositiveTitles) {
+    const result = scoreCandidate({ title, headline: 'Business function leader' }, icpConfig);
+
+    assert.equal(result.eligible, false, title);
+    assert.equal(result.score, 0, title);
+    assert.equal(result.breakdown.nonIcpTitleReason, 'false_positive_buyer_function', title);
+  }
+
+  const technicalException = scoreCandidate({
+    title: 'Director Value Engineering Observability Platform',
+    headline: 'Owns platform adoption for observability and SRE teams',
+  }, icpConfig);
+
+  assert.equal(technicalException.eligible, true);
+  assert.ok(technicalException.score >= icpConfig.saveToListThreshold);
+});
+
 test('scoreCandidate recognizes multilingual EMEA buyer and operator personas', () => {
   const candidates = [
     {


### PR DESCRIPTION
## Summary
- harden company resolution against cross-company contamination and EDEKA DIGITAL all-resolution failures
- add curated enterprise IT subsidiary targets for common Konzern accounts
- calibrate ICP scoring for German seniority titles and buyer false positives
- add relative-rank manual-review fallback, save retry/readback verification, richer SDR reports, and progress output

## Issues covered
Resolves #46
Resolves #47
Resolves #48
Resolves #49
Resolves #50
Resolves #51
Resolves #52
Resolves #53
Resolves #54
Resolves #55

## Tests
- npm test
- npm run test:release-readiness
- git diff --check