### PR TITLE
Prioritize related IT and digital company entities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ For faster guarded tests, you may add `--api-read-prefetch`. Explain it simply a
 npm run sdr-research -- --accounts="Account A, Account B, Account C" --api-read-prefetch
 ```
 
+For large enterprise accounts, think in related company entities, not one page. Prioritize IT, digital, systems, technology, and platform subsidiaries first because they often own infrastructure and observability. Still keep the parent or main company in scope because buyers and observability owners can sit there too. Only treat a company as out of scope when it is clearly unrelated or a same-name homonym.
+
 If the SDR asked for a Sales Navigator list, add `--live-save`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ npm run sdr-research -- \
   --api-read-prefetch
 ```
 
+For large companies, the tool treats the account as a related company set. It checks IT, digital, systems, technology, and platform entities first, then the parent or main company, because useful observability contacts can live in either place. Same-name companies that are not clearly related still stop for review.
+
 Research and create/update one Sales Navigator list:
 
 ```bash

--- a/config/account-coverage/README.md
+++ b/config/account-coverage/README.md
@@ -2,13 +2,13 @@
 
 ## Company entity selection
 
-Do not sweep a holding entity directly when the real engineering teams live in named subsidiaries or product companies. Resolve the company target set first, then sweep the pages that match the territory and the technical org.
+Do not treat a large account as only one company page. Resolve the company target set first, then sweep every clearly related target. Run IT, digital, systems, technology, and platform entities first because they often own infrastructure and observability. Keep parent/main entities in the sweep too because buyers and observability owners can sit there.
 
 Examples:
 
-- Prefer `About You`, `Bonprix`, or another confirmed tech subsidiary over a generic retail holding page when the holding mostly contains corporate-management roles.
+- Prioritize `About You`, `Bonprix`, or another confirmed tech subsidiary before a generic retail holding page, but do not drop the parent/main company when it is related.
 - Prefer the exact LinkedIn/Sales Navigator company page over the Salesforce display name when they differ.
-- If the selected company filter has low confidence, stop with `needs_manual_alias` instead of collecting leads from a likely wrong entity.
+- If the selected company filter has low confidence or points to an unrelated homonym, stop with `needs_manual_alias` instead of collecting leads from a likely wrong entity.
 
 ## Speed guardrail
 

--- a/docs/enterprise-company-resolution.md
+++ b/docs/enterprise-company-resolution.md
@@ -1,6 +1,8 @@
 # Enterprise Company Resolution
 
-Use this note when an account is a large parent brand but the useful IT org lives in a separate LinkedIn company page.
+Use this note when an account is a large parent brand but the useful IT org lives in one or more separate LinkedIn company pages.
+
+The rule is: prioritize IT/digital entities first, but keep every clearly related entity in the sweep. Parent or main company pages stay in scope because executive buyers and observability owners can sit there. `out_of_scope` is only for unrelated homonyms or clearly wrong companies, not for parent or holding entities that look less technical.
 
 ## When To Add A Curated Target
 
@@ -47,6 +49,12 @@ Edit `config/account-aliases/default.json` and add or update the account entry:
 ```
 
 Keep the mapping conservative. If the subsidiary is not clearly related to the territory account, prefer manual review over automatic sweeps.
+
+When multiple related targets exist, the sweep order should be:
+
+1. IT, digital, systems, technology, platform, cloud, data, or engineering subsidiaries.
+2. Parent or main company pages for buyer coverage.
+3. Regional, product, brand, or other related entities.
 
 ## Operator Check
 

--- a/src/core/account-batch.js
+++ b/src/core/account-batch.js
@@ -419,6 +419,12 @@ function renderAccountBatchReportMarkdown(payload) {
     lines.push(`- Coverage status: \`${sdrSummary.coverageStatus}\``);
     if (result.apiReadPrefetch) {
       lines.push(`- API read prefetch: \`${result.apiReadPrefetch.companyResolution?.status || result.apiReadPrefetch.status}\` | leads=\`${result.apiReadPrefetch.leadCandidateCount || 0}\` | ui_sweeps_skipped=\`${result.apiReadPrefetch.uiSweepsSkipped ? 'yes' : 'no'}\``);
+      const entityPriorities = (result.apiReadPrefetch.companyResolution?.selectedTargets || [])
+        .map((target) => `${target.name || target.linkedinName || 'unknown'}=${target.entityPriority || 'related_entity'}`)
+        .slice(0, 5);
+      if (entityPriorities.length > 0) {
+        lines.push(`- Entity priority: \`${entityPriorities.join(', ')}\``);
+      }
     }
     if (result.companyScope?.warning) {
       lines.push(`- Company scope warning: \`${result.companyScope.warning}\` (${(result.companyScope.unrelatedCompanies || []).join(', ') || 'unknown company'})`);

--- a/src/core/company-resolution-retry.js
+++ b/src/core/company-resolution-retry.js
@@ -6,6 +6,7 @@ const { BACKGROUND_RUNNER_ARTIFACTS_DIR, ensureDir } = require('../lib/paths');
 const RETRYABLE_RESOLUTION_STATUSES = new Set([
   'resolved_exact',
   'resolved_multi_target',
+  'resolved_multi_target_curated',
 ]);
 
 function slugify(value) {

--- a/src/core/company-resolution.js
+++ b/src/core/company-resolution.js
@@ -10,6 +10,7 @@ const {
 const COMPANY_RESOLUTION_STATUSES = new Set([
   'resolved_exact',
   'resolved_multi_target',
+  'resolved_multi_target_curated',
   'resolved_low_confidence',
   'needs_manual_company_review',
   'all_resolution_failed',
@@ -169,13 +170,22 @@ function buildCompanyResolution({
     .sort((left, right) => right.score - left.score);
 
   const selectedTargets = targets.filter((target) => target.score >= 50).slice(0, 5);
-  const top = selectedTargets[0] || null;
+  selectedTargets.sort(compareCompanyTargetPriority);
+  const top = [...selectedTargets].sort((left, right) => right.score - left.score)[0] || null;
   const strongTargets = selectedTargets.filter((target) => target.score >= 70);
   const inferredStatus = classifyCompanyResolutionStatus({ top, strongTargets });
-  const status = COMPANY_RESOLUTION_STATUSES.has(aliasEntry.resolutionStatus)
+  const explicitStatus = COMPANY_RESOLUTION_STATUSES.has(aliasEntry.resolutionStatus)
     && inferredStatus !== 'all_resolution_failed'
     ? aliasEntry.resolutionStatus
-    : inferredStatus;
+    : null;
+  const hasCuratedMultiTarget = selectedTargets.length > 1
+    && selectedTargets.some((target) => target.evidence.includes('curated_target'));
+  const status = (explicitStatus === 'resolved_multi_target' && hasCuratedMultiTarget)
+    ? 'resolved_multi_target_curated'
+    : explicitStatus
+    || (inferredStatus === 'resolved_multi_target' && hasCuratedMultiTarget
+      ? 'resolved_multi_target_curated'
+      : inferredStatus);
   const confidence = top ? Number((top.score / 100).toFixed(2)) : 0;
   const recommendedAction = getCompanyResolutionRecommendedAction(status);
 
@@ -321,7 +331,7 @@ function scoreCompanyTarget({ target, accountName, domains = [], territoryCountr
     score += 20;
     evidence.push('partial_name_match');
   }
-  if (evidence.some((item) => /alias/.test(item))) {
+  if (evidence.some((item) => /alias|curated_target|curated_it_subsidiary|curated_parent/.test(item))) {
     score += 30;
   }
   if (target.linkedinCompanyUrl || evidence.some((item) => /linkedin_url/.test(item))) {
@@ -346,12 +356,59 @@ function scoreCompanyTarget({ target, accountName, domains = [], territoryCountr
   }
 
   const cappedScore = Math.max(0, Math.min(100, score));
+  const entityPriority = classifyCompanyEntityPriority(target);
   return {
     ...target,
     score: cappedScore,
     confidence: Number((cappedScore / 100).toFixed(2)),
+    entityPriority,
+    entityPriorityRank: getCompanyEntityPriorityRank(entityPriority),
     evidence: [...new Set(evidence)],
   };
+}
+
+function classifyCompanyEntityPriority(target = {}) {
+  const name = String(target.linkedinName || target.name || target.companyName || '').toLowerCase();
+  const evidence = (target.evidence || []).join(' ').toLowerCase();
+  const type = String(target.targetType || '').toLowerCase();
+  const text = `${name} ${evidence} ${type}`;
+  if (/\b(it|digital|systems?|technology|tech|platform|cloud|data|software|engineering|rechenzentrum|informatik)\b/.test(text)) {
+    return 'it_digital_first';
+  }
+  if (type === 'parent' || /\b(parent|holding|main|curated_parent)\b/.test(text)) {
+    return 'parent_buyer_scope';
+  }
+  return 'related_entity';
+}
+
+function getCompanyEntityPriorityRank(priority) {
+  switch (priority) {
+    case 'it_digital_first':
+      return 0;
+    case 'parent_buyer_scope':
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+function compareCompanyTargetPriority(left = {}, right = {}) {
+  const leftRank = Number.isFinite(left.entityPriorityRank)
+    ? left.entityPriorityRank
+    : getCompanyEntityPriorityRank(classifyCompanyEntityPriority(left));
+  const rightRank = Number.isFinite(right.entityPriorityRank)
+    ? right.entityPriorityRank
+    : getCompanyEntityPriorityRank(classifyCompanyEntityPriority(right));
+  if (leftRank === 0 || rightRank === 0) {
+    return leftRank - rightRank;
+  }
+  if ((left.score || 0) !== (right.score || 0)) {
+    return (right.score || 0) - (left.score || 0);
+  }
+  if (leftRank !== rightRank) {
+    return leftRank - rightRank;
+  }
+  return (right.score || 0) - (left.score || 0);
 }
 
 function classifyCompanyResolutionStatus({ top, strongTargets }) {
@@ -378,6 +435,7 @@ function getCompanyResolutionRecommendedAction(status) {
     case 'resolved_exact':
       return 'run_people_sweeps';
     case 'resolved_multi_target':
+    case 'resolved_multi_target_curated':
       return 'run_guarded_multi_target_sweeps';
     case 'resolved_low_confidence':
     case 'needs_manual_company_review':
@@ -394,6 +452,7 @@ function normalizeTargetForArtifact(target) {
     salesNavCompanyUrl: target.salesNavCompanyUrl || null,
     targetType: target.targetType || 'unknown',
     territoryFit: target.territoryFit || 'unclear',
+    entityPriority: target.entityPriority || classifyCompanyEntityPriority(target),
     confidence: target.confidence,
     score: target.score,
     evidence: target.evidence || [],
@@ -514,7 +573,7 @@ function summarizeCompanyResolutionArtifacts(artifactsDir = COMPANY_RESOLUTION_A
   return {
     total: artifacts.length,
     resolvedExact: artifacts.filter((artifact) => artifact.status === 'resolved_exact').length,
-    multiTarget: artifacts.filter((artifact) => artifact.status === 'resolved_multi_target').length,
+    multiTarget: artifacts.filter((artifact) => ['resolved_multi_target', 'resolved_multi_target_curated'].includes(artifact.status)).length,
     needsManualReview: artifacts.filter((artifact) => ['needs_manual_company_review', 'resolved_low_confidence'].includes(artifact.status)).length,
     failed: artifacts.filter((artifact) => artifact.status === 'all_resolution_failed').length,
     nextActions,
@@ -527,8 +586,10 @@ module.exports = {
   buildCompanyResolution,
   buildCompanyResolutionArtifactPath,
   buildCompanyResolutionReportPath,
+  classifyCompanyEntityPriority,
   classifyCompanyResolutionStatus,
   companyNameFromLinkedInUrl,
+  compareCompanyTargetPriority,
   findCompanyAliasEntry,
   buildCompanyResolutionSearchDiagnostics,
   findLatestCompanyResolutionArtifact,

--- a/src/core/sales-nav-api-probe.js
+++ b/src/core/sales-nav-api-probe.js
@@ -1,3 +1,8 @@
+const {
+  classifyCompanyEntityPriority,
+  compareCompanyTargetPriority,
+} = require('./company-resolution');
+
 const SAFE_TEXT_LIMIT = 500;
 
 function stripQuotedCookieValue(value) {
@@ -201,6 +206,14 @@ function assessApiCompanyResolution(accountName, companyCandidates = []) {
       index,
       normalizedName: normalizeCompanyNameForApi(candidate.name),
     }))
+    .map((candidate) => ({
+      ...candidate,
+      entityPriority: classifyCompanyEntityPriority({
+        linkedinName: candidate.name,
+        targetType: candidate.normalizedName === normalizedAccount ? 'parent' : 'unknown',
+        evidence: candidate.evidence || [],
+      }),
+    }))
     .filter((candidate) => candidate.normalizedName && candidate.companyId);
   const exact = enriched.filter((candidate) => candidate.normalizedName === normalizedAccount);
   const prefixed = enriched.filter((candidate) => (
@@ -221,16 +234,17 @@ function assessApiCompanyResolution(accountName, companyCandidates = []) {
     return {
       status: 'needs_company_scope_review',
       confidence: 0.55,
-      selectedTargets: exact,
+      selectedTargets: [...exact].sort(compareCompanyTargetPriority),
       warning: 'api_company_search_ambiguous_exact_matches',
     };
   }
 
   if (exact.length === 1 && prefixed.length >= 2) {
+    const selectedTargets = [exact[0], ...prefixed.slice(0, 4)].sort(compareCompanyTargetPriority);
     return {
       status: 'resolved_multi_target_api',
       confidence: 0.82,
-      selectedTargets: [exact[0], ...prefixed.slice(0, 4)],
+      selectedTargets,
       warning: null,
     };
   }
@@ -248,7 +262,7 @@ function assessApiCompanyResolution(accountName, companyCandidates = []) {
     return {
       status: 'needs_company_scope_review',
       confidence: 0.62,
-      selectedTargets: prefixed.slice(0, 4),
+      selectedTargets: prefixed.slice(0, 4).sort(compareCompanyTargetPriority),
       warning: 'api_company_search_missing_exact_match',
     };
   }

--- a/src/drivers/playwright-sales-nav.js
+++ b/src/drivers/playwright-sales-nav.js
@@ -1046,7 +1046,7 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     accountName,
     companyCount = 10,
     leadCount = 100,
-    maxTargets = 3,
+    maxTargets = 5,
   } = {}) {
     const errors = [];
     let companyResponse = null;

--- a/tests/account-batch.test.js
+++ b/tests/account-batch.test.js
@@ -237,6 +237,17 @@ test('renderAccountBatchReportMarkdown shows strong report-only candidates and n
           unrelatedCompanies: ['Deutsche Bank'],
         },
         strongButNotAutoSavedCount: 2,
+        apiReadPrefetch: {
+          companyResolution: {
+            status: 'resolved_multi_target_api',
+            selectedTargets: [
+              { name: 'EDEKA IT', entityPriority: 'it_digital_first' },
+              { name: 'EDEKA', entityPriority: 'parent_buyer_scope' },
+            ],
+          },
+          leadCandidateCount: 30,
+          uiSweepsSkipped: true,
+        },
         saveResults: [],
         strongButNotAutoSavedCandidates: [
           {
@@ -271,6 +282,7 @@ test('renderAccountBatchReportMarkdown shows strong report-only candidates and n
 
   assert.match(markdown, /SDR summary: found=`30` \| selected=`6` .* out_of_network=`2` \| failed_sweeps=`8`/);
   assert.match(markdown, /Coverage status: `needs_company_scope_review`/);
+  assert.match(markdown, /Entity priority: `EDEKA IT=it_digital_first, EDEKA=parent_buyer_scope`/);
   assert.match(markdown, /Company scope warning: `cross_company_contamination_detected` \(Deutsche Bank\)/);
   assert.match(markdown, /Manual review fallback: `top candidates shown because no candidate passed the normal save threshold`/);
   assert.match(markdown, /Sweeps: `12\/20 succeeded`/);

--- a/tests/company-resolution.test.js
+++ b/tests/company-resolution.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 
 const {
   buildCompanyResolution,
+  classifyCompanyEntityPriority,
   companyNameFromLinkedInUrl,
   findCompanyAliasEntry,
   normalizeCompanyName,
@@ -44,6 +45,25 @@ test('findCompanyAliasEntry matches configured target and subsidiary aliases', (
   );
 });
 
+test('company entity priority ranks IT and digital targets before parent while keeping parent in scope', () => {
+  const aliasConfig = readJson(resolveProjectPath('config', 'account-aliases', 'default.json'));
+  const resolution = buildCompanyResolution({
+    accountName: 'EDEKA',
+    source: 'territory',
+    aliasConfig,
+    now: new Date('2026-05-06T12:00:00.000Z'),
+  });
+
+  assert.equal(resolution.status, 'resolved_multi_target_curated');
+  assert.equal(resolution.targets[0].entityPriority, 'it_digital_first');
+  assert.equal(resolution.targets.some((target) => target.linkedinName === 'EDEKA'), true);
+  assert.equal(
+    resolution.targets.find((target) => target.linkedinName === 'EDEKA').entityPriority,
+    'parent_buyer_scope',
+  );
+  assert.equal(classifyCompanyEntityPriority({ linkedinName: 'Retail Brand', targetType: 'brand' }), 'related_entity');
+});
+
 test('buildCompanyResolution resolves seeded hard accounts', () => {
   const aliasConfig = readJson(resolveProjectPath('config', 'account-aliases', 'default.json'));
   const mediaGroup = buildCompanyResolution({
@@ -79,6 +99,42 @@ test('buildCompanyResolution resolves EDEKA DIGITAL through curated subsidiary t
   assert.equal(resolution.targets.some((target) => target.linkedinName === 'EDEKA DIGITAL GmbH'), true);
   assert.ok(resolution.searchVariantsTried.includes('EDEKA DIGITAL'));
   assert.match(resolution.manualSearchUrls.linkedinCompanySearchUrl, /linkedin\.com\/search\/results\/companies/);
+});
+
+test('buildCompanyResolution can resolve METRO as curated multi-target without unrelated homonyms', () => {
+  const resolution = buildCompanyResolution({
+    accountName: 'METRO',
+    source: 'territory',
+    aliasConfig: {
+      accounts: {
+        metro: {
+          targets: [
+            {
+              linkedinName: 'METRO.digital',
+              targetType: 'subsidiary',
+              territoryFit: 'likely',
+              evidence: ['curated_it_subsidiary'],
+            },
+            {
+              linkedinName: 'METRO AG',
+              targetType: 'parent',
+              territoryFit: 'likely',
+              evidence: ['curated_parent'],
+            },
+          ],
+          resolutionStatus: 'resolved_multi_target',
+        },
+      },
+    },
+    now: new Date('2026-05-06T12:00:00.000Z'),
+  });
+
+  assert.equal(resolution.status, 'resolved_multi_target_curated');
+  assert.deepEqual(
+    resolution.targets.map((target) => target.linkedinName),
+    ['METRO.digital', 'METRO AG'],
+  );
+  assert.equal(resolution.targets[0].entityPriority, 'it_digital_first');
 });
 
 test('buildCompanyResolution marks low-confidence manual-review accounts', () => {

--- a/tests/playwright-driver.test.js
+++ b/tests/playwright-driver.test.js
@@ -227,6 +227,49 @@ test('detectRateLimit reads LinkedIn rate-limit indicators from title and body',
   assert.equal(await detectRateLimit(normalPage), false);
 });
 
+test('playwright API prefetch reads every selected related target in entity-priority order', async () => {
+  const driver = new PlaywrightSalesNavigatorDriver();
+  const requestedCompanyIds = [];
+  driver.salesNavApiGet = async (requestPath) => {
+    if (String(requestPath).includes('salesApiAccountSearch')) {
+      return {
+        ok: true,
+        payload: {
+          elements: [
+            { entityUrn: 'urn:li:fs_salesCompany:1', name: 'EDEKA', navigationUrl: 'https://www.linkedin.com/sales/company/1' },
+            { entityUrn: 'urn:li:fs_salesCompany:2', name: 'EDEKA IT', navigationUrl: 'https://www.linkedin.com/sales/company/2' },
+            { entityUrn: 'urn:li:fs_salesCompany:3', name: 'EDEKA ZENTRALE Stiftung & Co. KG', navigationUrl: 'https://www.linkedin.com/sales/company/3' },
+            { entityUrn: 'urn:li:fs_salesCompany:4', name: 'EDEKA DIGITAL GmbH', navigationUrl: 'https://www.linkedin.com/sales/company/4' },
+          ],
+        },
+      };
+    }
+    const companyId = String(requestPath).match(/\(id:(\d+)\)/)?.[1] || '';
+    requestedCompanyIds.push(companyId);
+    return {
+      ok: true,
+      payload: {
+        elements: [{
+          entityUrn: `urn:li:fs_salesProfile:(lead-${companyId},NAME_SEARCH,x)`,
+          firstName: `Lead${companyId}`,
+          lastName: 'Example',
+          currentPositions: [{ title: 'Site Reliability Engineer', companyName: `Company ${companyId}`, current: true }],
+        }],
+      },
+    };
+  };
+
+  const result = await driver.runSalesNavApiReadPrefetch({
+    accountName: 'EDEKA',
+    leadCount: 5,
+  });
+
+  assert.equal(result.companyResolution.status, 'resolved_multi_target_api');
+  assert.deepEqual(requestedCompanyIds, ['2', '4', '1', '3']);
+  assert.equal(result.leadCandidates.length, 4);
+  assert.equal(result.companyResolution.selectedTargets[0].entityPriority, 'it_digital_first');
+});
+
 test('playwright driver backs off once and resumes after transient rate limit', async () => {
   const waits = [];
   let bodyText = 'Too many requests. Try later.';

--- a/tests/sales-nav-api-probe.test.js
+++ b/tests/sales-nav-api-probe.test.js
@@ -79,11 +79,15 @@ test('assessApiCompanyResolution distinguishes exact, multi-target, and ambiguou
     { name: 'Process Analytics Factory - PAFnow by Celonis', companyId: '5286872' },
   ]).status, 'resolved_exact_api');
 
-  assert.equal(assessApiCompanyResolution('EDEKA', [
+  const edeka = assessApiCompanyResolution('EDEKA', [
     { name: 'EDEKA', companyId: '12267150' },
     { name: 'EDEKA IT', companyId: '905440' },
     { name: 'EDEKA ZENTRALE Stiftung & Co. KG', companyId: '2783130' },
-  ]).status, 'resolved_multi_target_api');
+  ]);
+  assert.equal(edeka.status, 'resolved_multi_target_api');
+  assert.equal(edeka.selectedTargets[0].name, 'EDEKA IT');
+  assert.equal(edeka.selectedTargets[0].entityPriority, 'it_digital_first');
+  assert.equal(edeka.selectedTargets.some((target) => target.name === 'EDEKA'), true);
 
   const metro = assessApiCompanyResolution('METRO', [
     { name: 'Metro', companyId: '332814' },


### PR DESCRIPTION
## Summary
- documents that large accounts should be treated as related company entity sets
- prioritizes IT/digital/systems/technology/platform entities while keeping parent/main companies in scope
- adds entityPriority reporting for API-prefetch account batch reports
- keeps unrelated homonyms fail-closed with needs_company_scope_review

## Verification
- npm test
- npm run test:release-readiness
- git diff --check