### PR TITLE
Resolve METRO with curated Sales Nav company targets

### DIFF
--- a/config/account-aliases/default.json
+++ b/config/account-aliases/default.json
@@ -306,6 +306,30 @@
       "resolutionStatus": "resolved_multi_target",
       "resolutionNotes": "Parent plus known IT entities should be reviewed together."
     },
+    "metro": {
+      "accountSearchAliases": ["METRO", "METRO.digital", "METRO/MAKRO"],
+      "companyFilterAliases": ["METRO", "METRO.digital", "METRO/MAKRO"],
+      "targets": [
+        {
+          "linkedinName": "METRO.digital",
+          "salesNavCompanyUrl": "https://www.linkedin.com/sales/company/70517322",
+          "targetType": "subsidiary",
+          "territoryFit": "likely",
+          "evidence": ["curated_it_subsidiary"]
+        },
+        {
+          "linkedinName": "METRO/MAKRO",
+          "salesNavCompanyUrl": "https://www.linkedin.com/sales/company/164955",
+          "targetType": "parent",
+          "territoryFit": "likely",
+          "evidence": ["curated_parent"]
+        }
+      ],
+      "subsidiaryAliases": ["METRO.digital"],
+      "territoryCountries": ["Germany"],
+      "resolutionStatus": "resolved_multi_target",
+      "resolutionNotes": "Use curated METRO.digital first for IT/digital owners and METRO/MAKRO as parent/main buyer scope; avoid generic same-name Metro homonyms."
+    },
     "bertelsmann": {
       "accountSearchAliases": ["Bertelsmann", "Arvato Systems"],
       "companyFilterAliases": ["Bertelsmann", "Arvato Systems"],

--- a/src/core/account-coverage.js
+++ b/src/core/account-coverage.js
@@ -1012,6 +1012,7 @@ async function runAccountCoverageWorkflow({
         driver.runSalesNavApiReadPrefetch({
           accountName,
           leadCount: apiReadPrefetchLeadCount,
+          companyTargets: companyResolution.targets || activeAccount?.salesNav?.companyTargets || [],
         }), { now });
     } catch (error) {
       apiReadPrefetchResult = {

--- a/src/core/company-resolution.js
+++ b/src/core/company-resolution.js
@@ -169,7 +169,11 @@ function buildCompanyResolution({
     }))
     .sort((left, right) => right.score - left.score);
 
-  const selectedTargets = targets.filter((target) => target.score >= 50).slice(0, 5);
+  const hasCuratedTargets = targets.some((target) => target.evidence.includes('curated_target'));
+  const selectableTargets = hasCuratedTargets
+    ? targets.filter((target) => target.evidence.includes('curated_target'))
+    : targets;
+  const selectedTargets = selectableTargets.filter((target) => target.score >= 50).slice(0, 5);
   selectedTargets.sort(compareCompanyTargetPriority);
   const top = [...selectedTargets].sort((left, right) => right.score - left.score)[0] || null;
   const strongTargets = selectedTargets.filter((target) => target.score >= 70);
@@ -334,7 +338,7 @@ function scoreCompanyTarget({ target, accountName, domains = [], territoryCountr
   if (evidence.some((item) => /alias|curated_target|curated_it_subsidiary|curated_parent/.test(item))) {
     score += 30;
   }
-  if (target.linkedinCompanyUrl || evidence.some((item) => /linkedin_url/.test(item))) {
+  if (target.linkedinCompanyUrl || target.salesNavCompanyUrl || evidence.some((item) => /linkedin_url/.test(item))) {
     score += 30;
   }
   if (domains.length > 0 && target.linkedinCompanyUrl && domains.some((domain) => target.linkedinCompanyUrl.includes(String(domain).replace(/^https?:\/\//i, '').replace(/^www\./i, '')))) {

--- a/src/core/sales-nav-api-probe.js
+++ b/src/core/sales-nav-api-probe.js
@@ -107,6 +107,11 @@ function extractCompanyId(value = {}) {
   return '';
 }
 
+function extractCompanyIdFromSalesNavUrl(url) {
+  const match = String(url || '').match(/\/sales\/company\/([^/?#]+)/i);
+  return match ? decodeURIComponent(match[1]).trim() : '';
+}
+
 function extractLeadIdFromUrn(entityUrn = '') {
   const match = String(entityUrn || '').match(/fs_salesProfile:\(?([^,\)]+)/i);
   return match ? match[1].trim() : '';
@@ -196,6 +201,44 @@ function normalizeCompanyNameForApi(value) {
     .replace(/[^a-z0-9]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+function normalizeCuratedApiCompanyTargets(companyTargets = []) {
+  return (Array.isArray(companyTargets) ? companyTargets : [])
+    .map((target, index) => {
+      const name = target.linkedinName || target.name || target.companyName || '';
+      const companyId = target.companyId || extractCompanyIdFromSalesNavUrl(target.salesNavCompanyUrl);
+      if (!name || !companyId) {
+        return null;
+      }
+      return {
+        name,
+        companyId,
+        entityUrn: target.entityUrn || `urn:li:fs_salesCompany:${companyId}`,
+        salesNavigatorUrl: target.salesNavCompanyUrl || `https://www.linkedin.com/sales/company/${companyId}`,
+        index,
+        normalizedName: normalizeCompanyNameForApi(name),
+        entityPriority: classifyCompanyEntityPriority(target),
+        evidence: [...new Set(['curated_target', ...(target.evidence || [])])],
+      };
+    })
+    .filter(Boolean)
+    .sort(compareCompanyTargetPriority);
+}
+
+function assessCuratedApiCompanyResolution(accountName, companyTargets = []) {
+  const selectedTargets = normalizeCuratedApiCompanyTargets(companyTargets);
+  if (selectedTargets.length === 0) {
+    return null;
+  }
+  return {
+    status: selectedTargets.length > 1 ? 'resolved_multi_target_curated' : 'resolved_exact_api',
+    confidence: selectedTargets.length > 1 ? 0.9 : 0.95,
+    selectedTargets,
+    warning: null,
+    source: 'curated_company_targets',
+    accountName,
+  };
 }
 
 function assessApiCompanyResolution(accountName, companyCandidates = []) {
@@ -350,12 +393,14 @@ module.exports = {
   buildLeadSearchPath,
   buildSalesNavApiProbeArtifact,
   assessApiCompanyResolution,
+  assessCuratedApiCompanyResolution,
   classifySalesNavApiFailure,
   extractCsrfFromCookieHeader,
   extractCsrfFromCookies,
   extractLeadIdFromUrn,
   normalizeApiLeadForCoverage,
   normalizeCompanySearchResponse,
+  normalizeCuratedApiCompanyTargets,
   normalizeLeadElement,
   normalizeLeadSearchResponse,
   safePreview,

--- a/src/drivers/playwright-sales-nav.js
+++ b/src/drivers/playwright-sales-nav.js
@@ -11,6 +11,7 @@ const {
   buildLeadSearchPath,
   buildSalesNavApiProbeArtifact,
   assessApiCompanyResolution,
+  assessCuratedApiCompanyResolution,
   classifySalesNavApiFailure,
   extractCsrfFromCookies,
   normalizeApiLeadForCoverage,
@@ -1047,23 +1048,26 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     companyCount = 10,
     leadCount = 100,
     maxTargets = 5,
+    companyTargets = [],
   } = {}) {
     const errors = [];
     let companyResponse = null;
-    try {
-      companyResponse = await this.salesNavApiGet(buildCompanySearchPath(accountName, { count: companyCount }));
-    } catch (error) {
-      errors.push(error);
+    const curatedResolution = assessCuratedApiCompanyResolution(accountName, companyTargets);
+    if (!curatedResolution) {
+      try {
+        companyResponse = await this.salesNavApiGet(buildCompanySearchPath(accountName, { count: companyCount }));
+      } catch (error) {
+        errors.push(error);
+      }
     }
 
-    const companyCandidates = companyResponse?.payload
-      ? normalizeCompanySearchResponse(companyResponse.payload)
-      : [];
-    const companyResolution = assessApiCompanyResolution(accountName, companyCandidates);
+    const companyCandidates = curatedResolution?.selectedTargets
+      || (companyResponse?.payload ? normalizeCompanySearchResponse(companyResponse.payload) : []);
+    const companyResolution = curatedResolution || assessApiCompanyResolution(accountName, companyCandidates);
     const leadCandidates = [];
     const targetResponses = [];
 
-    if (['resolved_exact_api', 'resolved_multi_target_api'].includes(companyResolution.status)) {
+    if (['resolved_exact_api', 'resolved_multi_target_api', 'resolved_multi_target_curated'].includes(companyResolution.status)) {
       for (const target of companyResolution.selectedTargets.slice(0, Math.max(1, maxTargets))) {
         try {
           const response = await this.salesNavApiGet(buildLeadSearchPath({

--- a/tests/company-resolution.test.js
+++ b/tests/company-resolution.test.js
@@ -102,37 +102,18 @@ test('buildCompanyResolution resolves EDEKA DIGITAL through curated subsidiary t
 });
 
 test('buildCompanyResolution can resolve METRO as curated multi-target without unrelated homonyms', () => {
+  const aliasConfig = readJson(resolveProjectPath('config', 'account-aliases', 'default.json'));
   const resolution = buildCompanyResolution({
     accountName: 'METRO',
     source: 'territory',
-    aliasConfig: {
-      accounts: {
-        metro: {
-          targets: [
-            {
-              linkedinName: 'METRO.digital',
-              targetType: 'subsidiary',
-              territoryFit: 'likely',
-              evidence: ['curated_it_subsidiary'],
-            },
-            {
-              linkedinName: 'METRO AG',
-              targetType: 'parent',
-              territoryFit: 'likely',
-              evidence: ['curated_parent'],
-            },
-          ],
-          resolutionStatus: 'resolved_multi_target',
-        },
-      },
-    },
+    aliasConfig,
     now: new Date('2026-05-06T12:00:00.000Z'),
   });
 
   assert.equal(resolution.status, 'resolved_multi_target_curated');
   assert.deepEqual(
     resolution.targets.map((target) => target.linkedinName),
-    ['METRO.digital', 'METRO AG'],
+    ['METRO.digital', 'METRO/MAKRO'],
   );
   assert.equal(resolution.targets[0].entityPriority, 'it_digital_first');
 });

--- a/tests/playwright-driver.test.js
+++ b/tests/playwright-driver.test.js
@@ -270,6 +270,54 @@ test('playwright API prefetch reads every selected related target in entity-prio
   assert.equal(result.companyResolution.selectedTargets[0].entityPriority, 'it_digital_first');
 });
 
+test('playwright API prefetch uses curated METRO company IDs instead of ambiguous name search', async () => {
+  const driver = new PlaywrightSalesNavigatorDriver();
+  const requestedPaths = [];
+  driver.salesNavApiGet = async (requestPath) => {
+    requestedPaths.push(requestPath);
+    assert.doesNotMatch(requestPath, /salesApiAccountSearch/);
+    const companyId = String(requestPath).match(/\(id:(\d+)\)/)?.[1] || '';
+    return {
+      ok: true,
+      payload: {
+        elements: [{
+          entityUrn: `urn:li:fs_salesProfile:(metro-${companyId},NAME_SEARCH,x)`,
+          firstName: `Metro${companyId}`,
+          lastName: 'Lead',
+          currentPositions: [{ title: 'Cloud Platform Lead', companyName: `Company ${companyId}`, current: true }],
+        }],
+      },
+    };
+  };
+
+  const result = await driver.runSalesNavApiReadPrefetch({
+    accountName: 'METRO',
+    leadCount: 5,
+    companyTargets: [
+      {
+        linkedinName: 'METRO/MAKRO',
+        salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/164955',
+        targetType: 'parent',
+        evidence: ['curated_parent'],
+      },
+      {
+        linkedinName: 'METRO.digital',
+        salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/70517322',
+        targetType: 'subsidiary',
+        evidence: ['curated_it_subsidiary'],
+      },
+    ],
+  });
+
+  assert.equal(result.companyResolution.status, 'resolved_multi_target_curated');
+  assert.equal(result.leadCandidates.length, 2);
+  assert.deepEqual(
+    result.targetResponses.map((response) => response.target.companyId),
+    ['70517322', '164955'],
+  );
+  assert.equal(requestedPaths.length, 2);
+});
+
 test('playwright driver backs off once and resumes after transient rate limit', async () => {
   const waits = [];
   let bodyText = 'Too many requests. Try later.';

--- a/tests/sales-nav-api-probe.test.js
+++ b/tests/sales-nav-api-probe.test.js
@@ -7,6 +7,7 @@ const {
   buildLeadSearchPath,
   buildSalesNavApiProbeArtifact,
   assessApiCompanyResolution,
+  assessCuratedApiCompanyResolution,
   classifySalesNavApiFailure,
   extractCsrfFromCookieHeader,
   extractCsrfFromCookies,
@@ -96,6 +97,30 @@ test('assessApiCompanyResolution distinguishes exact, multi-target, and ambiguou
   ]);
   assert.equal(metro.status, 'needs_company_scope_review');
   assert.equal(metro.warning, 'api_company_search_ambiguous_exact_matches');
+});
+
+test('assessCuratedApiCompanyResolution turns METRO targets into safe ordered API targets', () => {
+  const resolution = assessCuratedApiCompanyResolution('METRO', [
+    {
+      linkedinName: 'METRO/MAKRO',
+      salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/164955',
+      targetType: 'parent',
+      evidence: ['curated_parent'],
+    },
+    {
+      linkedinName: 'METRO.digital',
+      salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/70517322',
+      targetType: 'subsidiary',
+      evidence: ['curated_it_subsidiary'],
+    },
+  ]);
+
+  assert.equal(resolution.status, 'resolved_multi_target_curated');
+  assert.deepEqual(
+    resolution.selectedTargets.map((target) => target.companyId),
+    ['70517322', '164955'],
+  );
+  assert.equal(resolution.selectedTargets[0].entityPriority, 'it_digital_first');
 });
 
 test('entityUrn is a first-class Sales Navigator identity match', () => {


### PR DESCRIPTION
## Summary
- adds curated METRO company targets for METRO.digital and METRO/MAKRO
- lets API read prefetch use curated Sales Nav company IDs instead of ambiguous name search
- keeps IT/digital entity priority first while preserving parent/main buyer scope
- prevents generic same-name METRO homonyms from entering scoped research

## Live dry-safe validation
- METRO account coverage no longer stops at needs_company_scope_review
- Result: 190 unique candidates, 31 direct observability, 42 technical adjacent, coverage_sufficient
- Duration: 9.76s

## Verification
- npm test
- npm run test:release-readiness
- git diff --check