### PR TITLE
Add API-assisted list import verification

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -858,7 +858,12 @@ async function handleFastListImport(values, logger) {
         accountKey: 'fast-list-import',
         dryRun: false,
       });
-      const existingSnapshot = readLatestLeadListArtifactSnapshot(importPlan.listName);
+      const existingSnapshot = await readLeadListPreflightSnapshot(
+        driver,
+        importPlan.listName,
+        logger,
+        readLatestLeadListArtifactSnapshot(importPlan.listName),
+      );
       const mutationReview = buildMutationReviewArtifact({
         command: 'fast-list-import',
         importPlan,
@@ -946,7 +951,12 @@ async function handleRetryFailedFastListImport(values, logger) {
         accountKey: 'retry-failed-fast-list-import',
         dryRun: false,
       });
-      const existingSnapshot = readLatestLeadListArtifactSnapshot(importPlan.listName);
+      const existingSnapshot = await readLeadListPreflightSnapshot(
+        driver,
+        importPlan.listName,
+        logger,
+        readLatestLeadListArtifactSnapshot(importPlan.listName),
+      );
       const mutationReview = buildMutationReviewArtifact({
         command: 'retry-failed-fast-list-import',
         importPlan,
@@ -1041,7 +1051,12 @@ async function handleImportCoverage(values, logger) {
         accountKey: 'import-coverage',
         dryRun: false,
       });
-      const existingSnapshot = readLatestLeadListArtifactSnapshot(importPlan.listName);
+      const existingSnapshot = await readLeadListPreflightSnapshot(
+        driver,
+        importPlan.listName,
+        logger,
+        readLatestLeadListArtifactSnapshot(importPlan.listName),
+      );
       const mutationReview = buildMutationReviewArtifact({
         command: 'import-coverage',
         importPlan,
@@ -1509,7 +1524,30 @@ async function readLeadListSnapshot(driver, listName) {
   }
 }
 
+async function readLeadListPreflightSnapshot(driver, listName, logger, fallbackSnapshot = null) {
+  try {
+    const snapshot = await readLeadListSnapshotStrict(driver, listName);
+    if (typeof logger?.info === 'function') {
+      const source = snapshot.source ? ` via ${snapshot.source}` : '';
+      logger.info(`Preflight list readback: ${snapshot.rows?.length || 0} existing lead(s)${source}`);
+    }
+    return snapshot;
+  } catch (error) {
+    if (typeof logger?.info === 'function') {
+      logger.info(`Preflight list readback unavailable: ${String(error.message || error)}`);
+    }
+    return fallbackSnapshot;
+  }
+}
+
 async function readLeadListSnapshotStrict(driver, listName) {
+  if (!driver.options?.skipApiListReadback && typeof driver.readLeadListSnapshotViaApiReadOnly === 'function') {
+    try {
+      return await driver.readLeadListSnapshotViaApiReadOnly(listName);
+    } catch {
+      // Fall back to the existing UI snapshot path when the read-only API shape is unavailable.
+    }
+  }
   if (typeof driver.runHarnessJson === 'function') {
     return await readLeadListSnapshotViaHarness(driver, listName);
   }
@@ -4347,9 +4385,9 @@ Usage:
   node src/cli.js render-coverage-review --account-name="Acme"
   node src/cli.js test-list-save --driver=playwright|browser-harness|hybrid --candidate-url="https://www.linkedin.com/sales/lead/..." --list-name="Territory List" --live-save
   node src/cli.js fast-resolve-leads --source=/path/to/leads.md [--driver=playwright] [--search-timeout-ms=8000]
-  node src/cli.js fast-list-import --source=/path/to/leads.md[,/path/to/coverage.json] [--bucket=direct_observability] [--min-score=40] [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create]
-  node src/cli.js retry-failed-fast-list-import --artifact=/path/to/failed-fast-import.json [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create]
-  node src/cli.js import-coverage --accounts=example-marketplace-a,example-saas-marketplace,olx-group [--bucket=direct_observability] [--min-score=40] [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create]
+  node src/cli.js fast-list-import --source=/path/to/leads.md[,/path/to/coverage.json] [--bucket=direct_observability] [--min-score=40] [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create] [--skip-api-list-readback]
+  node src/cli.js retry-failed-fast-list-import --artifact=/path/to/failed-fast-import.json [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create] [--skip-api-list-readback]
+  node src/cli.js import-coverage --accounts=example-marketplace-a,example-saas-marketplace,olx-group [--bucket=direct_observability] [--min-score=40] [--list-name="Lead List"] [--driver=playwright] [--live-save] [--allow-list-create] [--skip-api-list-readback]
   node src/cli.js test-connect --driver=playwright|browser-harness|hybrid --candidate-url="https://www.linkedin.com/sales/lead/..." [--full-name="Jane Doe"] --live-connect
   node src/cli.js inspect-connect-surface --driver=playwright --candidate-url="https://www.linkedin.com/sales/lead/..." [--full-name="Jane Doe"]
   node src/cli.js connect-lead-list --driver=playwright|browser-harness|hybrid --list-name="Territory List" [--limit=25] --live-connect [--allow-unverified-connect-continue]

--- a/src/core/fast-list-import.js
+++ b/src/core/fast-list-import.js
@@ -1619,6 +1619,12 @@ async function saveFastListImport({
     }
   }
 
+  await applyFinalListReadbackVerification({
+    results,
+    listName: importPlan.listName,
+    readLeadListSnapshot,
+  });
+
   return buildFastListImportResult({
     ...importPlan,
     liveSave: true,
@@ -1707,6 +1713,68 @@ async function verifyFastListSaveRow({
   };
 }
 
+function needsFinalListReadbackVerification(row = {}) {
+  return ['save_clicked_unverified', 'wrong_identity_detected'].includes(row.status)
+    || ['unverified', 'missing_after_save', 'wrong_identity_detected'].includes(row.verificationStatus);
+}
+
+async function applyFinalListReadbackVerification({
+  results = [],
+  listName,
+  readLeadListSnapshot,
+} = {}) {
+  if (typeof readLeadListSnapshot !== 'function') {
+    return results;
+  }
+  if (!results.some(needsFinalListReadbackVerification)) {
+    return results;
+  }
+
+  let snapshot;
+  try {
+    snapshot = await readLeadListSnapshot(listName);
+  } catch {
+    return results;
+  }
+
+  for (const row of results) {
+    if (!needsFinalListReadbackVerification(row)) {
+      continue;
+    }
+    const match = findSalesNavigatorLeadIdentityMatch(row, snapshot?.rows || []);
+    if (match.status === 'matched') {
+      row.status = row.status === 'already_saved' ? 'already_saved_verified' : 'saved_and_verified';
+      row.verifiedSaved = true;
+      row.verificationStatus = 'verified';
+      row.verificationMethod = snapshot?.source === 'sales_nav_api'
+        ? 'final_api_lead_list_readback'
+        : 'final_lead_list_readback';
+      row.readbackLeadIdentity = match.identity;
+      row.failureCategory = null;
+      if (row.note && /readback failed|missing from target list/i.test(row.note)) {
+        row.previousVerificationNote = row.note;
+      }
+      row.note = 'verified in final target Sales Navigator list';
+      delete row.nextAction;
+      continue;
+    }
+    if (match.status === 'same_name_wrong_identity') {
+      row.status = 'wrong_identity_detected';
+      row.verifiedSaved = false;
+      row.verificationStatus = 'wrong_identity_detected';
+      row.verificationMethod = snapshot?.source === 'sales_nav_api'
+        ? 'final_api_lead_list_readback'
+        : 'final_lead_list_readback';
+      row.failureCategory = 'wrong_identity_detected';
+      row.readbackLeadIdentity = match.identity;
+      row.note = 'same-name row found in final target list readback, but Sales Navigator lead identity does not match intended lead';
+      row.nextAction = 'manual_review_before_connect';
+    }
+  }
+
+  return results;
+}
+
 function classifySaveFailure(note) {
   const message = String(note || '');
   if (/too many requests|rate.?limit|throttl|429|please wait before trying again|try again later/i.test(message)) {
@@ -1762,6 +1830,15 @@ function buildFastListImportResult(payload) {
   const snapshotSkipped = results.filter((row) => ['already_saved', 'already_saved_verified'].includes(row.status) && row.saveRecoveryPath === 'snapshot_preflight').length;
   const rateLimitSkipped = results.filter((row) => row.status === 'skipped_rate_limit_cooldown').length;
   const failureBreakdown = summarizeSaveFailureBreakdown(results);
+  const listImportSummary = {
+    found: payload.uniqueLeads ?? payload.detectedRows ?? results.length,
+    selected: results.length,
+    alreadyInList: alreadySaved,
+    addedNow: confirmedSaved,
+    verifiedInSalesNav: confirmedSaved + alreadySaved,
+    needsFollowUp: failed + unresolved + manualReview + unverified + mutationReviewExcluded + rateLimitSkipped,
+    attemptedAdds: results.filter((row) => Number(row.attempt || 0) > 0).length,
+  };
   return {
     ...payload,
     status: failed || unresolved || manualReview || unverified || mutationReviewExcluded || rateLimitSkipped ? 'completed_with_followup' : 'completed',
@@ -1776,6 +1853,7 @@ function buildFastListImportResult(payload) {
     unverified,
     mutationReviewExcluded,
     failureBreakdown,
+    listImportSummary,
     nextAction: deriveFastListImportNextAction({ failed, unresolved, manualReview, unverified, mutationReviewExcluded, rateLimitSkipped, failureBreakdown }),
   };
 }
@@ -2033,6 +2111,13 @@ function renderFastListImportMarkdown(artifact) {
   lines.push(`- Resolved leads: \`${artifact.resolvedLeads ?? 0}\``);
   lines.push(`- Unresolved leads: \`${artifact.unresolvedLeads ?? artifact.unresolved ?? 0}\``);
   if (artifact.liveSave) {
+    if (artifact.listImportSummary) {
+      lines.push(`- Found/selected: \`${artifact.listImportSummary.found ?? 0}/${artifact.listImportSummary.selected ?? 0}\``);
+      lines.push(`- Already in Sales Nav list: \`${artifact.listImportSummary.alreadyInList ?? 0}\``);
+      lines.push(`- Added now and verified: \`${artifact.listImportSummary.addedNow ?? 0}\``);
+      lines.push(`- Verified in Sales Nav total: \`${artifact.listImportSummary.verifiedInSalesNav ?? 0}\``);
+      lines.push(`- Needs follow-up: \`${artifact.listImportSummary.needsFollowUp ?? 0}\``);
+    }
     lines.push(`- Confirmed saved this run: \`${artifact.confirmedSaved ?? artifact.saved ?? 0}\``);
     lines.push(`- Already in list: \`${artifact.alreadySaved ?? 0}\``);
     lines.push(`- Snapshot preflight skips: \`${artifact.snapshotSkipped ?? 0}\``);

--- a/src/drivers/hybrid-sales-nav.js
+++ b/src/drivers/hybrid-sales-nav.js
@@ -119,6 +119,16 @@ class HybridSalesNavigatorDriver extends DriverAdapter {
     return this.mutationDriver.saveCandidateToList(candidate, listInfo, context);
   }
 
+  async readLeadListSnapshotViaApiReadOnly(listRef, options) {
+    if (typeof this.discoveryDriver.readLeadListSnapshotViaApiReadOnly === 'function') {
+      return this.discoveryDriver.readLeadListSnapshotViaApiReadOnly(listRef, options);
+    }
+    if (typeof this.mutationDriver.readLeadListSnapshotViaApiReadOnly === 'function') {
+      return this.mutationDriver.readLeadListSnapshotViaApiReadOnly(listRef, options);
+    }
+    throw new Error('sales_nav_api: read-only list snapshot is unavailable for this driver');
+  }
+
   async sendConnect(candidate, context) {
     return this.mutationDriver.sendConnect(candidate, context);
   }

--- a/src/drivers/playwright-sales-nav.js
+++ b/src/drivers/playwright-sales-nav.js
@@ -234,6 +234,7 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     this.currentAccountKey = null;
     this.launchedPersistentContext = false;
     this.connectAttemptCount = 0;
+    this.leadListReadbackCache = new Map();
   }
 
   async openSession(context) {
@@ -964,14 +965,22 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     const normalized = String(listRef || '').trim();
     const urlMatch = normalized.match(/\/sales\/lists\/people\/(\d+)/i);
     if (urlMatch) {
-      return {
+      const direct = {
         listId: urlMatch[1],
         listUrl: normalized,
         listName: normalized,
       };
+      this.leadListReadbackCache.set(normalized, direct);
+      this.leadListReadbackCache.set(direct.listId, direct);
+      return direct;
     }
     if (!normalized) {
       return null;
+    }
+
+    const cached = this.leadListReadbackCache.get(normalized);
+    if (cached?.listId) {
+      return cached;
     }
 
     await this.navigateIfNeeded('https://www.linkedin.com/sales/lists/people');
@@ -993,7 +1002,52 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
       error.code = 'unexpected_shape';
       throw error;
     }
+    this.leadListReadbackCache.set(normalized, match);
+    this.leadListReadbackCache.set(match.listId, match);
+    this.leadListReadbackCache.set(match.listUrl, match);
     return match;
+  }
+
+  async readLeadListSnapshotViaApiReadOnly(listRef, { count = 100, maxRows = 1000 } = {}) {
+    const list = await this.resolveLeadListIdReadOnly(listRef);
+    if (!list?.listId) {
+      const error = new Error(`sales_nav_api: unable to resolve lead list ${listRef}`);
+      error.code = 'unexpected_shape';
+      throw error;
+    }
+
+    const rows = [];
+    const seen = new Set();
+    const pageSize = Math.max(1, Math.min(Number(count) || 100, 100));
+    const rowLimit = Math.max(pageSize, Number(maxRows) || 1000);
+    for (let start = 0; start < rowLimit; start += pageSize) {
+      const response = await this.salesNavApiGet(buildLeadListReadbackPath({
+        listId: list.listId,
+        start,
+        count: pageSize,
+      }));
+      const pageRows = normalizeLeadSearchResponse(response.payload);
+      for (const row of pageRows) {
+        const key = row.salesNavigatorLeadId || row.entityUrn || row.salesNavigatorUrl;
+        if (!key || seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+        rows.push(row);
+      }
+      if (pageRows.length < pageSize) {
+        break;
+      }
+    }
+
+    return {
+      status: 'ok',
+      source: 'sales_nav_api',
+      listName: list.listName || listRef,
+      listUrl: list.listUrl || listRef,
+      listId: list.listId,
+      rows,
+    };
   }
 
   async runSalesNavApiProbe({

--- a/src/lib/driver-options.js
+++ b/src/lib/driver-options.js
@@ -41,6 +41,7 @@ function buildDriverOptions(values, run = null, defaults = {}) {
     allowListCreate: getBoolean(values, 'allow-list-create'),
     recoveryMode: getString(values, 'recovery-mode') || defaults.recoveryMode || 'screenshot-only',
     dryRun: runDry,
+    skipApiListReadback: getBoolean(values, 'skip-api-list-readback') || Boolean(defaults.skipApiListReadback),
     maxScrollSteps: Number(getString(values, 'max-scroll-steps') || 10),
     settleMs: Number(getString(values, 'settle-ms') || 350),
     rateLimitBackoffMs: Number(getString(values, 'rate-limit-backoff-ms') || defaults.rateLimitBackoffMs || 60000),

--- a/tests/fast-list-import.test.js
+++ b/tests/fast-list-import.test.js
@@ -456,6 +456,50 @@ test('saveFastListImport downgrades click-only saves when no live readback verif
   assert.equal(result.results[0].verifiedSaved, false);
 });
 
+test('saveFastListImport final readback verifies rows after early list lookup misses', async () => {
+  let readCalls = 0;
+  const result = await saveFastListImport({
+    driver: {
+      async saveCandidateToList() {
+        return { status: 'saved', selectionMode: 'created_list' };
+      },
+    },
+    liveSave: true,
+    maxRetries: 0,
+    readLeadListSnapshot: async () => {
+      readCalls += 1;
+      if (readCalls === 1) {
+        throw new Error('Unable to open lead list Calling List');
+      }
+      return {
+        source: 'sales_nav_api',
+        rows: [{
+          fullName: 'Nora Platform',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+          entityUrn: 'urn:li:fs_salesProfile:(123,NAME_SEARCH,x)',
+        }],
+      };
+    },
+    importPlan: {
+      listName: 'Calling List',
+      leads: [
+        {
+          accountName: 'Example Network Co',
+          fullName: 'Nora Platform',
+          salesNavigatorUrl: 'https://www.linkedin.com/sales/lead/123',
+          resolutionStatus: 'resolved',
+        },
+      ],
+    },
+  });
+
+  assert.equal(readCalls, 2);
+  assert.equal(result.status, 'completed');
+  assert.equal(result.confirmedSaved, 1);
+  assert.equal(result.results[0].status, 'saved_and_verified');
+  assert.equal(result.results[0].verificationMethod, 'final_api_lead_list_readback');
+});
+
 test('saveFastListImport flags same-name wrong-identity readback', async () => {
   const result = await saveFastListImport({
     driver: {

--- a/tests/playwright-driver.test.js
+++ b/tests/playwright-driver.test.js
@@ -318,6 +318,51 @@ test('playwright API prefetch uses curated company IDs instead of ambiguous name
   assert.equal(requestedPaths.length, 2);
 });
 
+test('playwright API list snapshot reads direct list URLs and paginates members', async () => {
+  const driver = new PlaywrightSalesNavigatorDriver();
+  const requestedPaths = [];
+  driver.salesNavApiGet = async (requestPath) => {
+    requestedPaths.push(requestPath);
+    const start = Number(String(requestPath).match(/start=(\d+)/)?.[1] || 0);
+    const elements = start === 0
+      ? [
+        {
+          entityUrn: 'urn:li:fs_salesProfile:(lead-1,NAME_SEARCH,x)',
+          firstName: 'Lead',
+          lastName: 'One',
+          currentPositions: [{ title: 'SRE', companyName: 'METRO.digital', current: true }],
+        },
+        {
+          entityUrn: 'urn:li:fs_salesProfile:(lead-2,NAME_SEARCH,x)',
+          firstName: 'Lead',
+          lastName: 'Two',
+          currentPositions: [{ title: 'Cloud Engineer', companyName: 'METRO.digital', current: true }],
+        },
+      ]
+      : [
+        {
+          entityUrn: 'urn:li:fs_salesProfile:(lead-3,NAME_SEARCH,x)',
+          firstName: 'Lead',
+          lastName: 'Three',
+          currentPositions: [{ title: 'Platform Lead', companyName: 'METRO.digital', current: true }],
+        },
+      ];
+    return { ok: true, payload: { elements } };
+  };
+
+  const snapshot = await driver.readLeadListSnapshotViaApiReadOnly(
+    'https://www.linkedin.com/sales/lists/people/7457764280071872512',
+    { count: 2 },
+  );
+
+  assert.equal(snapshot.source, 'sales_nav_api');
+  assert.equal(snapshot.listId, '7457764280071872512');
+  assert.deepEqual(snapshot.rows.map((row) => row.salesNavigatorLeadId), ['lead-1', 'lead-2', 'lead-3']);
+  assert.equal(requestedPaths.length, 2);
+  assert.match(requestedPaths[0], /start=0&count=2/);
+  assert.match(requestedPaths[1], /start=2&count=2/);
+});
+
 test('playwright API prefetch recovers ambiguous enterprise accounts through entity resolver suggestions', async () => {
   const driver = new PlaywrightSalesNavigatorDriver();
   const requestedCompanyIds = [];


### PR DESCRIPTION
## Summary
- add read-only Sales Nav API list snapshot/readback for live-save verification
- use API-backed preflight snapshots before list imports to skip already-present leads
- add final readback verification so newly created lists can be confirmed by list ID after Sales Nav indexing lag
- keep all Sales Nav mutations UI-based; no API POST/DELETE/bulk-save paths

## Tests
- npm test
- npm run test:release-readiness
- git diff --check
- read-only METRO API smoke: 62 list rows, 100% entity URN coverage