### PR TITLE
Document API readback and enterprise resolver defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ If LinkedIn/Sales Navigator is not logged in, explain the two safe paths:
 ## Safety Defaults
 
 - Do not save leads or send connection requests unless the user explicitly asks for that live action.
+- For live list saves, prefer the standard `sdr-research --live-save` or `fast-list-import --live-save` path. The app already uses read-only list readback when available to skip existing leads and verify the final Sales Navigator list.
+- Do not attempt API-based list creation, bulk add, delete, connect, or message actions. API usage in the normal flow is read-only verification and research acceleration only.
 - Treat `runtime/`, `.env`, browser profiles, cookies, screenshots, logs, and local databases as local-only.
 - Prefer research-only runs for first tests.
 - If LinkedIn login is missing, do not present that as a failure. It is a normal setup step.
@@ -64,4 +66,10 @@ If session check fails:
 
 ```bash
 npm run bootstrap-session -- --driver=playwright --wait-minutes=10
+```
+
+For enterprise accounts with unclear company scope, use the read-only resolver before retrying research:
+
+```bash
+npm run resolve-enterprise-entities -- --account-name="Account Name"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ npm run sdr-research -- \
   --live-save
 ```
 
+The app handles the safer list path automatically. With `--live-save`, it uses the guarded browser UI to save leads and, when available, uses read-only Sales Navigator browser data before and after the save to skip people already in the list and verify the final membership. Do not ask the SDR whether to "use the API"; just explain simply: "I will check the list before and after saving so we know the right people are really there." If that read-only check fails, the tool falls back to UI verification and reports follow-up instead of pretending the list is complete.
+
 While it runs, tell the SDR what's happening in plain language:
 
 - "Searching for contacts at [Account]..."
@@ -100,6 +102,7 @@ After the list is created, tell the SDR:
 - How many strong contacts were found but not saved automatically, and why
 - Whether any account needs company-scope review
 - That the list is now live in Sales Navigator under the exact name used
+- Whether the final list was verified in Sales Navigator or needs follow-up
 - Which contacts to start with: DevOps, platform, cloud, infrastructure, and engineering leaders first.
 
 Example closing message:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,15 @@ A deterministic, dry-safe ordered plan derived from autoresearch evidence. Valid
 **Company Scope**
 Evidence that a people search is constrained to the intended account/company. If Company Scope is missing or ambiguous, browser-backed people search must fail closed rather than search broadly.
 
+**Enterprise Entity Resolver**
+The read-only workflow that inspects related Sales Navigator company pages for large accounts, ranks IT/digital entities first, keeps the parent/main company in scope, and excludes unrelated homonyms. It may produce learned suggestions, but it does not mutate Sales Navigator or automatically promote config.
+
+**API Read Prefetch**
+An opt-in read-only path that uses the logged-in browser session to fetch Sales Navigator company/lead evidence faster than UI sweeps. API Read Prefetch can accelerate research and improve company identity evidence, but it is not permission for Live Mutation.
+
+**API List Readback**
+The read-only list verification path that reads Sales Navigator list membership by stable lead identity before and after Live-save. API List Readback may skip already-present leads and verify final membership; it must not create lists, add leads, remove leads, connect, or message.
+
 **Company Resolution Blocker**
 A state where an account/company target cannot be safely resolved or scoped. Live-save candidates from blocked accounts are not eligible until the blocker is cleared or explicitly reviewed.
 
@@ -110,6 +119,8 @@ A task that requires human-in-the-loop judgment, live external access, design ap
 ## Relationships
 
 - An **Operator** approves any **Live Mutation**.
+- **API Read Prefetch** and **API List Readback** are read-only helpers; they never grant **Live Mutation** permission.
+- The **Enterprise Entity Resolver** strengthens **Company Scope** for large related company sets before **Account Research** or **Live-save** eligibility.
 - **Autoresearch** produces **Runtime Artifacts**, a **Research Loop Plan**, evaluation metrics, and an **Execution Gate**.
 - A **Gate Report** and **Supervisor Runbook** render the **Execution Gate** without executing live actions.
 - A **Safe-to-save Candidate** requires valid **Lead Identity**, verified **Company Scope**, no blocking **Manual Review**, and acceptable duplicate/already-saved state.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ npm run sdr-research -- \
 
 This command never sends connection invitations. It reports what it found, what it saved, what it skipped, and what needs review.
 
+When live-save is used, the tool now checks the target Sales Navigator list before and after saving with a read-only browser API path when available. In plain terms: it first skips people who are already in the list, saves only missing approved leads through the browser UI, then verifies the final list membership by stable Sales Navigator IDs. If the read-only API is not available, the tool falls back to the older UI snapshot check.
+
 ## Environment Setup
 
 Create a local `.env` from `.env.example` only if you need Salesforce, BigQuery, or other live integrations:
@@ -173,6 +175,8 @@ npm run account-coverage -- \
 ```
 
 The API prefetch only reads data from the logged-in browser. Real list saves still require `--live-save`.
+
+For list creation and list updates, API usage is read-only by default. The app may use it to find the list, read existing members, skip duplicates, and verify the final result, but the actual lead save still happens through the guarded browser UI. Use `--skip-api-list-readback` only when debugging the fallback path.
 
 ### Enterprise Entity Resolver
 

--- a/docs/fast-list-import.md
+++ b/docs/fast-list-import.md
@@ -89,13 +89,32 @@ npm run fast-list-import -- \
 
 If the list already exists, `--allow-list-create` is harmless. If it does not exist, it allows the first save to create it.
 
+## API-Assisted Verification
+
+Live-save still uses the guarded browser UI to add people to a Sales Navigator list. The read-only Sales Navigator browser API is used as a safety and speed layer around that UI action when available:
+
+1. Before saving, the tool reads the target list and skips leads that are already there.
+2. The browser UI saves only the approved missing leads.
+3. After saving, the tool reads the list again and verifies the intended Sales Navigator IDs are present.
+
+The report uses simple counts:
+
+- `Already in list`: approved leads that did not need another UI save.
+- `Added now`: approved leads the browser UI attempted to add.
+- `Verified in Sales Nav`: leads confirmed in the final list readback.
+- `Needs follow-up`: clicked or planned leads that could not be verified.
+
+This API path is read-only. It does not create lists, add leads, remove leads, or send connects by API. Use `--skip-api-list-readback` only when you need to debug the older UI snapshot fallback.
+
 ## Why This Is Faster
 
 The old flow often required manual one-off resolution and ad-hoc retries. The fast flow centralizes that into a reusable import manifest:
 
 - cached Sales Navigator URLs avoid repeated lookup,
+- read-only list readback skips leads that are already saved,
 - one browser session handles the batch,
 - transient render failures retry automatically,
+- final list membership is verified by stable Sales Navigator IDs when available,
 - unresolved leads are reported instead of silently skipped.
 
 ## Current Learning
@@ -124,4 +143,5 @@ Next hardening targets:
 - No live save without `--live-save`.
 - No list creation unless the driver is allowed to create the list.
 - No live connect, ever.
+- No API-based list mutation in the default flow; API readback is verification only.
 - Public LinkedIn `/in/` URLs are not saved directly; the lead must resolve to a Sales Navigator `/sales/lead/` URL first.

--- a/docs/first-run-onboarding.md
+++ b/docs/first-run-onboarding.md
@@ -51,3 +51,21 @@ These actions should never happen as part of a first-run setup or unattended boo
 In SDR-facing language, say:
 
 > I can research accounts safely. Saving leads or sending connection requests is a separate action and I will ask before doing it.
+
+## What The Agent Should Use Automatically
+
+For normal SDR list work, use:
+
+```bash
+npm run sdr-research -- --accounts="Account A, Account B, Account C"
+```
+
+If the SDR asks for a real Sales Navigator list, add `--live-save`. The tool will still stay supervised: it uses the browser UI for the actual save and uses read-only list checks when available to skip duplicates and verify the final list.
+
+For large enterprise accounts or unclear company names, use:
+
+```bash
+npm run resolve-enterprise-entities -- --account-name="Account Name"
+```
+
+Explain this as: "I am checking which related Sales Navigator company pages belong to the account, starting with IT and digital entities, then the parent company."

--- a/docs/operator-quickstart.md
+++ b/docs/operator-quickstart.md
@@ -30,6 +30,14 @@ For normal SDR work, use this:
 npm run sdr-research -- --accounts="Thales Group, Skello, Oodrive"
 ```
 
+For large or messy enterprise accounts, add the faster read-only lookup:
+
+```bash
+npm run sdr-research -- --accounts="Thales Group, Skello, Oodrive" --api-read-prefetch
+```
+
+This lets the tool read company and lead IDs from the logged-in browser before running slower UI sweeps. If a company has several related pages, the tool should search IT/digital entities first, then the parent company, and stop only for truly unrelated same-name companies.
+
 To also create/update a Sales Navigator list:
 
 ```bash
@@ -40,6 +48,8 @@ npm run sdr-research -- \
 ```
 
 This command does not send connection requests.
+
+When `--live-save` is used, the tool checks the Sales Navigator list before saving, skips people already in the list, saves only missing approved leads through the browser UI, and then checks the list again. The final answer should say whether the list was verified in Sales Navigator or whether follow-up is needed.
 
 ## 4. Advanced Single-Account Research
 
@@ -74,6 +84,14 @@ The report should answer:
 - What should the SDR do next?
 
 If the report says `manual_review`, `needs_company_resolution`, `environment_blocked`, or `email_required`, stop and review instead of forcing the action.
+
+If the report says `needs_company_scope_review`, run:
+
+```bash
+npm run resolve-enterprise-entities -- --account-name="Account Name"
+```
+
+Use the result to confirm the related IT, digital, parent, regional, or brand entities before retrying the account.
 
 ## 6. Live Actions
 

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -7,6 +7,8 @@ The first release is a supervised SDR assistant, not a fully automatic LinkedIn 
 - Build lists first.
 - Background research should not change Sales Navigator.
 - Real list saves must be explicitly requested.
+- Read-only Sales Navigator browser API data may be used to speed up research, resolve company IDs, and verify list membership.
+- API-based list creation, lead adding, lead removal, connection requests, or messaging are not part of the default release path.
 - Connection requests must be explicitly supervised.
 - Background connection requests stay off unless separately approved.
 
@@ -27,6 +29,12 @@ Every connection request attempt should end in one clear state:
 ## Account Scope
 
 The tool should use the right LinkedIn company page. If it is unsure, it should stop for review instead of researching the wrong company.
+
+For enterprise accounts, the tool should treat the account as a related company set. It should search IT, digital, systems, technology, platform, cloud, data, or engineering entities first, then the parent or main company. Parent/main entities remain in scope for buyers and observability owners. Only unrelated same-name companies should be excluded.
+
+## List Verification
+
+Live-save success means the intended leads were verified in the Sales Navigator list, not merely that a browser click happened. When available, read-only API list readback should verify stable Sales Navigator identities before and after saving. If verification fails, the run should finish with follow-up instead of reporting a clean completed state.
 
 ## Runner States
 


### PR DESCRIPTION
## Summary
- documents that live-save now uses read-only Sales Navigator list readback for preflight and final verification when available
- clarifies Enterprise Entity Resolver defaults across README, CLAUDE, AGENTS, quickstart, release contract, and shared context
- keeps API mutation out of the default path and points agents to the standard SDR flow

## Tests
- npm test
- npm run test:release-readiness
- git diff --check