### PR TITLE
Add enterprise entity resolver skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,14 @@ npm run sdr-research -- --accounts="Account A, Account B, Account C" --api-read-
 
 For large enterprise accounts, think in related company entities, not one page. Prioritize IT, digital, systems, technology, and platform subsidiaries first because they often own infrastructure and observability. Still keep the parent or main company in scope because buyers and observability owners can sit there too. Only treat a company as out of scope when it is clearly unrelated or a same-name homonym.
 
+If company scope is unclear, use:
+
+```bash
+npm run resolve-enterprise-entities -- --account-name="Account Name"
+```
+
+Explain it simply: "I am checking the related Sales Navigator company pages first, searching IT/digital entities before the parent, and skipping unrelated same-name pages." This command is read-only and must not be mixed with live-save or connect flags.
+
 If the SDR asked for a Sales Navigator list, add `--live-save`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ npm run account-coverage -- \
 
 The API prefetch only reads data from the logged-in browser. Real list saves still require `--live-save`.
 
+### Enterprise Entity Resolver
+
+Use this when an enterprise account has several related LinkedIn company pages, for example a parent brand plus IT, digital, systems, or platform subsidiaries. The resolver is read-only: it checks possible company pages, prioritizes IT/digital entities first, keeps the parent company in scope, and skips unrelated same-name companies.
+
+```bash
+npm run resolve-enterprise-entities -- --account-name="Example Enterprise"
+```
+
+With `--api-read-prefetch`, account research can call this resolver automatically when the first company lookup is ambiguous. If the resolver finds safe related entities, the run continues; if not, the report asks for company-scope review instead of searching the wrong company.
+
 ### Log In Again If Needed
 
 Use this when LinkedIn needs a fresh manual login:

--- a/docs/enterprise-company-resolution.md
+++ b/docs/enterprise-company-resolution.md
@@ -66,3 +66,15 @@ node src/cli.js resolve-company --account-name="Account Name"
 ```
 
 The resolution report should show the intended parent/subsidiary targets and should not include unrelated companies.
+
+## Read-Only Resolver Skill
+
+Before adding a permanent alias, you can let the tool inspect related Sales Navigator company pages in read-only mode:
+
+```bash
+npm run resolve-enterprise-entities -- --account-name="Example Enterprise"
+```
+
+The resolver writes JSON and Markdown under `runtime/artifacts/company-resolution/enterprise-entities/`. It reports which pages should be included, suggested for review, or excluded as unrelated homonyms. New findings stay as learned suggestions in the runtime artifact first; they are not automatically promoted into `config/account-aliases/default.json`.
+
+When `--api-read-prefetch` is used for `account-coverage` or `sdr-research`, the same resolver can be used automatically if the first company lookup is ambiguous. Safe related targets continue the sweep; unclear targets keep the run in `needs_company_scope_review`.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "print-first-run-onboarding": "node src/cli.js print-first-run-onboarding",
     "check-driver-session": "node src/cli.js check-driver-session",
     "test-sales-nav-api": "node src/cli.js test-sales-nav-api",
+    "resolve-enterprise-entities": "node src/cli.js resolve-enterprise-entities",
     "bootstrap-browser-harness": "automation/bootstrap-browser-harness",
     "bootstrap-session": "node src/cli.js bootstrap-session",
     "test-account-search": "node src/cli.js test-account-search",

--- a/src/cli.js
+++ b/src/cli.js
@@ -186,6 +186,9 @@ async function main() {
       case 'test-sales-nav-api':
         await handleTestSalesNavApi(values, logger);
         break;
+      case 'resolve-enterprise-entities':
+        await handleResolveEnterpriseEntities(values, logger);
+        break;
       case 'doctor':
       case 'print-first-run-onboarding':
         await handleFirstRunOnboarding(values);
@@ -526,6 +529,77 @@ async function handleTestSalesNavApi(values, logger) {
       }
     }
     logger.info(`Artifact: ${artifactPath}`);
+  } finally {
+    await driver.close().catch(() => {});
+  }
+}
+
+async function handleResolveEnterpriseEntities(values, logger) {
+  if (getBoolean(values, 'live-save') || getBoolean(values, 'live-connect') || getBoolean(values, 'allow-mutations')) {
+    throw new Error('resolve-enterprise-entities is read-only and refuses live mutation flags');
+  }
+
+  const accountName = getString(values, 'account-name');
+  if (!accountName) {
+    throw new Error('resolve-enterprise-entities requires --account-name="Account Name"');
+  }
+
+  const driverName = getString(values, 'driver') || 'playwright';
+  const driver = createDriver(driverName, {
+    ...buildDriverOptions(values, { dryRun: true }, {
+      sessionMode: 'persistent',
+      headless: false,
+    }),
+    allowMutations: false,
+    dryRun: true,
+  });
+
+  try {
+    await driver.openSession({
+      runId: 'enterprise-entity-resolution',
+      territoryId: 'enterprise-entity-resolution',
+      dryRun: true,
+      weeklyCap: 140,
+    });
+    const health = await driver.checkSessionHealth();
+    if (!health.authenticated) {
+      throw new Error(`LinkedIn session is not authenticated (${health.state || 'unknown'})`);
+    }
+    if (typeof driver.resolveEnterpriseEntitiesReadOnly !== 'function') {
+      throw new Error(`Driver ${driverName} does not support enterprise entity resolution`);
+    }
+
+    const resolution = await driver.resolveEnterpriseEntitiesReadOnly({
+      accountName,
+      companyCount: Number(getString(values, 'max-companies') || 10),
+      leadSampleCount: Number(getString(values, 'lead-sample-count') || 10),
+      maxLeadSampleTargets: Number(getString(values, 'max-targets') || 8),
+      writeArtifact: true,
+    });
+
+    if (getBoolean(values, 'json')) {
+      console.log(JSON.stringify(resolution, null, 2));
+      return;
+    }
+
+    logger.info(`Enterprise entity resolver: ${resolution.status}`);
+    logger.info(`Mode: ${resolution.mode}`);
+    logger.info(`Included targets: ${resolution.summary?.included || 0}`);
+    logger.info(`Suggested targets: ${resolution.summary?.suggested || 0}`);
+    logger.info(`Excluded homonyms: ${resolution.summary?.excluded || 0}`);
+    for (const target of resolution.included || []) {
+      logger.info(`Include: ${target.name} | ${target.entityPriority} | confidence=${target.confidence}`);
+    }
+    for (const target of resolution.excluded || []) {
+      logger.info(`Skip: ${target.name} | ${target.reason}`);
+    }
+    if ((resolution.errors || []).length > 0) {
+      for (const error of resolution.errors) {
+        logger.warn(`${error.code}: ${error.message}`);
+      }
+    }
+    logger.info(`Artifact: ${resolution.artifactPath}`);
+    logger.info(`Report: ${resolution.reportPath}`);
   } finally {
     await driver.close().catch(() => {});
   }
@@ -4261,6 +4335,7 @@ Usage:
   node src/cli.js print-first-run-onboarding [--json]
   node src/cli.js check-driver-session [--driver=playwright|browser-harness|hybrid] [--session-mode=storage-state|persistent]
   node src/cli.js test-sales-nav-api --account-name="Acme" [--list-name="Existing Test List"] [--driver=playwright] [--max-candidates=25]
+  node src/cli.js resolve-enterprise-entities --account-name="Acme" [--driver=playwright] [--max-companies=10] [--lead-sample-count=10]
   node src/cli.js bootstrap-session [--driver=playwright] [--wait-minutes=10]
   node src/cli.js test-account-search --driver=playwright|browser-harness|hybrid --account-name="Acme" [--account-list="Territory List"] [--keywords="site reliability,observability"]
   node src/cli.js account-coverage --driver=hybrid --account-name="Acme" [--research-mode=persona-led|exhaustive|keyword] [--speed-profile=balanced] [--reuse-sweep-cache] [--adaptive-sweep-pruning] [--api-read-prefetch] [--inter-sweep-delay-ms=2000]

--- a/src/core/account-batch.js
+++ b/src/core/account-batch.js
@@ -419,6 +419,9 @@ function renderAccountBatchReportMarkdown(payload) {
     lines.push(`- Coverage status: \`${sdrSummary.coverageStatus}\``);
     if (result.apiReadPrefetch) {
       lines.push(`- API read prefetch: \`${result.apiReadPrefetch.companyResolution?.status || result.apiReadPrefetch.status}\` | leads=\`${result.apiReadPrefetch.leadCandidateCount || 0}\` | ui_sweeps_skipped=\`${result.apiReadPrefetch.uiSweepsSkipped ? 'yes' : 'no'}\``);
+      if (result.apiReadPrefetch.companyResolution?.source === 'enterprise_entity_resolver') {
+        lines.push(`- Enterprise entity resolver: \`used\` | report=\`${result.apiReadPrefetch.companyResolution.reportPath || 'runtime/artifacts/company-resolution/enterprise-entities'}\``);
+      }
       const entityPriorities = (result.apiReadPrefetch.companyResolution?.selectedTargets || [])
         .map((target) => `${target.name || target.linkedinName || 'unknown'}=${target.entityPriority || 'related_entity'}`)
         .slice(0, 5);

--- a/src/core/account-coverage.js
+++ b/src/core/account-coverage.js
@@ -1012,6 +1012,7 @@ async function runAccountCoverageWorkflow({
         driver.runSalesNavApiReadPrefetch({
           accountName,
           leadCount: apiReadPrefetchLeadCount,
+          companyTargets: companyResolution.targets || activeAccount?.salesNav?.companyTargets || [],
         }), { now });
     } catch (error) {
       apiReadPrefetchResult = {

--- a/src/core/company-resolution.js
+++ b/src/core/company-resolution.js
@@ -169,7 +169,11 @@ function buildCompanyResolution({
     }))
     .sort((left, right) => right.score - left.score);
 
-  const selectedTargets = targets.filter((target) => target.score >= 50).slice(0, 5);
+  const hasCuratedTargets = targets.some((target) => target.evidence.includes('curated_target'));
+  const selectableTargets = hasCuratedTargets
+    ? targets.filter((target) => target.evidence.includes('curated_target'))
+    : targets;
+  const selectedTargets = selectableTargets.filter((target) => target.score >= 50).slice(0, 5);
   selectedTargets.sort(compareCompanyTargetPriority);
   const top = [...selectedTargets].sort((left, right) => right.score - left.score)[0] || null;
   const strongTargets = selectedTargets.filter((target) => target.score >= 70);
@@ -334,7 +338,7 @@ function scoreCompanyTarget({ target, accountName, domains = [], territoryCountr
   if (evidence.some((item) => /alias|curated_target|curated_it_subsidiary|curated_parent/.test(item))) {
     score += 30;
   }
-  if (target.linkedinCompanyUrl || evidence.some((item) => /linkedin_url/.test(item))) {
+  if (target.linkedinCompanyUrl || target.salesNavCompanyUrl || evidence.some((item) => /linkedin_url/.test(item))) {
     score += 30;
   }
   if (domains.length > 0 && target.linkedinCompanyUrl && domains.some((domain) => target.linkedinCompanyUrl.includes(String(domain).replace(/^https?:\/\//i, '').replace(/^www\./i, '')))) {

--- a/src/core/enterprise-entity-resolution.js
+++ b/src/core/enterprise-entity-resolution.js
@@ -1,0 +1,509 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { writeJson } = require('../lib/json');
+const {
+  COMPANY_RESOLUTION_ARTIFACTS_DIR,
+  ensureDir,
+} = require('../lib/paths');
+const {
+  classifyCompanyEntityPriority,
+  compareCompanyTargetPriority,
+  findCompanyAliasEntry,
+  loadCompanyAliasConfig,
+  normalizeCompanyName,
+} = require('./company-resolution');
+
+const ENTERPRISE_ENTITY_ARTIFACTS_DIR = path.join(COMPANY_RESOLUTION_ARTIFACTS_DIR, 'enterprise-entities');
+
+const IT_DIGITAL_PATTERN = /\b(it|digital|systems?|technology|tech|platform|cloud|data|software|engineering|analytics|ai|devops|sre|infrastructure|informatik|rechenzentrum)\b/i;
+const PARENT_PATTERN = /\b(parent|main|hq|headquarters|group|holding|zentrale|makro|macro|retail|global)\b/i;
+const UNRELATED_PATTERN = /\b(bank|broadband|include exclude|advertis|academy|university|real estate|properties|media sales|investment|capital|insurance|clinic|hospitality)\b/i;
+const TECH_TITLE_PATTERN = /\b(observability|monitoring|sre|site reliability|devops|platform|cloud|infrastructure|systems?|software|engineering|architect|technology|data|ai|security operations)\b/i;
+const LEGAL_OR_GENERIC_TOKENS = new Set([
+  'ag',
+  'co',
+  'company',
+  'corp',
+  'corporation',
+  'gmbh',
+  'group',
+  'holding',
+  'inc',
+  'ltd',
+  'limited',
+  'llc',
+  'plc',
+  'sa',
+  'se',
+]);
+
+function slugifyAccountName(accountName) {
+  return String(accountName || 'account')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'account';
+}
+
+function buildEnterpriseEntitySearchTerms(accountName, {
+  aliasEntry = null,
+  maxTerms = 12,
+} = {}) {
+  const raw = String(accountName || '').trim();
+  const aliases = aliasEntry || findCompanyAliasEntry(loadCompanyAliasConfig(), raw);
+  const configuredTerms = [
+    ...(aliases.accountSearchAliases || []),
+    ...(aliases.companyFilterAliases || []),
+    ...(aliases.parentAliases || []),
+    ...(aliases.subsidiaryAliases || []),
+    ...(aliases.targets || []).map((target) => target.linkedinName || target.name || target.companyName),
+  ].filter(Boolean);
+  const variants = [
+    raw,
+    `${raw} digital`,
+    `${raw} IT`,
+    `${raw} systems`,
+    `${raw} technology`,
+    `${raw} platform`,
+    `${raw} data`,
+    ...configuredTerms,
+  ]
+    .map((value) => String(value || '').replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+  return [...new Set(variants)].slice(0, maxTerms);
+}
+
+function candidateCompanyId(candidate = {}) {
+  if (candidate.companyId) return String(candidate.companyId);
+  const match = String(candidate.salesNavigatorUrl || candidate.salesNavCompanyUrl || '').match(/\/sales\/company\/([^/?#]+)/i);
+  return match ? decodeURIComponent(match[1]).trim() : '';
+}
+
+function normalizeCandidate(candidate = {}, index = 0) {
+  const name = candidate.name || candidate.linkedinName || candidate.companyName || '';
+  const companyId = candidateCompanyId(candidate);
+  return {
+    ...candidate,
+    name,
+    linkedinName: name,
+    companyId,
+    entityUrn: candidate.entityUrn || (companyId ? `urn:li:fs_salesCompany:${companyId}` : ''),
+    salesNavigatorUrl: candidate.salesNavigatorUrl || candidate.salesNavCompanyUrl || (companyId ? `https://www.linkedin.com/sales/company/${companyId}` : ''),
+    evidence: [...new Set(candidate.evidence || [])],
+    searchTerm: candidate.searchTerm || null,
+    source: candidate.source || 'api_company_search',
+    leadSamples: Array.isArray(candidate.leadSamples) ? candidate.leadSamples : [],
+    index,
+  };
+}
+
+function dedupeEntityCandidates(candidates = []) {
+  const byKey = new Map();
+  for (const [index, rawCandidate] of candidates.entries()) {
+    const candidate = normalizeCandidate(rawCandidate, index);
+    const key = candidate.companyId || normalizeCompanyName(candidate.name);
+    if (!key) continue;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, candidate);
+      continue;
+    }
+    existing.evidence = [...new Set([...(existing.evidence || []), ...(candidate.evidence || [])])];
+    existing.searchTerm = existing.searchTerm || candidate.searchTerm;
+    existing.leadSamples = mergeLeadSamples(existing.leadSamples, candidate.leadSamples);
+  }
+  return [...byKey.values()];
+}
+
+function buildBrandTokens(accountName) {
+  const tokens = normalizeCompanyName(accountName)
+    .split(' ')
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 4 && !LEGAL_OR_GENERIC_TOKENS.has(token));
+  if (tokens.length > 1) {
+    return tokens.filter((token, index) => index > 0 || token.length >= 5);
+  }
+  return tokens;
+}
+
+function mergeLeadSamples(left = [], right = []) {
+  const seen = new Set();
+  const merged = [];
+  for (const item of [...left, ...right]) {
+    const key = item.entityUrn || item.salesNavigatorLeadId || `${item.fullName}|${item.title}`;
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    merged.push(item);
+  }
+  return merged;
+}
+
+function leadSampleTechSignals(leadSamples = []) {
+  return (leadSamples || []).filter((lead) => TECH_TITLE_PATTERN.test(`${lead.title || ''} ${lead.headline || ''}`)).length;
+}
+
+function classifyEnterpriseEntityCandidate(accountName, candidate = {}, context = {}) {
+  const normalizedAccount = normalizeCompanyName(accountName);
+  const normalizedName = normalizeCompanyName(candidate.name || candidate.linkedinName);
+  const text = `${candidate.name || candidate.linkedinName || ''} ${(candidate.evidence || []).join(' ')}`;
+  const brandTokens = context.brandTokens || buildBrandTokens(accountName);
+  const exactName = normalizedName && normalizedName === normalizedAccount;
+  const relatedByName = normalizedName && normalizedAccount && (
+    normalizedName.startsWith(`${normalizedAccount} `)
+    || normalizedName.includes(` ${normalizedAccount} `)
+    || normalizedName.includes(`${normalizedAccount} `)
+    || normalizedName.includes(normalizedAccount)
+    || brandTokens.some((token) => normalizedName.split(' ').includes(token))
+  );
+  const itDigital = IT_DIGITAL_PATTERN.test(text);
+  const parentSignal = PARENT_PATTERN.test(text) || exactName;
+  const unrelatedSignal = UNRELATED_PATTERN.test(text);
+  const curatedSignal = (candidate.evidence || []).some((item) => /curated/.test(item));
+  const techLeadSignals = leadSampleTechSignals(candidate.leadSamples);
+  const hasStrongerRelatedTargets = Boolean(context.hasStrongerRelatedTargets);
+  let score = 0;
+  const reasons = [];
+
+  if (exactName) {
+    score += 30;
+    reasons.push('exact account-name match');
+  } else if (relatedByName) {
+    score += 24;
+    reasons.push('name is related to the account');
+  }
+  if (itDigital && (relatedByName || techLeadSignals > 0 || curatedSignal)) {
+    score += 50;
+    reasons.push('IT/digital/technology entity');
+  } else if (itDigital) {
+    score += 10;
+    reasons.push('IT/digital keyword without account relation');
+  }
+  if (parentSignal) {
+    score += 46;
+    reasons.push('parent/main buyer-scope entity');
+  }
+  if (techLeadSignals > 0) {
+    score += Math.min(30, techLeadSignals * 7);
+    reasons.push(`${techLeadSignals} technical lead sample${techLeadSignals === 1 ? '' : 's'}`);
+  }
+  if (relatedByName && techLeadSignals >= 3) {
+    score += 25;
+    reasons.push('technical sample confirms related entity');
+  }
+  if (curatedSignal) {
+    score += 70;
+    reasons.push('curated target');
+  }
+  if (unrelatedSignal) {
+    score -= 55;
+    reasons.push('unrelated homonym signal');
+  }
+  if (exactName && hasStrongerRelatedTargets && !itDigital && !PARENT_PATTERN.test(text)) {
+    score -= 20;
+    reasons.push('generic exact page kept behind stronger related entities');
+  }
+  if (!relatedByName && !exactName && !techLeadSignals && !curatedSignal) {
+    score -= 35;
+    reasons.push('no clear relation to account');
+  }
+
+  const confidence = Math.max(0, Math.min(1, Number((score / 100).toFixed(2))));
+  let entityPriority = classifyCompanyEntityPriority({
+    linkedinName: candidate.name || candidate.linkedinName,
+    targetType: parentSignal ? 'parent' : 'unknown',
+    evidence: candidate.evidence || [],
+  });
+  if (itDigital && (relatedByName || techLeadSignals > 0 || curatedSignal)) {
+    entityPriority = 'it_digital_first';
+  } else if (parentSignal && !unrelatedSignal) {
+    entityPriority = 'parent_buyer_scope';
+  } else if (unrelatedSignal || confidence < 0.35) {
+    entityPriority = 'unrelated_homonym';
+  } else {
+    entityPriority = 'related_entity';
+  }
+
+  let decision = 'exclude';
+  if (!unrelatedSignal && confidence >= 0.7) {
+    decision = 'include';
+  } else if (!unrelatedSignal && confidence >= 0.5) {
+    decision = 'suggest';
+  }
+
+  if (!relatedByName && !exactName && !techLeadSignals && !curatedSignal) {
+    decision = 'exclude';
+    entityPriority = 'unrelated_homonym';
+  }
+
+  if (entityPriority === 'unrelated_homonym') {
+    decision = 'exclude';
+  }
+
+  return {
+    ...candidate,
+    normalizedName,
+    entityPriority,
+    confidence,
+    decision,
+    reason: reasons.join('; ') || 'no strong relation signal',
+    leadSampleCount: candidate.leadSamples?.length || 0,
+    technicalLeadSampleCount: techLeadSignals,
+  };
+}
+
+function normalizeCuratedTargets(accountName, aliasEntry = {}) {
+  return (aliasEntry.targets || [])
+    .map((target) => normalizeCandidate({
+      name: target.linkedinName || target.name || target.companyName,
+      companyId: candidateCompanyId(target),
+      salesNavigatorUrl: target.salesNavCompanyUrl,
+      entityUrn: target.entityUrn,
+      evidence: [...new Set(['curated_target', ...(target.evidence || [])])],
+      source: 'curated_company_targets',
+    }))
+    .filter((candidate) => candidate.name && candidate.companyId)
+    .map((candidate) => classifyEnterpriseEntityCandidate(accountName, candidate, { hasStrongerRelatedTargets: true }))
+    .map((candidate) => ({
+      ...candidate,
+      decision: 'include',
+      confidence: Math.max(candidate.confidence, 0.9),
+      reason: `${candidate.reason}; curated config target`,
+    }));
+}
+
+function addCuratedEvidenceToCandidates(candidates = [], aliasEntry = {}) {
+  const curatedNames = new Map();
+  for (const target of aliasEntry.targets || []) {
+    const name = target.linkedinName || target.name || target.companyName;
+    const key = normalizeCompanyName(name);
+    if (!key) continue;
+    curatedNames.set(key, [...new Set(['curated_target', ...(target.evidence || [])])]);
+  }
+  return candidates.map((candidate) => {
+    const key = normalizeCompanyName(candidate.name || candidate.linkedinName);
+    const evidence = curatedNames.get(key);
+    if (!evidence) return candidate;
+    return {
+      ...candidate,
+      evidence: [...new Set([...(candidate.evidence || []), ...evidence])],
+    };
+  });
+}
+
+function resolveEnterpriseEntities({
+  accountName,
+  companyCandidates = [],
+  aliasConfig = null,
+  now = new Date(),
+} = {}) {
+  const config = aliasConfig || loadCompanyAliasConfig();
+  const aliasEntry = findCompanyAliasEntry(config, accountName);
+  const brandTokens = buildBrandTokens(accountName);
+  const curatedTargets = normalizeCuratedTargets(accountName, aliasEntry);
+  const candidates = dedupeEntityCandidates(addCuratedEvidenceToCandidates(companyCandidates, aliasEntry));
+  const hasStrongerRelatedTargets = candidates.some((candidate) => {
+    const text = `${candidate.name || ''} ${(candidate.evidence || []).join(' ')}`;
+    const normalizedName = normalizeCompanyName(candidate.name);
+    return (normalizedName.includes(normalizeCompanyName(accountName))
+      || brandTokens.some((token) => normalizedName.split(' ').includes(token)))
+      && (IT_DIGITAL_PATTERN.test(text) || PARENT_PATTERN.test(text));
+  });
+  const classifiedSearchCandidates = candidates.map((candidate) =>
+    classifyEnterpriseEntityCandidate(accountName, candidate, { hasStrongerRelatedTargets, brandTokens }));
+  const merged = dedupeEntityCandidates([...curatedTargets, ...classifiedSearchCandidates])
+    .map((candidate) => (
+      candidate.decision
+        ? candidate
+        : classifyEnterpriseEntityCandidate(accountName, candidate, { hasStrongerRelatedTargets, brandTokens })
+    ));
+  const included = merged
+    .filter((candidate) => candidate.decision === 'include')
+    .sort(compareEnterpriseEntityPriority);
+  const suggested = merged
+    .filter((candidate) => candidate.decision === 'suggest')
+    .sort(compareEnterpriseEntityPriority);
+  const excluded = merged
+    .filter((candidate) => candidate.decision === 'exclude')
+    .sort(compareEnterpriseEntityPriority);
+  const hasCuratedEvidence = merged.some((candidate) => (candidate.evidence || []).some((item) => /curated/.test(item)));
+  const source = curatedTargets.length > 0 || hasCuratedEvidence ? 'curated_company_targets' : 'api_company_search';
+  let status = 'needs_company_scope_review';
+  if (included.length > 0) {
+    status = curatedTargets.length > 0 || hasCuratedEvidence
+      ? (included.length > 1 ? 'resolved_multi_target_curated' : 'resolved_exact_curated')
+      : (included.length > 1 ? 'resolved_multi_target_suggested' : 'resolved_exact_suggested');
+  } else if (merged.length === 0) {
+    status = 'all_resolution_failed';
+  }
+
+  const selectedTargets = included.map(toApiTarget);
+  const searchedFirst = selectedTargets[0]?.name || null;
+  const searchedRest = selectedTargets.slice(1).map((target) => target.name);
+  const skippedCount = excluded.length;
+
+  return {
+    generatedAt: now.toISOString(),
+    accountName,
+    source,
+    status,
+    mode: 'read_only',
+    learningMode: 'suggest_first',
+    recommendedAction: included.length > 0 ? 'run_related_entity_sweeps' : 'review_enterprise_entities',
+    summary: {
+      included: included.length,
+      suggested: suggested.length,
+      excluded: excluded.length,
+      searchedFirst,
+      searchedRest,
+      skippedCount,
+    },
+    selectedTargets,
+    included: included.map(toArtifactEntity),
+    suggested: suggested.map(toArtifactEntity),
+    excluded: excluded.map(toArtifactEntity),
+    learnedSuggestions: curatedTargets.length > 0 || hasCuratedEvidence ? [] : suggested.concat(included).map(toLearnedSuggestion),
+  };
+}
+
+function compareEnterpriseEntityPriority(left = {}, right = {}) {
+  const leftRank = entityPriorityRank(left.entityPriority);
+  const rightRank = entityPriorityRank(right.entityPriority);
+  if (leftRank !== rightRank) return leftRank - rightRank;
+  if ((right.confidence || 0) !== (left.confidence || 0)) return (right.confidence || 0) - (left.confidence || 0);
+  return (left.index || 0) - (right.index || 0);
+}
+
+function entityPriorityRank(priority) {
+  switch (priority) {
+    case 'it_digital_first':
+      return 0;
+    case 'parent_buyer_scope':
+      return 1;
+    case 'related_entity':
+      return 2;
+    case 'unrelated_homonym':
+      return 9;
+    default:
+      return 5;
+  }
+}
+
+function toApiTarget(entity = {}) {
+  return {
+    name: entity.name || entity.linkedinName,
+    companyId: entity.companyId,
+    entityUrn: entity.entityUrn || (entity.companyId ? `urn:li:fs_salesCompany:${entity.companyId}` : ''),
+    salesNavigatorUrl: entity.salesNavigatorUrl || (entity.companyId ? `https://www.linkedin.com/sales/company/${entity.companyId}` : ''),
+    entityPriority: entity.entityPriority,
+    confidence: entity.confidence,
+    decision: entity.decision,
+    reason: entity.reason,
+    evidence: entity.evidence || [],
+  };
+}
+
+function toArtifactEntity(entity = {}) {
+  return {
+    name: entity.name || entity.linkedinName,
+    companyId: entity.companyId,
+    entityUrn: entity.entityUrn || null,
+    salesNavigatorUrl: entity.salesNavigatorUrl || null,
+    entityPriority: entity.entityPriority,
+    confidence: entity.confidence,
+    decision: entity.decision,
+    reason: entity.reason,
+    evidence: entity.evidence || [],
+    leadSampleCount: entity.leadSampleCount || 0,
+    technicalLeadSampleCount: entity.technicalLeadSampleCount || 0,
+  };
+}
+
+function toLearnedSuggestion(entity = {}) {
+  return {
+    linkedinName: entity.name || entity.linkedinName,
+    salesNavCompanyUrl: entity.salesNavigatorUrl || null,
+    targetType: entity.entityPriority === 'parent_buyer_scope' ? 'parent' : 'subsidiary',
+    territoryFit: 'likely',
+    confidence: entity.confidence,
+    entityPriority: entity.entityPriority,
+    evidence: [...new Set(['enterprise_entity_resolver', ...(entity.evidence || [])])],
+    reason: entity.reason,
+  };
+}
+
+function buildEnterpriseEntityArtifactPath(accountName, now = new Date()) {
+  ensureDir(ENTERPRISE_ENTITY_ARTIFACTS_DIR, 0o700);
+  const timestamp = now.toISOString().replace(/[:.]/g, '-');
+  return path.join(ENTERPRISE_ENTITY_ARTIFACTS_DIR, `${timestamp}-${slugifyAccountName(accountName)}.json`);
+}
+
+function writeEnterpriseEntityResolutionArtifact(resolution, artifactPath = null) {
+  const targetPath = artifactPath || buildEnterpriseEntityArtifactPath(resolution?.accountName);
+  const reportPath = targetPath.replace(/\.json$/i, '.md');
+  writeJson(targetPath, {
+    ...resolution,
+    artifactPath: targetPath,
+    reportPath,
+  });
+  fs.writeFileSync(reportPath, renderEnterpriseEntityResolutionMarkdown({
+    ...resolution,
+    artifactPath: targetPath,
+    reportPath,
+  }), {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  return { artifactPath: targetPath, reportPath };
+}
+
+function renderEnterpriseEntityResolutionMarkdown(resolution = {}) {
+  const lines = [];
+  lines.push('# Enterprise Entity Resolution');
+  lines.push('');
+  lines.push(`- Account: \`${resolution.accountName || 'unknown'}\``);
+  lines.push(`- Status: \`${resolution.status || 'unknown'}\``);
+  lines.push(`- Mode: \`${resolution.mode || 'read_only'}\``);
+  lines.push(`- Learning: \`${resolution.learningMode || 'suggest_first'}\``);
+  lines.push(`- Recommended action: \`${resolution.recommendedAction || 'review_enterprise_entities'}\``);
+  if (resolution.summary?.searchedFirst) {
+    const rest = (resolution.summary.searchedRest || []).join(', ');
+    lines.push(`- Plain English: Searched ${resolution.summary.searchedFirst} first${rest ? `, then ${rest}` : ''}; skipped ${resolution.summary.skippedCount || 0} unrelated page${resolution.summary.skippedCount === 1 ? '' : 's'}.`);
+  }
+  lines.push('');
+  lines.push('## Included Targets');
+  appendEntityTable(lines, resolution.included || []);
+  lines.push('');
+  lines.push('## Suggested Targets');
+  appendEntityTable(lines, resolution.suggested || []);
+  lines.push('');
+  lines.push('## Excluded Targets');
+  appendEntityTable(lines, resolution.excluded || []);
+  lines.push('');
+  return `${lines.join('\n').trim()}\n`;
+}
+
+function appendEntityTable(lines, entities) {
+  if (!entities.length) {
+    lines.push('- none');
+    return;
+  }
+  lines.push('| Name | Decision | Priority | Confidence | Reason |');
+  lines.push('| --- | --- | --- | ---: | --- |');
+  for (const entity of entities) {
+    lines.push(`| ${escapeMarkdownCell(entity.name)} | ${escapeMarkdownCell(entity.decision)} | ${escapeMarkdownCell(entity.entityPriority)} | ${entity.confidence ?? 0} | ${escapeMarkdownCell(entity.reason)} |`);
+  }
+}
+
+function escapeMarkdownCell(value) {
+  return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+module.exports = {
+  ENTERPRISE_ENTITY_ARTIFACTS_DIR,
+  buildEnterpriseEntityArtifactPath,
+  buildEnterpriseEntitySearchTerms,
+  classifyEnterpriseEntityCandidate,
+  renderEnterpriseEntityResolutionMarkdown,
+  resolveEnterpriseEntities,
+  writeEnterpriseEntityResolutionArtifact,
+};

--- a/src/core/sales-nav-api-probe.js
+++ b/src/core/sales-nav-api-probe.js
@@ -107,6 +107,11 @@ function extractCompanyId(value = {}) {
   return '';
 }
 
+function extractCompanyIdFromSalesNavUrl(url) {
+  const match = String(url || '').match(/\/sales\/company\/([^/?#]+)/i);
+  return match ? decodeURIComponent(match[1]).trim() : '';
+}
+
 function extractLeadIdFromUrn(entityUrn = '') {
   const match = String(entityUrn || '').match(/fs_salesProfile:\(?([^,\)]+)/i);
   return match ? match[1].trim() : '';
@@ -196,6 +201,44 @@ function normalizeCompanyNameForApi(value) {
     .replace(/[^a-z0-9]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+function normalizeCuratedApiCompanyTargets(companyTargets = []) {
+  return (Array.isArray(companyTargets) ? companyTargets : [])
+    .map((target, index) => {
+      const name = target.linkedinName || target.name || target.companyName || '';
+      const companyId = target.companyId || extractCompanyIdFromSalesNavUrl(target.salesNavCompanyUrl);
+      if (!name || !companyId) {
+        return null;
+      }
+      return {
+        name,
+        companyId,
+        entityUrn: target.entityUrn || `urn:li:fs_salesCompany:${companyId}`,
+        salesNavigatorUrl: target.salesNavCompanyUrl || `https://www.linkedin.com/sales/company/${companyId}`,
+        index,
+        normalizedName: normalizeCompanyNameForApi(name),
+        entityPriority: classifyCompanyEntityPriority(target),
+        evidence: [...new Set(['curated_target', ...(target.evidence || [])])],
+      };
+    })
+    .filter(Boolean)
+    .sort(compareCompanyTargetPriority);
+}
+
+function assessCuratedApiCompanyResolution(accountName, companyTargets = []) {
+  const selectedTargets = normalizeCuratedApiCompanyTargets(companyTargets);
+  if (selectedTargets.length === 0) {
+    return null;
+  }
+  return {
+    status: selectedTargets.length > 1 ? 'resolved_multi_target_curated' : 'resolved_exact_api',
+    confidence: selectedTargets.length > 1 ? 0.9 : 0.95,
+    selectedTargets,
+    warning: null,
+    source: 'curated_company_targets',
+    accountName,
+  };
 }
 
 function assessApiCompanyResolution(accountName, companyCandidates = []) {
@@ -350,12 +393,14 @@ module.exports = {
   buildLeadSearchPath,
   buildSalesNavApiProbeArtifact,
   assessApiCompanyResolution,
+  assessCuratedApiCompanyResolution,
   classifySalesNavApiFailure,
   extractCsrfFromCookieHeader,
   extractCsrfFromCookies,
   extractLeadIdFromUrn,
   normalizeApiLeadForCoverage,
   normalizeCompanySearchResponse,
+  normalizeCuratedApiCompanyTargets,
   normalizeLeadElement,
   normalizeLeadSearchResponse,
   safePreview,

--- a/src/drivers/playwright-sales-nav.js
+++ b/src/drivers/playwright-sales-nav.js
@@ -11,12 +11,18 @@ const {
   buildLeadSearchPath,
   buildSalesNavApiProbeArtifact,
   assessApiCompanyResolution,
+  assessCuratedApiCompanyResolution,
   classifySalesNavApiFailure,
   extractCsrfFromCookies,
   normalizeApiLeadForCoverage,
   normalizeCompanySearchResponse,
   normalizeLeadSearchResponse,
 } = require('../core/sales-nav-api-probe');
+const {
+  buildEnterpriseEntitySearchTerms,
+  resolveEnterpriseEntities,
+  writeEnterpriseEntityResolutionArtifact,
+} = require('../core/enterprise-entity-resolution');
 
 const SALES_HOME_URL = 'https://www.linkedin.com/sales/home';
 const MIN_COMPANY_FILTER_CONFIDENCE = 0.7;
@@ -1047,23 +1053,73 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     companyCount = 10,
     leadCount = 100,
     maxTargets = 5,
+    companyTargets = [],
   } = {}) {
     const errors = [];
     let companyResponse = null;
-    try {
-      companyResponse = await this.salesNavApiGet(buildCompanySearchPath(accountName, { count: companyCount }));
-    } catch (error) {
-      errors.push(error);
+    const curatedResolution = assessCuratedApiCompanyResolution(accountName, companyTargets);
+    if (!curatedResolution) {
+      try {
+        companyResponse = await this.salesNavApiGet(buildCompanySearchPath(accountName, { count: companyCount }));
+      } catch (error) {
+        errors.push(error);
+      }
     }
 
-    const companyCandidates = companyResponse?.payload
-      ? normalizeCompanySearchResponse(companyResponse.payload)
-      : [];
-    const companyResolution = assessApiCompanyResolution(accountName, companyCandidates);
+    let companyCandidates = curatedResolution?.selectedTargets
+      || (companyResponse?.payload ? normalizeCompanySearchResponse(companyResponse.payload) : []);
+    let companyResolution = curatedResolution || assessApiCompanyResolution(accountName, companyCandidates);
+
+    if (!curatedResolution && ['needs_company_scope_review', 'all_resolution_failed'].includes(companyResolution.status)) {
+      const enterpriseResolution = await this.resolveEnterpriseEntitiesReadOnly({
+        accountName,
+        seedCompanyCandidates: companyCandidates,
+        companyCount,
+        leadSampleCount: Math.min(25, leadCount),
+        maxLeadSampleTargets: maxTargets,
+        writeArtifact: true,
+      }).catch((error) => ({
+        status: 'needs_company_scope_review',
+        selectedTargets: [],
+        included: [],
+        suggested: [],
+        excluded: [],
+        errors: [{
+          code: error.code || 'unexpected_shape',
+          message: String(error.message || error).slice(0, 500),
+        }],
+      }));
+
+      if (['resolved_multi_target_suggested', 'resolved_exact_suggested', 'resolved_multi_target_curated', 'resolved_exact_curated'].includes(enterpriseResolution.status)) {
+        companyResolution = {
+          status: enterpriseResolution.status,
+          confidence: enterpriseResolution.selectedTargets.length > 1 ? 0.86 : 0.9,
+          selectedTargets: enterpriseResolution.selectedTargets,
+          warning: null,
+          source: 'enterprise_entity_resolver',
+          accountName,
+          artifactPath: enterpriseResolution.artifactPath || null,
+          reportPath: enterpriseResolution.reportPath || null,
+          summary: enterpriseResolution.summary || null,
+        };
+        companyCandidates = [
+          ...(enterpriseResolution.included || []),
+          ...(enterpriseResolution.suggested || []),
+          ...(enterpriseResolution.excluded || []),
+        ];
+      }
+    }
     const leadCandidates = [];
     const targetResponses = [];
 
-    if (['resolved_exact_api', 'resolved_multi_target_api'].includes(companyResolution.status)) {
+    if ([
+      'resolved_exact_api',
+      'resolved_multi_target_api',
+      'resolved_multi_target_curated',
+      'resolved_exact_curated',
+      'resolved_exact_suggested',
+      'resolved_multi_target_suggested',
+    ].includes(companyResolution.status)) {
       for (const target of companyResolution.selectedTargets.slice(0, Math.max(1, maxTargets))) {
         try {
           const response = await this.salesNavApiGet(buildLeadSearchPath({
@@ -1108,6 +1164,95 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
         path: error.path || null,
       })),
     };
+  }
+
+  async resolveEnterpriseEntitiesReadOnly({
+    accountName,
+    seedCompanyCandidates = [],
+    companyCount = 10,
+    leadSampleCount = 10,
+    maxLeadSampleTargets = 8,
+    writeArtifact = true,
+  } = {}) {
+    const errors = [];
+    const searchTerms = buildEnterpriseEntitySearchTerms(accountName);
+    const companyCandidates = [...(seedCompanyCandidates || []).map((candidate) => ({
+      ...candidate,
+      searchTerm: candidate.searchTerm || accountName,
+    }))];
+    for (const term of searchTerms) {
+      try {
+        const response = await this.salesNavApiGet(buildCompanySearchPath(term, { count: companyCount }));
+        companyCandidates.push(...normalizeCompanySearchResponse(response.payload).map((candidate) => ({
+          ...candidate,
+          searchTerm: term,
+        })));
+      } catch (error) {
+        errors.push({
+          code: error.code || 'unexpected_shape',
+          message: String(error.message || error).slice(0, 500),
+          status: error.status || null,
+          path: error.path || null,
+          searchTerm: term,
+        });
+      }
+    }
+
+    const byCompanyId = new Map();
+    for (const candidate of companyCandidates) {
+      const key = candidate.companyId || candidate.entityUrn || candidate.name;
+      if (!key || byCompanyId.has(key)) continue;
+      byCompanyId.set(key, candidate);
+    }
+    const allUniqueCandidates = [...byCompanyId.values()];
+    const sampledCandidates = [];
+    for (const candidate of allUniqueCandidates.slice(0, Math.max(1, maxLeadSampleTargets))) {
+      const companyId = candidate.companyId;
+      if (!companyId) {
+        sampledCandidates.push(candidate);
+        continue;
+      }
+      try {
+        const response = await this.salesNavApiGet(buildLeadSearchPath({
+          companyId,
+          count: leadSampleCount,
+        }));
+        sampledCandidates.push({
+          ...candidate,
+          leadSamples: normalizeLeadSearchResponse(response.payload),
+        });
+      } catch (error) {
+        errors.push({
+          code: error.code || 'unexpected_shape',
+          message: String(error.message || error).slice(0, 500),
+          status: error.status || null,
+          path: error.path || null,
+          companyId,
+        });
+        sampledCandidates.push(candidate);
+      }
+    }
+
+    const sampledKeys = new Set(sampledCandidates.map((candidate) => candidate.companyId || candidate.entityUrn || candidate.name));
+    const resolution = {
+      ...resolveEnterpriseEntities({
+        accountName,
+        companyCandidates: [
+          ...sampledCandidates,
+          ...allUniqueCandidates.filter((candidate) => !sampledKeys.has(candidate.companyId || candidate.entityUrn || candidate.name)),
+        ],
+      }),
+      searchTerms,
+      errors,
+    };
+    if (writeArtifact) {
+      const paths = writeEnterpriseEntityResolutionArtifact(resolution);
+      return {
+        ...resolution,
+        ...paths,
+      };
+    }
+    return resolution;
   }
 
   async close() {

--- a/tests/account-coverage.test.js
+++ b/tests/account-coverage.test.js
@@ -1140,8 +1140,8 @@ test('runAccountCoverageWorkflow stops before UI sweeps when API company scope i
           status: 'needs_company_scope_review',
           confidence: 0.55,
           selectedTargets: [
-            { name: 'Metro', companyId: '332814' },
-            { name: 'Metro', companyId: '1950279' },
+            { name: 'Globex', companyId: '332814' },
+            { name: 'Globex', companyId: '1950279' },
           ],
           warning: 'api_company_search_ambiguous_exact_matches',
         },
@@ -1162,7 +1162,7 @@ test('runAccountCoverageWorkflow stops before UI sweeps when API company scope i
 
   const run = await runAccountCoverageWorkflow({
     driver,
-    accountName: 'METRO',
+    accountName: 'Globex',
     coverageConfig,
     icpConfig,
     priorityModel: null,

--- a/tests/company-resolution.test.js
+++ b/tests/company-resolution.test.js
@@ -101,42 +101,6 @@ test('buildCompanyResolution resolves EDEKA DIGITAL through curated subsidiary t
   assert.match(resolution.manualSearchUrls.linkedinCompanySearchUrl, /linkedin\.com\/search\/results\/companies/);
 });
 
-test('buildCompanyResolution can resolve METRO as curated multi-target without unrelated homonyms', () => {
-  const resolution = buildCompanyResolution({
-    accountName: 'METRO',
-    source: 'territory',
-    aliasConfig: {
-      accounts: {
-        metro: {
-          targets: [
-            {
-              linkedinName: 'METRO.digital',
-              targetType: 'subsidiary',
-              territoryFit: 'likely',
-              evidence: ['curated_it_subsidiary'],
-            },
-            {
-              linkedinName: 'METRO AG',
-              targetType: 'parent',
-              territoryFit: 'likely',
-              evidence: ['curated_parent'],
-            },
-          ],
-          resolutionStatus: 'resolved_multi_target',
-        },
-      },
-    },
-    now: new Date('2026-05-06T12:00:00.000Z'),
-  });
-
-  assert.equal(resolution.status, 'resolved_multi_target_curated');
-  assert.deepEqual(
-    resolution.targets.map((target) => target.linkedinName),
-    ['METRO.digital', 'METRO AG'],
-  );
-  assert.equal(resolution.targets[0].entityPriority, 'it_digital_first');
-});
-
 test('buildCompanyResolution marks low-confidence manual-review accounts', () => {
   const aliasConfig = readJson(resolveProjectPath('config', 'account-aliases', 'default.json'));
   const resolution = buildCompanyResolution({

--- a/tests/enterprise-entity-resolution.test.js
+++ b/tests/enterprise-entity-resolution.test.js
@@ -1,0 +1,129 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildEnterpriseEntitySearchTerms,
+  classifyEnterpriseEntityCandidate,
+  renderEnterpriseEntityResolutionMarkdown,
+  resolveEnterpriseEntities,
+} = require('../src/core/enterprise-entity-resolution');
+const { loadCompanyAliasConfig } = require('../src/core/company-resolution');
+
+test('buildEnterpriseEntitySearchTerms includes IT and digital probes plus configured aliases', () => {
+  const terms = buildEnterpriseEntitySearchTerms('Globex', {
+    aliasEntry: {
+      subsidiaryAliases: ['Globex Digital'],
+      targets: [{ linkedinName: 'Globex Group' }],
+    },
+  });
+
+  assert.deepEqual(terms.slice(0, 7), [
+    'Globex',
+    'Globex digital',
+    'Globex IT',
+    'Globex systems',
+    'Globex technology',
+    'Globex platform',
+    'Globex data',
+  ]);
+  assert.equal(terms.includes('Globex Digital'), true);
+  assert.equal(terms.includes('Globex Group'), true);
+});
+
+test('enterprise resolver includes IT and parent entities while excluding unrelated homonyms', () => {
+  const resolution = resolveEnterpriseEntities({
+    accountName: 'Globex',
+    aliasConfig: { accounts: {} },
+    companyCandidates: [
+      { name: 'Globex', companyId: '332814', salesNavigatorUrl: 'https://www.linkedin.com/sales/company/332814' },
+      { name: 'Globex Digital', companyId: '70517322', salesNavigatorUrl: 'https://www.linkedin.com/sales/company/70517322' },
+      { name: 'Globex Group', companyId: '164955', salesNavigatorUrl: 'https://www.linkedin.com/sales/company/164955' },
+      { name: 'Globex Bank', companyId: '999', salesNavigatorUrl: 'https://www.linkedin.com/sales/company/999' },
+    ],
+  });
+
+  assert.equal(resolution.status, 'resolved_multi_target_suggested');
+  assert.deepEqual(
+    resolution.selectedTargets.map((target) => target.companyId),
+    ['70517322', '164955'],
+  );
+  assert.equal(resolution.included[0].entityPriority, 'it_digital_first');
+  assert.equal(resolution.excluded.some((entity) => entity.name === 'Globex Bank'), true);
+  assert.equal(resolution.learnedSuggestions.length >= 2, true);
+});
+
+test('enterprise resolver keeps curated config as source of truth without learned suggestions', () => {
+  const aliasConfig = loadCompanyAliasConfig();
+  const resolution = resolveEnterpriseEntities({
+    accountName: 'EDEKA',
+    aliasConfig,
+    companyCandidates: [
+      { name: 'EDEKA', companyId: '1' },
+      { name: 'EDEKA DIGITAL GmbH', companyId: '4' },
+      { name: 'Lunar GmbH', companyId: '5' },
+      { name: 'Deutsche Bank', companyId: '2' },
+    ],
+  });
+
+  assert.equal(resolution.status, 'resolved_multi_target_curated');
+  assert.equal(resolution.source, 'curated_company_targets');
+  assert.equal(resolution.learnedSuggestions.length, 0);
+  assert.equal(resolution.selectedTargets.some((target) => /edeka/i.test(target.name)), true);
+});
+
+test('unrelated homonym is excluded even when it shares the account token', () => {
+  const candidate = classifyEnterpriseEntityCandidate('Globex', {
+    name: 'Globex Bank',
+    companyId: 'bank-1',
+    leadSamples: [{ title: 'Branch Manager' }],
+  }, { hasStrongerRelatedTargets: true });
+
+  assert.equal(candidate.decision, 'exclude');
+  assert.equal(candidate.entityPriority, 'unrelated_homonym');
+});
+
+test('enterprise resolver markdown explains what was searched and skipped in plain English', () => {
+  const resolution = resolveEnterpriseEntities({
+    accountName: 'Globex',
+    aliasConfig: { accounts: {} },
+    companyCandidates: [
+      { name: 'Globex Digital', companyId: '70517322' },
+      { name: 'Globex Group', companyId: '164955' },
+      { name: 'Globex Bank', companyId: '999' },
+    ],
+  });
+  const markdown = renderEnterpriseEntityResolutionMarkdown(resolution);
+
+  assert.match(markdown, /Searched Globex Digital first, then Globex Group; skipped 1 unrelated page/);
+  assert.match(markdown, /Included Targets/);
+  assert.match(markdown, /Excluded Targets/);
+});
+
+test('enterprise resolver treats shortened brand entities as related but blocks generic keyword-only companies', () => {
+  const resolution = resolveEnterpriseEntities({
+    accountName: 'Carl Zeiss',
+    aliasConfig: { accounts: {} },
+    companyCandidates: [
+      { name: 'ZEISS Group', companyId: '938659' },
+      { name: 'Carl Zeiss IQS Software R&D Center', companyId: '1233280' },
+      {
+        name: 'Carl Zeiss MES Solutions GmbH',
+        companyId: '223971',
+        leadSamples: [
+          { title: 'Cloud Platform Engineer' },
+          { title: 'DevOps Engineer' },
+          { title: 'Software Architect' },
+        ],
+      },
+      { name: 'Digital Cinema Service', companyId: '2231829' },
+      { name: 'Carl Benz School of Engineering', companyId: '12425839' },
+    ],
+  });
+
+  assert.equal(resolution.status, 'resolved_multi_target_suggested');
+  assert.equal(resolution.selectedTargets.some((target) => target.name === 'ZEISS Group'), true);
+  assert.equal(resolution.selectedTargets.some((target) => target.name === 'Carl Zeiss IQS Software R&D Center'), true);
+  assert.equal(resolution.included.some((target) => target.name === 'Carl Zeiss MES Solutions GmbH'), true);
+  assert.equal(resolution.excluded.some((target) => target.name === 'Digital Cinema Service'), true);
+  assert.equal(resolution.excluded.some((target) => target.name === 'Carl Benz School of Engineering'), true);
+});

--- a/tests/playwright-driver.test.js
+++ b/tests/playwright-driver.test.js
@@ -270,6 +270,102 @@ test('playwright API prefetch reads every selected related target in entity-prio
   assert.equal(result.companyResolution.selectedTargets[0].entityPriority, 'it_digital_first');
 });
 
+test('playwright API prefetch uses curated company IDs instead of ambiguous name search', async () => {
+  const driver = new PlaywrightSalesNavigatorDriver();
+  const requestedPaths = [];
+  driver.salesNavApiGet = async (requestPath) => {
+    requestedPaths.push(requestPath);
+    assert.doesNotMatch(requestPath, /salesApiAccountSearch/);
+    const companyId = String(requestPath).match(/\(id:(\d+)\)/)?.[1] || '';
+    return {
+      ok: true,
+      payload: {
+        elements: [{
+          entityUrn: `urn:li:fs_salesProfile:(globex-${companyId},NAME_SEARCH,x)`,
+          firstName: `Globex${companyId}`,
+          lastName: 'Lead',
+          currentPositions: [{ title: 'Cloud Platform Lead', companyName: `Company ${companyId}`, current: true }],
+        }],
+      },
+    };
+  };
+
+  const result = await driver.runSalesNavApiReadPrefetch({
+    accountName: 'Globex',
+    leadCount: 5,
+    companyTargets: [
+      {
+        linkedinName: 'Globex Group',
+        salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/164955',
+        targetType: 'parent',
+        evidence: ['curated_parent'],
+      },
+      {
+        linkedinName: 'Globex Digital',
+        salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/70517322',
+        targetType: 'subsidiary',
+        evidence: ['curated_it_subsidiary'],
+      },
+    ],
+  });
+
+  assert.equal(result.companyResolution.status, 'resolved_multi_target_curated');
+  assert.equal(result.leadCandidates.length, 2);
+  assert.deepEqual(
+    result.targetResponses.map((response) => response.target.companyId),
+    ['70517322', '164955'],
+  );
+  assert.equal(requestedPaths.length, 2);
+});
+
+test('playwright API prefetch recovers ambiguous enterprise accounts through entity resolver suggestions', async () => {
+  const driver = new PlaywrightSalesNavigatorDriver();
+  const requestedCompanyIds = [];
+  driver.salesNavApiGet = async (requestPath) => {
+    if (String(requestPath).includes('salesApiAccountSearch')) {
+      return {
+        ok: true,
+        payload: {
+          elements: [
+            { entityUrn: 'urn:li:fs_salesCompany:332814', name: 'Globex', navigationUrl: 'https://www.linkedin.com/sales/company/332814' },
+            { entityUrn: 'urn:li:fs_salesCompany:1950279', name: 'Globex', navigationUrl: 'https://www.linkedin.com/sales/company/1950279' },
+            { entityUrn: 'urn:li:fs_salesCompany:70517322', name: 'Globex Digital', navigationUrl: 'https://www.linkedin.com/sales/company/70517322' },
+            { entityUrn: 'urn:li:fs_salesCompany:164955', name: 'Globex Group', navigationUrl: 'https://www.linkedin.com/sales/company/164955' },
+            { entityUrn: 'urn:li:fs_salesCompany:999', name: 'Globex Bank', navigationUrl: 'https://www.linkedin.com/sales/company/999' },
+          ],
+        },
+      };
+    }
+    const companyId = String(requestPath).match(/\(id:(\d+)\)/)?.[1] || '';
+    requestedCompanyIds.push(companyId);
+    return {
+      ok: true,
+      payload: {
+        elements: [{
+          entityUrn: `urn:li:fs_salesProfile:(enterprise-${companyId},NAME_SEARCH,x)`,
+          firstName: `Enterprise${companyId}`,
+          lastName: 'Lead',
+          currentPositions: [{ title: 'Cloud Platform Lead', companyName: `Company ${companyId}`, current: true }],
+        }],
+      },
+    };
+  };
+
+  const result = await driver.runSalesNavApiReadPrefetch({
+    accountName: 'Globex',
+    leadCount: 5,
+    maxTargets: 5,
+  });
+
+  assert.equal(result.companyResolution.status, 'resolved_multi_target_suggested');
+  assert.deepEqual(
+    result.companyResolution.selectedTargets.map((target) => target.companyId),
+    ['70517322', '164955'],
+  );
+  assert.deepEqual(requestedCompanyIds.slice(-2), ['70517322', '164955']);
+  assert.equal(result.companyCandidates.some((candidate) => candidate.name === 'Globex Bank' && candidate.decision === 'exclude'), true);
+});
+
 test('playwright driver backs off once and resumes after transient rate limit', async () => {
   const waits = [];
   let bodyText = 'Too many requests. Try later.';

--- a/tests/sales-nav-api-probe.test.js
+++ b/tests/sales-nav-api-probe.test.js
@@ -7,6 +7,7 @@ const {
   buildLeadSearchPath,
   buildSalesNavApiProbeArtifact,
   assessApiCompanyResolution,
+  assessCuratedApiCompanyResolution,
   classifySalesNavApiFailure,
   extractCsrfFromCookieHeader,
   extractCsrfFromCookies,
@@ -89,13 +90,37 @@ test('assessApiCompanyResolution distinguishes exact, multi-target, and ambiguou
   assert.equal(edeka.selectedTargets[0].entityPriority, 'it_digital_first');
   assert.equal(edeka.selectedTargets.some((target) => target.name === 'EDEKA'), true);
 
-  const metro = assessApiCompanyResolution('METRO', [
-    { name: 'Metro', companyId: '332814' },
-    { name: 'Metro', companyId: '1950279' },
-    { name: 'METRO/MAKRO', companyId: '164955' },
+  const globex = assessApiCompanyResolution('Globex', [
+    { name: 'Globex', companyId: '332814' },
+    { name: 'Globex', companyId: '1950279' },
+    { name: 'Globex Group', companyId: '164955' },
   ]);
-  assert.equal(metro.status, 'needs_company_scope_review');
-  assert.equal(metro.warning, 'api_company_search_ambiguous_exact_matches');
+  assert.equal(globex.status, 'needs_company_scope_review');
+  assert.equal(globex.warning, 'api_company_search_ambiguous_exact_matches');
+});
+
+test('assessCuratedApiCompanyResolution turns generic enterprise targets into safe ordered API targets', () => {
+  const resolution = assessCuratedApiCompanyResolution('Globex', [
+    {
+      linkedinName: 'Globex Group',
+      salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/164955',
+      targetType: 'parent',
+      evidence: ['curated_parent'],
+    },
+    {
+      linkedinName: 'Globex Digital',
+      salesNavCompanyUrl: 'https://www.linkedin.com/sales/company/70517322',
+      targetType: 'subsidiary',
+      evidence: ['curated_it_subsidiary'],
+    },
+  ]);
+
+  assert.equal(resolution.status, 'resolved_multi_target_curated');
+  assert.deepEqual(
+    resolution.selectedTargets.map((target) => target.companyId),
+    ['70517322', '164955'],
+  );
+  assert.equal(resolution.selectedTargets[0].entityPriority, 'it_digital_first');
 });
 
 test('entityUrn is a first-class Sales Navigator identity match', () => {


### PR DESCRIPTION
## Summary
- add a read-only Enterprise Entity Resolver command for ambiguous enterprise accounts
- integrate resolver suggestions into opt-in API read prefetch so safe related entities can continue instead of stopping at company-scope review
- keep learning suggest-first via runtime artifacts and avoid account-specific curated config
- document the SDR/operator workflow in README, CLAUDE, and enterprise company resolution docs

## Verification
- npm test
- npm run test:release-readiness
- git diff --check