### PR TITLE
Fix list duplication bug + EMEA multilang coverage

### DIFF
--- a/config/account-aliases/default.json
+++ b/config/account-aliases/default.json
@@ -1,6 +1,33 @@
 {
   "version": "1.0.0",
   "accounts": {
+    "grafana-labs": {
+      "accountSearchAliases": [
+        "Grafana Labs",
+        "Grafana"
+      ],
+      "companyFilterAliases": [
+        "Grafana Labs"
+      ],
+      "companyIds": ["11062162"],
+      "linkedinCompanyUrls": [
+        "https://www.linkedin.com/company/grafana"
+      ],
+      "resolutionStatus": "resolved_exact",
+      "resolutionNotes": "Internal network expansion target. Single canonical entity. NextLink Labs (id 5251900) is a homonym in Pittsburgh - explicitly excluded."
+    },
+    "agirc-arrco": {
+      "accountSearchAliases": [
+        "Agirc Arrco",
+        "Agirc-Arrco"
+      ],
+      "companyFilterAliases": [
+        "Agirc-Arrco"
+      ],
+      "companyIds": [
+        "998749"
+      ]
+    },
     "example-lists-first": {
       "accountSearchAliases": [
         "Example Lists First Account",
@@ -46,10 +73,14 @@
           "linkedinName": "Example Industry Association",
           "targetType": "brand",
           "territoryFit": "likely",
-          "evidence": ["alias"]
+          "evidence": [
+            "alias"
+          ]
         }
       ],
-      "territoryCountries": ["Germany"],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_exact",
       "resolutionNotes": "EXORG is commonly used in calling lists, while Sales Navigator usually needs the full organization name."
     },
@@ -73,12 +104,21 @@
           "linkedinCompanyUrl": "https://www.linkedin.com/company/example-media-germany",
           "targetType": "brand",
           "territoryFit": "likely",
-          "evidence": ["alias", "linkedin_url"]
+          "evidence": [
+            "alias",
+            "linkedin_url"
+          ]
         }
       ],
-      "domains": ["example-media.test"],
-      "parentAliases": ["Example Media Group"],
-      "territoryCountries": ["Germany"],
+      "domains": [
+        "example-media.test"
+      ],
+      "parentAliases": [
+        "Example Media Group"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_exact",
       "resolutionNotes": "LinkedIn public company page resolves the Salesforce-style account name to Example Media Germany."
     },
@@ -105,13 +145,25 @@
           "linkedinCompanyUrl": "https://www.linkedin.com/company/example-logistics",
           "targetType": "parent",
           "territoryFit": "likely",
-          "evidence": ["alias", "linkedin_url"]
+          "evidence": [
+            "alias",
+            "linkedin_url"
+          ]
         }
       ],
-      "domains": ["example-logistics.test"],
-      "parentAliases": ["Example Logistics Group"],
-      "subsidiaryAliases": ["Example Logistics Switzerland", "Example Logistics Switzerland"],
-      "territoryCountries": ["Switzerland"],
+      "domains": [
+        "example-logistics.test"
+      ],
+      "parentAliases": [
+        "Example Logistics Group"
+      ],
+      "subsidiaryAliases": [
+        "Example Logistics Switzerland",
+        "Example Logistics Switzerland"
+      ],
+      "territoryCountries": [
+        "Switzerland"
+      ],
       "resolutionStatus": "resolved_exact",
       "resolutionNotes": "LinkedIn public company page resolves the Swiss territory name to the global Example Logistics company page."
     },
@@ -131,18 +183,30 @@
           "linkedinName": "Example Broadcaster",
           "targetType": "parent",
           "territoryFit": "unclear",
-          "evidence": ["alias", "parent_subsidiary"]
+          "evidence": [
+            "alias",
+            "parent_subsidiary"
+          ]
         },
         {
           "linkedinName": "Example Broadcast Studio",
           "targetType": "subsidiary",
           "territoryFit": "unclear",
-          "evidence": ["alias"]
+          "evidence": [
+            "alias"
+          ]
         }
       ],
-      "parentAliases": ["Example Broadcaster"],
-      "subsidiaryAliases": ["Example Broadcast Studio", "Example Broadcast News"],
-      "territoryCountries": ["Germany"],
+      "parentAliases": [
+        "Example Broadcaster"
+      ],
+      "subsidiaryAliases": [
+        "Example Broadcast Studio",
+        "Example Broadcast News"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "needs_manual_company_review",
       "resolutionNotes": "Timed-out reference account; keep parent/broadcast aliases available for supervised retry instead of treating the timeout as zero-lead evidence."
     },
@@ -165,11 +229,18 @@
           "linkedinCompanyUrl": "https://www.linkedin.com/company/example-mobility",
           "targetType": "parent",
           "territoryFit": "exact",
-          "evidence": ["alias", "post_run_manual_validation"]
+          "evidence": [
+            "alias",
+            "post_run_manual_validation"
+          ]
         }
       ],
-      "domains": ["example-mobility.test"],
-      "territoryCountries": ["Germany"],
+      "domains": [
+        "example-mobility.test"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_exact",
       "resolutionNotes": "Post-run validation showed Sales Navigator partial matches can select Example Mobility France SARL; use the German Example Mobility entity for territory research."
     },
@@ -192,141 +263,274 @@
           "linkedinCompanyUrl": "https://www.linkedin.com/company/example-mobility",
           "targetType": "parent",
           "territoryFit": "exact",
-          "evidence": ["alias", "post_run_manual_validation"]
+          "evidence": [
+            "alias",
+            "post_run_manual_validation"
+          ]
         }
       ],
-      "domains": ["example-mobility.test"],
-      "territoryCountries": ["Germany"],
+      "domains": [
+        "example-mobility.test"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_exact",
       "resolutionNotes": "Avoid homonym matches such as unrelated broadband companies; route Example Mobility SE research to the Example Mobility LinkedIn company target."
     },
     "edeka": {
-      "accountSearchAliases": ["EDEKA", "EDEKA DIGITAL", "Edeka Digital", "Lunar"],
-      "companyFilterAliases": ["EDEKA", "EDEKA DIGITAL", "Edeka Digital", "EDEKA DIGITAL GmbH", "Lunar GmbH"],
+      "accountSearchAliases": [
+        "EDEKA",
+        "EDEKA DIGITAL",
+        "Edeka Digital",
+        "Lunar"
+      ],
+      "companyFilterAliases": [
+        "EDEKA",
+        "EDEKA DIGITAL",
+        "Edeka Digital",
+        "EDEKA DIGITAL GmbH",
+        "Lunar GmbH"
+      ],
       "targets": [
         {
           "linkedinName": "EDEKA",
           "targetType": "parent",
           "territoryFit": "likely",
-          "evidence": ["curated_parent"]
+          "evidence": [
+            "curated_parent"
+          ]
         },
         {
           "linkedinName": "EDEKA DIGITAL GmbH",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         },
         {
           "linkedinName": "Lunar GmbH",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         }
       ],
-      "subsidiaryAliases": ["EDEKA DIGITAL", "Edeka Digital", "EDEKA DIGITAL GmbH", "Lunar GmbH"],
-      "territoryCountries": ["Germany"],
+      "subsidiaryAliases": [
+        "EDEKA DIGITAL",
+        "Edeka Digital",
+        "EDEKA DIGITAL GmbH",
+        "Lunar GmbH"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_multi_target",
       "resolutionNotes": "Parent retail brand likely has separate IT entities; sweep parent plus curated IT subsidiaries, never unrelated companies."
     },
     "otto": {
-      "accountSearchAliases": ["Otto Group", "Otto GmbH & Co. KGaA", "About You", "Bonprix"],
-      "companyFilterAliases": ["Otto Group", "Otto GmbH & Co. KGaA", "About You", "Bonprix"],
+      "accountSearchAliases": [
+        "Otto Group",
+        "Otto GmbH & Co. KGaA",
+        "About You",
+        "Bonprix"
+      ],
+      "companyFilterAliases": [
+        "Otto Group",
+        "Otto GmbH & Co. KGaA",
+        "About You",
+        "Bonprix"
+      ],
       "targets": [
         {
           "linkedinName": "Otto Group",
           "targetType": "parent",
           "territoryFit": "likely",
-          "evidence": ["curated_parent"]
+          "evidence": [
+            "curated_parent"
+          ]
         },
         {
           "linkedinName": "About You",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         },
         {
           "linkedinName": "Bonprix",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         }
       ],
-      "subsidiaryAliases": ["About You", "Bonprix"],
-      "territoryCountries": ["Germany"],
+      "subsidiaryAliases": [
+        "About You",
+        "Bonprix"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_multi_target",
       "resolutionNotes": "Holding research should include known technology-heavy subsidiaries."
     },
     "schwarz": {
-      "accountSearchAliases": ["Schwarz Group", "Schwarz IT", "Lidl", "Kaufland"],
-      "companyFilterAliases": ["Schwarz Group", "Schwarz IT", "Lidl", "Kaufland"],
+      "accountSearchAliases": [
+        "Schwarz Group",
+        "Schwarz IT",
+        "Lidl",
+        "Kaufland"
+      ],
+      "companyFilterAliases": [
+        "Schwarz Group",
+        "Schwarz IT",
+        "Lidl",
+        "Kaufland"
+      ],
       "targets": [
         {
           "linkedinName": "Schwarz Group",
           "targetType": "parent",
           "territoryFit": "likely",
-          "evidence": ["curated_parent"]
+          "evidence": [
+            "curated_parent"
+          ]
         },
         {
           "linkedinName": "Schwarz IT",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         }
       ],
-      "subsidiaryAliases": ["Schwarz IT", "Lidl", "Kaufland"],
-      "territoryCountries": ["Germany"],
+      "subsidiaryAliases": [
+        "Schwarz IT",
+        "Lidl",
+        "Kaufland"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_multi_target",
       "resolutionNotes": "Retail parent often has a carved-out IT organization."
     },
     "rewe": {
-      "accountSearchAliases": ["REWE Group", "REWE digital", "REWE Systems"],
-      "companyFilterAliases": ["REWE Group", "REWE digital", "REWE Systems"],
+      "accountSearchAliases": [
+        "REWE Group",
+        "REWE digital",
+        "REWE Systems"
+      ],
+      "companyFilterAliases": [
+        "REWE Group",
+        "REWE digital",
+        "REWE Systems"
+      ],
       "targets": [
         {
           "linkedinName": "REWE Group",
           "targetType": "parent",
           "territoryFit": "likely",
-          "evidence": ["curated_parent"]
+          "evidence": [
+            "curated_parent"
+          ]
         },
         {
           "linkedinName": "REWE digital",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         },
         {
           "linkedinName": "REWE Systems",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         }
       ],
-      "subsidiaryAliases": ["REWE digital", "REWE Systems"],
-      "territoryCountries": ["Germany"],
+      "subsidiaryAliases": [
+        "REWE digital",
+        "REWE Systems"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_multi_target",
       "resolutionNotes": "Parent plus known IT entities should be reviewed together."
     },
     "bertelsmann": {
-      "accountSearchAliases": ["Bertelsmann", "Arvato Systems"],
-      "companyFilterAliases": ["Bertelsmann", "Arvato Systems"],
+      "accountSearchAliases": [
+        "Bertelsmann",
+        "Arvato Systems"
+      ],
+      "companyFilterAliases": [
+        "Bertelsmann",
+        "Arvato Systems"
+      ],
       "targets": [
         {
           "linkedinName": "Bertelsmann",
           "targetType": "parent",
           "territoryFit": "likely",
-          "evidence": ["curated_parent"]
+          "evidence": [
+            "curated_parent"
+          ]
         },
         {
           "linkedinName": "Arvato Systems",
           "targetType": "subsidiary",
           "territoryFit": "likely",
-          "evidence": ["curated_it_subsidiary"]
+          "evidence": [
+            "curated_it_subsidiary"
+          ]
         }
       ],
-      "subsidiaryAliases": ["Arvato Systems"],
-      "territoryCountries": ["Germany"],
+      "subsidiaryAliases": [
+        "Arvato Systems"
+      ],
+      "territoryCountries": [
+        "Germany"
+      ],
       "resolutionStatus": "resolved_multi_target",
       "resolutionNotes": "Bertelsmann technology research should include Arvato Systems as a likely IT subsidiary."
+    },
+    "agirc arrco": {
+      "accountSearchAliases": [
+        "Agirc-Arrco",
+        "Agirc-Arrco Insurance PARIS Follow L’Agirc-Arrco est le régime de retraite complémentaire obligatoire des salariés du secteur privé. Porteur d’une mission d’intérêt général, il repose sur les... 37K followers Enrico follows this page"
+      ],
+      "companyFilterAliases": [
+        "Agirc-Arrco Insurance PARIS Follow L’Agirc-Arrco est le régime de retraite complémentaire obligatoire des salariés du secteur privé. Porteur d’une mission d’intérêt général, il repose sur les... 37K followers Enrico follows this page",
+        "Agirc-Arrco"
+      ],
+      "linkedinCompanyUrls": [
+        "https://www.linkedin.com/company/agirc-arrco"
+      ],
+      "targets": [
+        {
+          "linkedinName": "Agirc-Arrco Insurance PARIS Follow L’Agirc-Arrco est le régime de retraite complémentaire obligatoire des salariés du secteur privé. Porteur d’une mission d’intérêt général, il repose sur les... 37K followers Enrico follows this page",
+          "linkedinCompanyUrl": "https://www.linkedin.com/company/agirc-arrco",
+          "targetType": "unknown",
+          "territoryFit": "likely",
+          "confidence": 0.82,
+          "evidence": [
+            "linkedin_company_search"
+          ]
+        }
+      ],
+      "resolutionStatus": "resolved_exact",
+      "resolutionNotes": "Resolved automatically from LinkedIn company search for \"Agirc-Arrco\".",
+      "lastVerifiedAt": "2026-05-07T11:33:37.901Z"
     }
   }
 }

--- a/config/account-coverage/default.json
+++ b/config/account-coverage/default.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0",
-  "name": "full_account_coverage_v1",
+  "version": "2.0.0-emea-multilang",
+  "name": "full_account_coverage_v2_emea",
   "titleExcludes": [
     "Architecture & Construction",
     "Architecture and Construction",
@@ -15,107 +15,681 @@
     "Client Marketing Platform",
     "Global Travel Retail",
     "Workforce Management",
-    "Client Relations"
+    "Client Relations",
+    "Retired",
+    "Retraité",
+    "Retraitée",
+    "En Retraite",
+    "Pensionné",
+    "Pensionnée",
+    "Rentner",
+    "Rentnerin",
+    "Im Ruhestand",
+    "Pensionär",
+    "Pensioniert",
+    "Pensionato",
+    "Pensionata",
+    "In Pensione",
+    "Jubilado",
+    "Jubilada",
+    "Retirado",
+    "Retirada",
+    "Reformado",
+    "Reformada",
+    "Aposentado",
+    "Aposentada",
+    "Gepensioneerd",
+    "Met Pensioen",
+    "Stagiaire",
+    "Praktikant",
+    "Praktikantin",
+    "Tirocinante",
+    "Becario",
+    "Becaria",
+    "Estagiário",
+    "Estagiária",
+    "Stagiair",
+    "Apprenti",
+    "Apprentie",
+    "Auszubildender",
+    "Auszubildende",
+    "Apprendista",
+    "Aprendiz",
+    "Recruiter",
+    "Talent Acquisition",
+    "Sourcer",
+    "Sourcing Specialist"
   ],
   "broadCrawl": {
-    "enabled": true
+    "enabled": true,
+    "maxCandidates": 200,
+    "maxScrollSteps": 30
   },
   "sweeps": [
     {
       "id": "architecture",
-      "keywords": [
-        "architecture"
-      ]
+      "keywords": ["architecture", "architect"],
+      "maxCandidates": 50
     },
     {
       "id": "security",
-      "keywords": [
-        "security"
-      ]
+      "keywords": ["security"],
+      "maxCandidates": 50
     },
     {
       "id": "cloud",
-      "keywords": [
-        "cloud"
-      ]
+      "keywords": ["cloud"],
+      "maxCandidates": 50
     },
     {
       "id": "data",
-      "keywords": [
-        "data"
-      ]
+      "keywords": ["data"],
+      "maxCandidates": 50
     },
     {
       "id": "infrastructure",
-      "keywords": [
-        "infrastructure"
-      ]
+      "keywords": ["infrastructure"],
+      "maxCandidates": 50
     },
     {
       "id": "platform",
-      "keywords": [
-        "platform"
-      ]
+      "keywords": ["platform"],
+      "maxCandidates": 50
     },
     {
       "id": "engineering",
-      "keywords": [
-        "engineering"
-      ]
+      "keywords": ["engineering"],
+      "maxCandidates": 50
     },
     {
       "id": "software",
-      "keywords": [
-        "software"
-      ]
+      "keywords": ["software"],
+      "maxCandidates": 50
     },
     {
       "id": "devops",
-      "keywords": [
-        "devops"
-      ]
+      "keywords": ["devops"],
+      "maxCandidates": 50
     },
     {
       "id": "technology",
-      "keywords": [
-        "technology"
-      ]
-    },
-    {
-      "id": "it",
-      "keywords": [
-        "it"
-      ]
+      "keywords": ["technology"],
+      "maxCandidates": 50
     },
     {
       "id": "system",
-      "keywords": [
-        "system"
-      ]
+      "keywords": ["system"],
+      "maxCandidates": 50
     },
     {
       "id": "integration",
-      "keywords": [
-        "integration"
-      ]
+      "keywords": ["integration"],
+      "maxCandidates": 50
     },
     {
       "id": "operations",
-      "keywords": [
-        "operations"
-      ]
+      "keywords": ["operations"],
+      "maxCandidates": 50
     },
     {
       "id": "reliability",
-      "keywords": [
-        "reliability"
-      ]
+      "keywords": ["reliability"],
+      "maxCandidates": 50
     },
     {
       "id": "monitoring",
+      "keywords": ["monitoring"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "kubernetes-container-experts",
       "keywords": [
-        "monitoring"
-      ]
+        "Kubernetes",
+        "K8s",
+        "Docker",
+        "Container",
+        "OpenShift",
+        "Helm",
+        "Rancher",
+        "EKS",
+        "AKS",
+        "GKE",
+        "Service Mesh",
+        "Istio"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "incident-itil-itsm",
+      "keywords": [
+        "Incident Manager",
+        "Problem Manager",
+        "Change Manager",
+        "ITIL",
+        "ITSM",
+        "Gestionnaire des Problèmes",
+        "Gestionnaire des Incidents",
+        "Problem Management",
+        "Incident Management",
+        "Resolution Manager",
+        "Resolution Engineer",
+        "Major Incident",
+        "Vorfallsmanager",
+        "Problemmanager",
+        "Änderungsmanager",
+        "Gestione Incidenti",
+        "Gestione Problemi",
+        "Gestor de Incidentes",
+        "Gestor de Problemas",
+        "Service Desk Manager",
+        "Operations Manager",
+        "Production Support",
+        "Application Support",
+        "Support N3"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "network-telecom-multilang",
+      "keywords": [
+        "Network Engineer",
+        "Network Architect",
+        "Network Operations",
+        "NetOps",
+        "Réseau",
+        "Réseaux",
+        "Télécoms",
+        "Sécurité Réseau",
+        "Ingénieur Réseau",
+        "Responsable Réseau",
+        "Netzwerk",
+        "Netzwerktechnik",
+        "Telekommunikation",
+        "Netzwerkarchitekt",
+        "Rete",
+        "Reti",
+        "Telecomunicazioni",
+        "Ingegnere Rete",
+        "Redes",
+        "Telecomunicaciones",
+        "Ingeniero de Redes",
+        "Engenheiro de Redes",
+        "Netwerk",
+        "Telecommunicatie"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "bi-data-platform",
+      "keywords": [
+        "Power BI",
+        "Hadoop",
+        "Big Data",
+        "Datastage",
+        "Spark",
+        "Cloudera",
+        "Iceberg",
+        "Snowflake",
+        "Databricks",
+        "BI Engineer",
+        "Data Platform",
+        "Data Lake",
+        "Data Warehouse",
+        "ETL",
+        "Data Pipeline",
+        "Tableau",
+        "Looker",
+        "Qlik",
+        "Décisionnel",
+        "Datawarehouse",
+        "BI Architect",
+        "Lakehouse"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "data-engineer-multilang",
+      "keywords": [
+        "Data Engineer",
+        "Senior Data Engineer",
+        "Lead Data Engineer",
+        "Ingénieur Data",
+        "Ingénieur Données",
+        "Datentechniker",
+        "Dateningenieur",
+        "Ingegnere Dati",
+        "Ingeniero de Datos",
+        "Engenheiro de Dados",
+        "Data Architect",
+        "Architecte Data",
+        "Architecte Données",
+        "Datenarchitekt",
+        "Architetto Dati",
+        "Arquitecto de Datos",
+        "Arquiteto de Dados"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "production-operations-multilang",
+      "keywords": [
+        "Production Informatique",
+        "Exploitation",
+        "Exploitation informatique",
+        "Fabrication",
+        "Mise en Production",
+        "IT-Betrieb",
+        "Betrieb",
+        "Produktion",
+        "Systembetrieb",
+        "Produzione",
+        "Produzione IT",
+        "Esercizio IT",
+        "Producción",
+        "Producción TI",
+        "Produção",
+        "Produção TI",
+        "Productie",
+        "IT-Productie",
+        "Operations Engineer",
+        "Operations Lead"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "architect-multilang-extended",
+      "keywords": [
+        "Solution Architect",
+        "Enterprise Architect",
+        "System Architect",
+        "Technical Architect",
+        "Cloud Architect",
+        "Data Architect",
+        "Security Architect",
+        "Application Architect",
+        "Architecte Technique",
+        "Architecte Solution",
+        "Architecte Système",
+        "Architecte d'Entreprise",
+        "Architecte Cloud",
+        "Architecte Sécurité",
+        "Architecte Applicatif",
+        "Lösungsarchitekt",
+        "Systemarchitekt",
+        "Technischer Architekt",
+        "Cloud Architekt",
+        "Sicherheitsarchitekt",
+        "Architetto Soluzioni",
+        "Architetto Sistemi",
+        "Architetto Cloud",
+        "Arquitecto Soluciones",
+        "Arquitecto de Sistemas",
+        "Arquitecto Cloud",
+        "Arquiteto de Soluções",
+        "Arquiteto de Sistemas",
+        "Oplossingsarchitect",
+        "Systeemarchitect"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "senior-tech-leadership",
+      "keywords": [
+        "CTO",
+        "CIO",
+        "CDO",
+        "CISO",
+        "DSI",
+        "RSSI",
+        "VP Engineering",
+        "VP Technology",
+        "VP Platform",
+        "VP Infrastructure",
+        "Head of IT",
+        "Head of Engineering",
+        "Head of Platform",
+        "Head of Infrastructure",
+        "Head of Cloud",
+        "Head of Data",
+        "Head of Observability",
+        "IT-Leiter",
+        "IT-Direktor",
+        "IT-Geschäftsführer",
+        "Bereichsleiter IT",
+        "Direttore Sistemi Informativi",
+        "Direttore IT",
+        "Director TI",
+        "Director de TI",
+        "Diretor TI",
+        "Diretor de TI",
+        "Hoofd IT",
+        "Directeur IT",
+        "Directeur Informatique",
+        "Director of Engineering",
+        "Director of Technology",
+        "Director of Platform",
+        "Director of Infrastructure"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "observability-multilang",
+      "keywords": [
+        "Observability",
+        "Observabilité",
+        "Observabilität",
+        "Beobachtbarkeit",
+        "Osservabilità",
+        "Observabilidad",
+        "Observabilidade",
+        "Monitoring",
+        "Surveillance IT",
+        "Surveillance Informatique",
+        "Überwachung",
+        "IT-Überwachung",
+        "Monitoraggio",
+        "Monitoraggio IT",
+        "Monitoreo",
+        "Monitoreo TI",
+        "Monitorização",
+        "APM",
+        "Application Performance",
+        "Telemetry",
+        "Télémétrie",
+        "Telemetria",
+        "Telemetría"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "devops-sre-platform-multilang",
+      "keywords": [
+        "DevOps",
+        "DevSecOps",
+        "SRE",
+        "Site Reliability",
+        "Site Reliability Engineer",
+        "Platform Engineer",
+        "Platform Engineering",
+        "Plateforme",
+        "Ingénieur Plateforme",
+        "Plattform-Engineering",
+        "Plattform Ingenieur",
+        "Plattformingenieur",
+        "Piattaforma",
+        "Ingegnere Piattaforma",
+        "Plataforma",
+        "Ingeniero de Plataforma",
+        "Engenheiro de Plataforma",
+        "Platform Engineer",
+        "Cloud Engineer",
+        "Ingénieur Cloud",
+        "Wolken-Ingenieur",
+        "Ingeniero Cloud",
+        "Engenheiro Cloud",
+        "GitOps",
+        "Internal Developer Platform",
+        "IDP"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "security-cybersecurity-multilang",
+      "keywords": [
+        "Cybersecurity",
+        "Cyber Security",
+        "Cybersécurité",
+        "Cyber-Sécurité",
+        "IT-Sicherheit",
+        "Cybersicherheit",
+        "Informationssicherheit",
+        "Sicurezza Informatica",
+        "Cybersicurezza",
+        "Ciberseguridad",
+        "Seguridad Informática",
+        "Cibersegurança",
+        "Segurança Informática",
+        "Cyberbeveiliging",
+        "Informatiebeveiliging",
+        "Security Operations",
+        "SOC",
+        "SIEM",
+        "Security Engineer",
+        "Security Analyst",
+        "Ingénieur Sécurité",
+        "Sicherheitsingenieur",
+        "Ingegnere Sicurezza",
+        "Ingeniero de Seguridad",
+        "Engenheiro de Segurança"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "java-tech-lead-fullstack",
+      "keywords": [
+        "Tech Lead",
+        "Lead Tech",
+        "Lead Developer",
+        "Lead Engineer",
+        "Développeur Senior",
+        "Senior Developer",
+        "Java",
+        "JEE",
+        "J2EE",
+        "Spring",
+        "Fullstack Lead",
+        "Backend Lead",
+        "Frontend Lead",
+        "Engineering Lead",
+        "Technical Lead",
+        "Responsable Technique",
+        "Technischer Leiter",
+        "Capo Tecnico",
+        "Líder Técnico",
+        "Líder Tecnológico"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "integration-middleware-multilang",
+      "keywords": [
+        "Middleware",
+        "Integration Engineer",
+        "Integration Architect",
+        "Integration Lead",
+        "Intégration",
+        "Ingénieur Intégration",
+        "Responsable Intégration",
+        "Integrationsingenieur",
+        "Integrationsarchitekt",
+        "Integrazione",
+        "Ingegnere Integrazione",
+        "Integración",
+        "Ingeniero de Integración",
+        "Integração",
+        "Engenheiro de Integração",
+        "API Manager",
+        "API Lead",
+        "ESB",
+        "MuleSoft",
+        "Boomi",
+        "Apache Camel",
+        "Kafka"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "fr-tech-roles-extended",
+      "keywords": [
+        "Responsable",
+        "Architecte",
+        "Ingénieur",
+        "Chef de Projet",
+        "Directeur Technique",
+        "DSI",
+        "Observabilité",
+        "Exploitation informatique",
+        "Responsable Domaine",
+        "Expert",
+        "Spécialiste",
+        "Pilote",
+        "Gestionnaire",
+        "Coordinateur",
+        "Coordinatrice",
+        "Chef de Service",
+        "Chef d'Équipe",
+        "Consultant Senior",
+        "Consultant Principal",
+        "Architecte Technique",
+        "Architecte Système",
+        "Architecte Solution",
+        "Architecte d'Entreprise",
+        "Architecte Données",
+        "Pôle",
+        "Référent Technique",
+        "Lead Tech"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "de-tech-roles-extended",
+      "keywords": [
+        "Leiter",
+        "Architekt",
+        "Ingenieur",
+        "Plattform",
+        "Betrieb",
+        "Systemadministrator",
+        "Lösungsarchitekt",
+        "IT-Leiter",
+        "Leiter Infrastruktur",
+        "Leiter Plattform",
+        "Leiter Cloud",
+        "Leiter IT-Betrieb",
+        "Verantwortlich",
+        "Verantwortlicher",
+        "Bereichsleiter",
+        "Teamleiter",
+        "Fachexperte",
+        "Spezialist",
+        "Sachbearbeiter IT",
+        "Berater",
+        "Senior Berater",
+        "Lead Engineer",
+        "Cloud Kompetenzzentrum",
+        "Digitale Transformation",
+        "IT-Architekt",
+        "Software-Architekt"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "it-tech-roles",
+      "keywords": [
+        "Responsabile",
+        "Direttore",
+        "Capo",
+        "Capo Progetto",
+        "Coordinatore",
+        "Coordinatrice",
+        "Gestore",
+        "Esperto",
+        "Specialista",
+        "Ingegnere",
+        "Consulente Senior",
+        "Architetto",
+        "Architetto Sistemi",
+        "Architetto Soluzioni",
+        "Architetto Cloud",
+        "Direttore Tecnico",
+        "Direttore Sistemi Informativi",
+        "Responsabile Piattaforma",
+        "Responsabile Infrastruttura",
+        "Responsabile Sicurezza",
+        "Lead Tecnico",
+        "Capo Tecnico"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "es-tech-roles",
+      "keywords": [
+        "Responsable",
+        "Director",
+        "Directora",
+        "Jefe",
+        "Jefa",
+        "Coordinador",
+        "Coordinadora",
+        "Gestor",
+        "Gestora",
+        "Experto",
+        "Especialista",
+        "Ingeniero",
+        "Ingeniera",
+        "Consultor Senior",
+        "Arquitecto",
+        "Arquitecta",
+        "Director Técnico",
+        "Director TI",
+        "Director de Sistemas",
+        "Jefe de Plataforma",
+        "Jefe de Infraestructura",
+        "Jefe de Sistemas",
+        "Líder Técnico"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "pt-tech-roles",
+      "keywords": [
+        "Responsável",
+        "Diretor",
+        "Diretora",
+        "Chefe",
+        "Coordenador",
+        "Coordenadora",
+        "Gestor",
+        "Gestora",
+        "Especialista",
+        "Engenheiro",
+        "Engenheira",
+        "Consultor Sénior",
+        "Arquiteto",
+        "Arquiteta",
+        "Diretor Técnico",
+        "Diretor TI",
+        "Diretor de Sistemas",
+        "Líder Técnico",
+        "Responsável de Plataforma",
+        "Responsável de Infraestrutura",
+        "Responsável de Sistemas"
+      ],
+      "maxCandidates": 50
+    },
+    {
+      "id": "nl-tech-roles",
+      "keywords": [
+        "Verantwoordelijke",
+        "Directeur",
+        "Hoofd",
+        "Hoofd IT",
+        "Coördinator",
+        "Beheerder",
+        "Specialist",
+        "Ingenieur",
+        "Senior Adviseur",
+        "Adviseur",
+        "Architect",
+        "Oplossingsarchitect",
+        "Systeemarchitect",
+        "Hoofd Platform",
+        "Hoofd Infrastructuur",
+        "Hoofd Cloud",
+        "Technisch Leider",
+        "Lead Engineer"
+      ],
+      "maxCandidates": 50
     },
     {
       "id": "emea-hidden-platform",
@@ -134,33 +708,24 @@
         "Dynatrace",
         "Prometheus",
         "Grafana",
-        "Technical Lead",
-        "Responsable Technique",
-        "Leiter Cloud",
-        "Direttore Tecnico",
-        "Jefe de Plataforma"
-      ]
-    },
-    {
-      "id": "emea-language-localized-titles",
-      "keywords": [
-        "Responsable Plateforme",
-        "Directeur Technique",
-        "Ing\u00e9nieur Cloud",
-        "Leiter Plattform",
-        "Cloud Kompetenzzentrum",
-        "Responsabile Piattaforma",
-        "Direttore Tecnico",
-        "Jefe de Plataforma",
-        "Director T\u00e9cnico",
-        "Ingeniero Cloud"
-      ]
+        "Splunk",
+        "New Relic",
+        "Elastic",
+        "OpenTelemetry",
+        "Pulumi",
+        "Ansible",
+        "Argo CD",
+        "GitOps",
+        "Backstage"
+      ],
+      "maxCandidates": 50
     },
     {
       "id": "emea-data-ai-buyers",
       "keywords": [
         "CDO",
         "Chief Data Officer",
+        "Chief AI Officer",
         "Data & AI",
         "Director Data",
         "Directeur Data",
@@ -171,8 +736,16 @@
         "Direttrice Dati",
         "Daten & KI",
         "Datos e IA",
-        "Dati e AI"
-      ]
+        "Dati e AI",
+        "Dados e IA",
+        "Head of Data",
+        "Head of AI",
+        "Director of Data",
+        "Director of AI",
+        "Diretor de Dados",
+        "Hoofd Data"
+      ],
+      "maxCandidates": 50
     },
     {
       "id": "emea-it-governance-operators",
@@ -180,7 +753,7 @@
         "Gouvernance SI",
         "Direction Informatique",
         "Responsable Domaine",
-        "Responsable Int\u00e9gration Cloud",
+        "Responsable Intégration Cloud",
         "IT-Governance",
         "Leiter Digitale Transformation",
         "Bereichsleiter IT",
@@ -190,55 +763,15 @@
         "Governo IT",
         "Trasformazione Digitale",
         "Transformation Digitale",
-        "Transformaci\u00f3n Digital",
+        "Transformación Digital",
+        "Transformação Digital",
+        "Digital Transformation",
         "Head of Tech",
-        "Architecture des Environnements"
-      ]
-    },
-    {
-      "id": "emea-localized-observability",
-      "keywords": [
-        "Observabilit\u00e9",
-        "Observabilit\u00e4t",
-        "Observabilidad",
-        "Osservabilit\u00e0",
-        "Chef de Projet Senior Cloud",
-        "Cloud & Observabilit\u00e9",
-        "Observability & Performance",
-        "Consultant Observability",
-        "Production Informatique",
-        "Produktion IT",
-        "Producci\u00f3n TI",
-        "Produzione IT"
-      ]
-    },
-    {
-      "id": "fr-titles",
-      "keywords": [
-        "Responsable",
-        "Architecte",
-        "Ing\u00e9nieur",
-        "Chef de Projet",
-        "Directeur Technique",
-        "DSI",
-        "Observabilit\u00e9",
-        "Exploitation informatique",
-        "Responsable Domaine"
-      ]
-    },
-    {
-      "id": "de-titles",
-      "keywords": [
-        "Leiter",
-        "Architekt",
-        "Ingenieur",
-        "Plattform",
-        "Betrieb",
-        "Systemadministrator",
-        "L\u00f6sungsarchitekt",
-        "IT-Leiter",
-        "Leiter Infrastruktur"
-      ]
+        "Architecture des Environnements",
+        "Architettura Aziendale",
+        "Arquitectura Empresarial"
+      ],
+      "maxCandidates": 50
     }
   ],
   "bucketRules": {

--- a/config/account-coverage/grafana-internal-gtm.json
+++ b/config/account-coverage/grafana-internal-gtm.json
@@ -1,0 +1,111 @@
+{
+  "version": "1.0.0",
+  "name": "grafana_internal_gtm_v1",
+  "purpose": "Internal network expansion - find Grafana Labs GTM/Sales colleagues for connect requests. NOT for prospecting. titleExcludes only filters retirees and competitors, not buyers.",
+  "titleExcludes": [
+    "Retired", "Retraité", "Retraitée", "En Retraite", "Rentner", "Im Ruhestand",
+    "Pensionato", "Jubilado", "Reformado", "Gepensioneerd",
+    "Stagiaire", "Praktikant", "Tirocinante", "Becario", "Estagiário", "Apprenti"
+  ],
+  "broadCrawl": {
+    "enabled": true,
+    "maxCandidates": 200,
+    "maxScrollSteps": 30
+  },
+  "sweeps": [
+    {
+      "id": "sales-ae-am",
+      "keywords": ["Account Executive", "Account Manager", "Enterprise Account", "Strategic Account", "Sales Director", "Sales Representative"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "sales-sdr-bdr",
+      "keywords": ["SDR", "BDR", "Sales Development", "Business Development Representative", "Outbound", "Pipeline Development"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "sales-engineer-solutions",
+      "keywords": ["Solutions Engineer", "Sales Engineer", "Solutions Architect", "Pre-Sales", "Solutions Consultant", "Technical Account Manager", "TAM"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "customer-success",
+      "keywords": ["Customer Success", "CSM", "Customer Success Manager", "Customer Engineer", "Customer Experience", "Customer Advocacy"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "marketing-demand-gen",
+      "keywords": ["Marketing", "Demand Generation", "Demand Gen", "Field Marketing", "Product Marketing", "ABM", "Account-Based Marketing", "Growth Marketing"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "marketing-content-comms",
+      "keywords": ["Content Marketing", "Communications", "PR", "Public Relations", "Brand", "Editorial", "Social Media", "Developer Relations", "DevRel", "Developer Advocate"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "marketing-events-programs",
+      "keywords": ["Events Marketing", "Event Manager", "Field Events", "Webinar", "Campaign Manager", "Marketing Programs", "Marketing Operations"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "revops-sales-ops",
+      "keywords": ["RevOps", "Revenue Operations", "Sales Operations", "Sales Ops", "GTM Operations", "Marketing Operations", "MarOps", "Deal Desk", "Sales Strategy", "Sales Enablement"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "partnerships-channel",
+      "keywords": ["Partner Manager", "Channel", "Alliances", "Strategic Partnerships", "Partnership Development", "Ecosystem", "Integration Partner"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "gtm-leadership",
+      "keywords": ["CRO", "VP Sales", "VP Marketing", "VP Customer Success", "Head of Sales", "Head of Marketing", "Head of GTM", "Chief Revenue", "Chief Marketing"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "gtm-emea-fr",
+      "keywords": ["Commercial", "Ingénieur Commercial", "Responsable Commercial", "Directeur Commercial", "Avant-Vente", "Chargé de Compte", "Développement Commercial"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "gtm-emea-de",
+      "keywords": ["Vertrieb", "Vertriebsleiter", "Account Manager", "Geschäftsentwicklung", "Vertriebsingenieur", "Kundenberater", "Außendienst"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "gtm-emea-italian-spanish",
+      "keywords": ["Commerciale", "Vendite", "Direttore Commerciale", "Sviluppo Commerciale", "Ventas", "Comercial", "Director Comercial", "Desarrollo de Negocio"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "gtm-regional-emea",
+      "keywords": ["EMEA", "DACH", "Nordics", "Iberia", "Benelux", "Southern Europe", "UK&I", "MEA", "Middle East"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "gtm-regional-amer-apac",
+      "keywords": ["AMER", "NAM", "LATAM", "APAC", "ANZ", "ASEAN", "Japan", "Korea", "India"],
+      "maxCandidates": 50
+    },
+    {
+      "id": "marketing-product",
+      "keywords": ["Product Marketing", "PMM", "Product Marketing Manager", "Competitive Intelligence", "Pricing", "Packaging"],
+      "maxCandidates": 50
+    }
+  ],
+  "bucketRules": {
+    "directObservabilityRoleFamilies": [
+      "site_reliability",
+      "platform_engineering",
+      "devops",
+      "infrastructure"
+    ],
+    "adjacentRoleFamilies": [
+      "software_engineering",
+      "security",
+      "data",
+      "executive_engineering"
+    ]
+  }
+}

--- a/config/search-templates/default.json
+++ b/config/search-templates/default.json
@@ -2,225 +2,169 @@
   {
     "id": "champions-core",
     "name": "Technical Champions Core",
-    "keywords": [
-      "observability",
-      "monitoring",
-      "telemetry",
-      "reliability"
-    ],
+    "keywords": ["observability", "monitoring", "telemetry", "reliability"],
     "titleIncludes": [
-      "SRE",
-      "Platform",
-      "Infrastructure",
-      "DevOps",
-      "Reliability",
-      "Observability"
+      "SRE", "Platform", "Infrastructure", "DevOps", "Reliability", "Observability",
+      "Plateforme", "Plattform", "Piattaforma", "Plataforma",
+      "Infrastruktur", "Infrastruttura", "Infraestructura", "Infraestrutura",
+      "Architecte", "Architekt", "Architetto", "Arquitecto", "Arquiteto", "Architect",
+      "Ingénieur", "Ingenieur", "Ingegnere", "Ingeniero", "Engenheiro",
+      "Responsable", "Leiter", "Responsabile", "Director", "Diretor", "Hoofd",
+      "Expert", "Spécialiste", "Spezialist", "Esperto", "Specialista", "Experto", "Especialista",
+      "Pilote", "Gestionnaire", "Coordinateur", "Coordinador", "Coordenador",
+      "Tech Lead", "Lead Tech", "Technical Lead", "Engineering Lead"
     ],
     "titleExcludes": [
-      "Recruiter",
-      "Sales",
-      "Marketing",
-      "Architecture & Construction",
-      "Real Estate",
-      "Process Engineering",
-      "Brand Platform"
+      "Recruiter", "Sales", "Marketing", "Architecture & Construction", "Real Estate",
+      "Process Engineering", "Brand Platform",
+      "Retired", "Retraité", "Retraitée", "En Retraite", "Rentner", "Im Ruhestand",
+      "Pensionato", "Pensionata", "Jubilado", "Reformado", "Gepensioneerd",
+      "Stagiaire", "Praktikant", "Tirocinante", "Becario", "Estagiário", "Stagiair",
+      "Apprenti", "Auszubildender", "Apprendista", "Aprendiz"
     ],
-    "seniorityTargets": [
-      "manager",
-      "director",
-      "head",
-      "staff",
-      "principal",
-      "vp"
-    ],
-    "maxCandidates": 12,
+    "seniorityTargets": ["manager", "director", "head", "staff", "principal", "vp", "lead", "senior"],
+    "maxCandidates": 30,
     "minimumRelevantHits": 2,
     "listSegment": "champions"
   },
   {
     "id": "decision-makers",
     "name": "Decision Makers",
-    "keywords": [
-      "platform engineering",
-      "infrastructure",
-      "cloud operations"
-    ],
+    "keywords": ["platform engineering", "infrastructure", "cloud operations", "plateforme", "plattform", "piattaforma", "plataforma"],
     "titleIncludes": [
-      "Head of",
-      "Director",
-      "VP",
-      "Vice President",
-      "CTO"
+      "Head of", "Director", "VP", "Vice President", "CTO", "CIO", "CISO", "CDO",
+      "Directeur", "Directrice", "Diretor", "Diretora", "Direttore", "Direttrice",
+      "Leiter", "Leiterin", "Bereichsleiter", "Geschäftsführer",
+      "Responsable", "Responsabile", "Hoofd", "Jefe", "Jefa", "Chefe",
+      "DSI", "RSSI", "IT-Leiter"
     ],
     "titleExcludes": [
-      "Student",
-      "Intern"
+      "Student", "Intern", "Stagiaire", "Praktikant", "Becario", "Estagiário",
+      "Retired", "Retraité", "Rentner", "Pensionato", "Jubilado", "Gepensioneerd"
     ],
-    "seniorityTargets": [
-      "director",
-      "vp",
-      "head"
-    ],
-    "maxCandidates": 8,
+    "seniorityTargets": ["director", "vp", "head", "c-level"],
+    "maxCandidates": 25,
     "minimumRelevantHits": 1,
     "listSegment": "decision-makers"
   },
   {
     "id": "account-platform-sweep",
     "name": "Account Platform Sweep",
-    "keywords": [
-      "platform"
-    ],
+    "keywords": ["platform", "plateforme", "plattform", "piattaforma", "plataforma"],
     "titleIncludes": [
-      "Platform",
-      "Architecture",
-      "Architect",
-      "Enterprise Architecture",
-      "Digital Product"
+      "Platform", "Architecture", "Architect", "Enterprise Architecture", "Digital Product",
+      "Plateforme", "Plattform", "Piattaforma", "Plataforma",
+      "Architecte", "Architekt", "Architetto", "Arquitecto", "Arquiteto",
+      "Ingénieur", "Ingenieur", "Ingegnere", "Ingeniero", "Engenheiro",
+      "Responsable", "Leiter", "Responsabile", "Director", "Hoofd",
+      "Expert", "Spécialiste", "Pilote", "Lead", "Tech Lead"
     ],
     "titleExcludes": [
-      "Recruiter",
-      "Sales",
-      "Marketing",
-      "Architecture & Construction",
-      "Real Estate",
-      "Process Engineering",
-      "Brand Platform"
+      "Recruiter", "Sales", "Marketing", "Architecture & Construction", "Real Estate",
+      "Process Engineering", "Brand Platform",
+      "Retired", "Retraité", "Rentner", "Pensionato", "Jubilado", "Gepensioneerd",
+      "Stagiaire", "Praktikant", "Becario", "Estagiário"
     ],
-    "seniorityTargets": [
-      "manager",
-      "director",
-      "head",
-      "principal",
-      "lead"
-    ],
-    "maxCandidates": 10,
+    "seniorityTargets": ["manager", "director", "head", "principal", "lead", "senior"],
+    "maxCandidates": 40,
     "minimumRelevantHits": 1,
     "listSegment": "account-platform"
   },
   {
     "id": "account-security-sweep",
     "name": "Account Security And Infrastructure Sweep",
-    "keywords": [
-      "security"
-    ],
+    "keywords": ["security", "sécurité", "sicherheit", "sicurezza", "seguridad", "segurança", "beveiliging"],
     "titleIncludes": [
-      "Security",
-      "Infrastructure",
-      "Technology",
-      "Engineer"
+      "Security", "Infrastructure", "Technology", "Engineer",
+      "Sécurité", "Sicherheit", "Sicurezza", "Seguridad", "Segurança", "Beveiliging",
+      "Architecte", "Architekt", "Architetto", "Arquitecto", "Arquiteto",
+      "Ingénieur", "Ingenieur", "Ingegnere", "Ingeniero", "Engenheiro",
+      "Responsable", "Leiter", "Responsabile", "Director", "Hoofd",
+      "Expert", "Spécialiste", "Pilote", "Coordinateur",
+      "RSSI", "CISO", "CSO", "SOC"
     ],
     "titleExcludes": [
-      "Recruiter",
-      "Sales",
-      "Marketing",
-      "Architecture & Construction",
-      "Real Estate",
-      "Process Engineering",
-      "Brand Platform"
+      "Recruiter", "Sales", "Marketing", "Architecture & Construction", "Real Estate",
+      "Process Engineering", "Brand Platform",
+      "Retired", "Retraité", "Rentner", "Pensionato", "Jubilado", "Gepensioneerd",
+      "Stagiaire", "Praktikant", "Becario", "Estagiário"
     ],
-    "seniorityTargets": [
-      "manager",
-      "director",
-      "head",
-      "senior",
-      "lead"
-    ],
-    "maxCandidates": 10,
+    "seniorityTargets": ["manager", "director", "head", "senior", "lead", "principal"],
+    "maxCandidates": 40,
     "minimumRelevantHits": 1,
     "listSegment": "account-security"
   },
   {
     "id": "account-cloud-sweep",
     "name": "Account Cloud And Delivery Sweep",
-    "keywords": [
-      "cloud"
-    ],
+    "keywords": ["cloud", "kubernetes", "container", "openshift"],
     "titleIncludes": [
-      "Cloud",
-      "DevOps",
-      "Software",
-      "Engineering",
-      "Development"
+      "Cloud", "DevOps", "Software", "Engineering", "Development",
+      "Kubernetes", "Container", "OpenShift", "Docker",
+      "Architecte", "Architekt", "Architetto", "Arquitecto", "Arquiteto",
+      "Ingénieur", "Ingenieur", "Ingegnere", "Ingeniero", "Engenheiro",
+      "Responsable", "Leiter", "Responsabile", "Director", "Hoofd",
+      "Expert", "Spécialiste", "Pilote", "Tech Lead", "Lead Tech",
+      "Plateforme", "Plattform", "Piattaforma", "Plataforma"
     ],
     "titleExcludes": [
-      "Recruiter",
-      "Sales",
-      "Marketing",
-      "Architecture & Construction",
-      "Real Estate",
-      "Process Engineering",
-      "Brand Platform"
+      "Recruiter", "Sales", "Marketing", "Architecture & Construction", "Real Estate",
+      "Process Engineering", "Brand Platform",
+      "Retired", "Retraité", "Rentner", "Pensionato", "Jubilado", "Gepensioneerd",
+      "Stagiaire", "Praktikant", "Becario", "Estagiário"
     ],
-    "seniorityTargets": [
-      "manager",
-      "director",
-      "head",
-      "senior",
-      "lead"
-    ],
-    "maxCandidates": 10,
+    "seniorityTargets": ["manager", "director", "head", "senior", "lead", "principal"],
+    "maxCandidates": 40,
     "minimumRelevantHits": 1,
     "listSegment": "account-cloud"
   },
   {
     "id": "account-architecture-sweep",
     "name": "Account Architecture Sweep",
-    "keywords": [
-      "architect"
-    ],
+    "keywords": ["architect", "architecture", "architecte", "architekt", "architetto", "arquitecto", "arquiteto"],
     "titleIncludes": [
-      "Architect",
-      "Architecture",
-      "Enterprise Architecture",
-      "System Engineer"
+      "Architect", "Architecture", "Enterprise Architecture", "System Engineer",
+      "Architecte", "Architekt", "Architetto", "Arquitecto", "Arquiteto",
+      "Solution Architect", "Cloud Architect", "Data Architect", "Security Architect",
+      "Technical Architect", "Application Architect",
+      "Architecte Technique", "Architecte Solution", "Architecte Cloud", "Architecte Données",
+      "Lösungsarchitekt", "Systemarchitekt", "Cloud Architekt",
+      "Architetto Soluzioni", "Architetto Cloud",
+      "Arquitecto Soluciones", "Oplossingsarchitect"
     ],
     "titleExcludes": [
-      "Recruiter",
-      "Sales",
-      "Marketing",
-      "Architecture & Construction",
-      "Real Estate",
-      "Process Engineering",
-      "Brand Platform"
+      "Recruiter", "Sales", "Marketing", "Architecture & Construction", "Real Estate",
+      "Process Engineering", "Brand Platform",
+      "Retired", "Retraité", "Rentner", "Pensionato", "Jubilado", "Gepensioneerd",
+      "Stagiaire", "Praktikant", "Becario", "Estagiário"
     ],
-    "seniorityTargets": [
-      "manager",
-      "director",
-      "head",
-      "principal",
-      "lead"
-    ],
-    "maxCandidates": 10,
+    "seniorityTargets": ["manager", "director", "head", "principal", "lead", "senior"],
+    "maxCandidates": 40,
     "minimumRelevantHits": 1,
     "listSegment": "account-architecture"
   },
   {
     "id": "account-data-sweep",
     "name": "Account Data And Analytics Sweep",
-    "keywords": [
-      "data"
-    ],
+    "keywords": ["data", "données", "daten", "dati", "datos", "dados", "hadoop", "big data", "power bi"],
     "titleIncludes": [
-      "Data",
-      "Analytics",
-      "Information Technology",
-      "Data Science",
-      "Engineer"
+      "Data", "Analytics", "Information Technology", "Data Science", "Engineer",
+      "Hadoop", "Big Data", "Power BI", "BI", "Datastage", "Spark",
+      "Données", "Daten", "Dati", "Datos", "Dados",
+      "Data Engineer", "Data Architect", "BI Engineer", "BI Architect",
+      "Décisionnel", "Datawarehouse", "Data Lake",
+      "Architecte Data", "Architecte Données", "Datenarchitekt",
+      "Architetto Dati", "Arquitecto de Datos", "Arquiteto de Dados",
+      "Ingénieur Data", "Datentechniker", "Ingegnere Dati",
+      "Tech Lead", "Lead Tech", "Lead Data"
     ],
     "titleExcludes": [
-      "Recruiter",
-      "Sales",
-      "Marketing"
+      "Recruiter", "Sales", "Marketing",
+      "Retired", "Retraité", "Rentner", "Pensionato", "Jubilado", "Gepensioneerd",
+      "Stagiaire", "Praktikant", "Becario", "Estagiário"
     ],
-    "seniorityTargets": [
-      "manager",
-      "director",
-      "head",
-      "senior",
-      "lead"
-    ],
-    "maxCandidates": 10,
+    "seniorityTargets": ["manager", "director", "head", "senior", "lead", "principal"],
+    "maxCandidates": 40,
     "minimumRelevantHits": 1,
     "listSegment": "account-data"
   },
@@ -228,53 +172,30 @@
     "id": "emea-hidden-platform-personas",
     "name": "EMEA Hidden Platform Personas",
     "keywords": [
-      "FinOps",
-      "CCOE",
-      "Cloud Governance",
-      "Observability Leader",
-      "Data Platform Lead",
-      "MLOps",
-      "AIOps",
-      "DevSecOps",
-      "Kubernetes",
-      "Terraform",
-      "Datadog",
-      "Dynatrace",
-      "Prometheus",
-      "Grafana"
+      "FinOps", "CCOE", "Cloud Governance", "Observability Leader", "Data Platform Lead",
+      "MLOps", "AIOps", "DevSecOps", "Kubernetes", "Terraform",
+      "Datadog", "Dynatrace", "Prometheus", "Grafana", "Splunk", "New Relic",
+      "Technical Lead", "Tech Lead", "SRE Lead",
+      "Responsable Technique", "Leiter Cloud", "Direttore Tecnico", "Jefe de Plataforma"
     ],
     "titleIncludes": [
-      "Responsable",
-      "Directeur Technique",
-      "Leiter",
-      "Cloud Kompetenzzentrum",
-      "Responsabile",
-      "Direttore Tecnico",
-      "Jefe",
-      "Director T\u00e9cnico",
-      "Technical Lead",
-      "Tech Lead",
-      "SRE Lead"
+      "Responsable", "Directeur Technique", "Leiter", "Cloud Kompetenzzentrum",
+      "Responsabile", "Direttore Tecnico", "Jefe", "Director Técnico",
+      "Diretor", "Hoofd", "Verantwoordelijke",
+      "Technical Lead", "Tech Lead", "SRE Lead", "Platform Lead",
+      "Architecte", "Architekt", "Architetto", "Arquitecto", "Arquiteto",
+      "Ingénieur", "Ingenieur", "Ingegnere", "Ingeniero", "Engenheiro",
+      "Expert", "Spécialiste", "Pilote", "Gestionnaire", "Coordinateur",
+      "Esperto", "Specialista", "Experto", "Especialista"
     ],
     "titleExcludes": [
-      "Facilities",
-      "Fleet",
-      "HSEQ",
-      "Procurement",
-      "Purchasing",
-      "Category Manager",
-      "Sales Director",
-      "Commercial Finance"
+      "Facilities", "Fleet", "HSEQ", "Procurement", "Purchasing", "Category Manager",
+      "Sales Director", "Commercial Finance",
+      "Retired", "Retraité", "Rentner", "Pensionato", "Jubilado", "Gepensioneerd",
+      "Stagiaire", "Praktikant", "Becario", "Estagiário"
     ],
-    "seniorityTargets": [
-      "manager",
-      "director",
-      "head",
-      "lead",
-      "principal",
-      "vp"
-    ],
-    "maxCandidates": 10,
+    "seniorityTargets": ["manager", "director", "head", "lead", "principal", "vp", "senior"],
+    "maxCandidates": 40,
     "minimumRelevantHits": 1,
     "listSegment": "emea-hidden-platform"
   }

--- a/docs/postmortems/2026-05-12-list-duplication.md
+++ b/docs/postmortems/2026-05-12-list-duplication.md
@@ -1,0 +1,178 @@
+# BUG REPORT: Duplicate Empty Lists on Live-Save Workflow
+
+**Date**: 2026-05-12
+**Severity**: P0 — Critical
+**Reporter**: Daniel Datsenko (SDR)
+**Affected Command**: `npm run sdr-research -- --live-save --list-name="..."`
+**Affected Driver**: `playwright`
+**Reproduction Run**: `bgmp4emaz.output` — 5 PL accounts, list `Grafana - Daniel Datsenko - PZU PKO Millennium TVN Polkomtel` (60 chars)
+
+---
+
+## Symptom
+
+Single live-save run with **155 selected leads** across 5 accounts produced **dozens of empty lead lists in Sales Navigator**, all with the same (truncated) name `Grafana - Daniel Datsenko - PZU PKO Millenni...`. Screenshot from user shows ≥11 visible duplicate lists, the count likely scales 1:1 with save attempts (one new list per saved lead).
+
+Expected behavior: **Exactly one** list named `Grafana - Daniel Datsenko - PZU PKO Millennium TVN Polkomtel` containing 155 leads.
+
+---
+
+## Root Cause Analysis
+
+### The chain that breaks
+
+1. **List name exceeds Sales Nav UI display limit**
+   - User-supplied list name: `Grafana - Daniel Datsenko - PZU PKO Millennium TVN Polkomtel` = **60 chars**
+   - Sales Navigator truncates display to ~32–46 chars: `Grafana - Daniel Datsenko - PZU PKO Millenni...`
+   - The DOM-level `innerText` returns the **truncated** string, not the full title
+
+2. **List-row matching uses exact `innerText` comparison**
+
+   File: `src/drivers/playwright-sales-nav.js:3140` — `clickVisibleListRow()`
+   - First selector: `button[aria-label*="${listName}"]` — exact substring match against the full 60-char name
+   - Fallback: `page.getByRole('button', { name: new RegExp(escaped, 'i') })` — regex match against full name
+
+   When Sales Nav renders truncated text in DOM, **neither selector matches**, so `clickVisibleListRow` returns `null`.
+
+3. **`null` triggers a fresh `tryCreateList()` call**
+
+   File: `src/drivers/playwright-sales-nav.js:567`
+   ```js
+   if (rowOutcome?.outcome === 'clicked') { ...existing list... }
+   // ...
+   const created = await this.tryCreateList(listInfo.listName);  // <-- new list every time
+   ```
+   `tryCreateList` happily creates another list with the same name — Sales Navigator allows duplicate list names.
+
+4. **Per-save loop = per-save new list**
+
+   The `saveCandidateToList` runs once per candidate. Step 2 fails on every iteration → step 3 creates a new list on every iteration. **155 leads → up to 155 new lists.**
+
+5. **Post-save list verification also fails** (separate symptom, same root cause)
+
+   File: `src/cli.js:1601, 1679, 1742` — `readLeadListSnapshot()` uses:
+   ```js
+   const match = links.find((link) =>
+     normalize(link.innerText) === target_name
+   )
+   ```
+   Exact `innerText === target_name` cannot match a truncated 46-char display against a 60-char target → throws `Unable to open lead list <name>` → save logged as `save_clicked_unverified` for every lead.
+
+---
+
+## Reproduction
+
+```bash
+npm run sdr-research -- \
+  --accounts="A, B, C, D, E" \
+  --list-name="Grafana - Daniel Datsenko - PZU PKO Millennium TVN Polkomtel" \
+  --live-save
+```
+
+- Any list name >32 chars triggers the bug
+- Any account batch with >1 save reveals the duplication
+
+---
+
+## Impact
+
+- **Sales Nav UI pollution**: dozens of empty lists per run, all with identical truncated display names — hard to distinguish in UI
+- **Lead-list integrity broken**: no single list contains all saved leads; leads are scattered 1-per-list
+- **Connect workflow blocked**: `connect-lead-list` operates on one list at a time — cannot run against 155 fragmented lists
+- **No verifiable save state**: tool reports `save_clicked_unverified` for every lead, operator cannot trust the result
+- **Cleanup is manual and expensive**: SDR must delete each duplicate list individually in Sales Nav UI
+
+---
+
+## Fix Recommendations (ordered by impact / effort)
+
+### Fix 1 — Hard cap on list-name length (lowest effort, blocks the bug)
+Reject or auto-truncate list names >32 chars in `cli.js` before passing to driver.
+```js
+const MAX_LIST_NAME = 32;
+if (listName.length > MAX_LIST_NAME) {
+  throw new Error(`List name too long (${listName.length} chars). Sales Nav UI truncates >${MAX_LIST_NAME} chars and triggers list duplication. Shorten to <=${MAX_LIST_NAME}.`);
+}
+```
+**Pros**: 1-line fix, prevents 100% of cases. **Cons**: doesn't fix underlying matching weakness.
+
+### Fix 2 — Per-run list-handle cache (right architecture)
+Create the list **once** at the start of the save loop, capture its `href` / `entity-urn`, and pass that handle through every subsequent save. Never call `clickVisibleListRow` by name on iteration N>1.
+
+In `account-batch.js` save loop:
+```js
+const listHandle = await driver.ensureList(listName);  // creates if missing, returns ref
+for (const lead of leads) {
+  await driver.saveCandidateToList(lead, listHandle, ctx);  // uses ref, not name
+}
+```
+`ensureList` becomes a real implementation that:
+- Searches for an existing list by name (with both exact + truncated-prefix match)
+- Creates if not found
+- Returns `{ listName, externalRef, listUrl }`
+- Caches the handle for the lifetime of the run
+
+**Pros**: removes name-matching dependency. **Cons**: 30–50 lines, needs browser test.
+
+### Fix 3 — Match on `title` attribute or `aria-label`, with prefix fallback
+Sales Nav typically populates `title="<full name>"` on truncated elements. Update `clickVisibleListRow`:
+```js
+const match = await page.evaluate((target) => {
+  const buttons = [...document.querySelectorAll('button, a')];
+  return buttons.find(el => {
+    const title = el.getAttribute('title') || '';
+    const aria = el.getAttribute('aria-label') || '';
+    const text = el.innerText || '';
+    return title === target || aria.includes(target) ||
+           target.startsWith(text.replace(/…$/, '').trim());  // truncated-prefix match
+  });
+}, listName);
+```
+**Pros**: also fixes verification path. **Cons**: depends on Sales Nav DOM stability.
+
+### Fix 4 — Idempotency sanity check before `tryCreateList`
+Before creating, count existing lists with same name. If ≥1 exists, refuse to create and use the existing one.
+```js
+const existing = await this.findListsByName(listName);
+if (existing.length > 0) {
+  return { status: 'using_existing', listHandle: existing[0] };
+}
+return this.tryCreateList(listName);
+```
+**Pros**: defense in depth. **Cons**: doesn't help with truncation-driven non-detection.
+
+### Fix 5 — `readLeadListSnapshot` should accept truncated match
+File `cli.js:1565+, 1627+` — replace `normalize(text) === target_name` with `target_name.startsWith(normalize(text).replace(/…$/, '').trim())`.
+
+---
+
+## Recommended action plan
+
+1. **Immediate (today)**: Apply Fix 1 (hard-cap) as guard. Ship it.
+2. **This week**: Implement Fix 2 (per-run list handle) — proper architecture.
+3. **Same PR as Fix 2**: Add Fix 3 (title/prefix match) + Fix 5 (verification match) for robustness.
+4. **Test matrix**:
+   - List name 1 char
+   - List name exactly 32 chars
+   - List name 33 chars (boundary)
+   - List name 60+ chars (current failing case)
+   - List name with Unicode (Polish/German umlauts)
+   - List name with emoji
+   - Re-run against same list (idempotency)
+
+---
+
+## User-Facing Cleanup Required
+
+The 5 PL accounts produced an unknown number of duplicate empty lists. Recommended cleanup:
+1. In Sales Nav, sort lead lists by date, filter to `2026-05-12`
+2. Delete all duplicates of `Grafana - Daniel Datsenko - PZU PKO Millenni...`
+3. Re-run the save with a **shortened list name** (e.g. `Grafana DDS PL Wave 1 2026-05-12` = 31 chars) — under the hard cap
+4. Apply Fix 1 to `src/cli.js` before next run
+
+---
+
+## Related observations
+
+- The `Grafana Internal Network - GTM Wave 1` list (38 chars) likely has the **same problem at smaller scale** — please check that list for duplicates as well.
+- The `Agirc-Arrco` list runs from earlier this session used shorter names (`SDR Research - Daniel Datsenko - Agirc Arrco 2026-05-07` = 54 chars) — these may also have triggered the bug. Worth verifying.

--- a/src/cli.js
+++ b/src/cli.js
@@ -1613,7 +1613,15 @@ list_target = js(${JSON.stringify(`
 (() => {
   const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
   const links = [...document.querySelectorAll('a[href]')];
-  const match = links.find((link) => normalize(link.innerText || link.textContent || '') === ${JSON.stringify(normalizedListName)});
+  const target = ${JSON.stringify(normalizedListName)};
+  const match = links.find((link) => {
+    const text = normalize(link.innerText || link.textContent || '').replace(/…|\\.{3}$/u, '').trim();
+    const title = (link.getAttribute('title') || '').trim();
+    if (text === target || title === target) return true;
+    if (title && (title === target || title.includes(target))) return true;
+    if (text && text.length >= 8 && target.startsWith(text)) return true;
+    return false;
+  });
   if (!match || typeof match.getBoundingClientRect !== 'function') {
     return null;
   }
@@ -1732,7 +1740,14 @@ async function readLeadListSnapshotViaPlaywright(driver, listName) {
   const listLink = await driver.page.evaluateHandle((targetName) => {
     const normalize = (value) => (value || '').replace(/\s+/g, ' ').trim();
     const links = [...document.querySelectorAll('a[href]')];
-    const match = links.find((link) => normalize(link.innerText || link.textContent || '') === targetName);
+    const match = links.find((link) => {
+      const text = normalize(link.innerText || link.textContent || '').replace(/…|\.{3}$/u, '').trim();
+      const title = (link.getAttribute('title') || '').trim();
+      if (text === targetName || title === targetName) return true;
+      if (title && title.includes(targetName)) return true;
+      if (text && text.length >= 8 && targetName.startsWith(text)) return true;
+      return false;
+    });
     return match || null;
   }, normalizedListName);
 
@@ -1802,7 +1817,15 @@ list_target = js(${JSON.stringify(`
 (() => {
   const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim();
   const links = [...document.querySelectorAll('a[href]')];
-  const match = links.find((link) => normalize(link.innerText || link.textContent || '') === ${JSON.stringify(String(listName || '').trim())});
+  const target = ${JSON.stringify(String(listName || '').trim())};
+  const match = links.find((link) => {
+    const text = normalize(link.innerText || link.textContent || '').replace(/…|\\.{3}$/u, '').trim();
+    const title = (link.getAttribute('title') || '').trim();
+    if (text === target || title === target) return true;
+    if (title && title.includes(target)) return true;
+    if (text && text.length >= 8 && target.startsWith(text)) return true;
+    return false;
+  });
   return match ? { href: match.href } : null;
 })()
 `)})
@@ -3639,6 +3662,13 @@ async function handleRunAccountBatch(repository, values, logger) {
           dryRun: false,
         });
 
+        // Circuit breaker: if `created_list` fires consecutively, the list-match
+        // logic is failing on every save and we are spawning duplicate lists.
+        // See runtime/BUG-REPORT-list-duplication-2026-05-12.md. Abort early.
+        const DUPLICATE_LIST_CIRCUIT_TRIP = 3;
+        let consecutiveCreatedList = 0;
+        let circuitTripped = false;
+
         for (let saveIndex = 0; saveIndex < selectedForListSave.length; saveIndex += 1) {
           const candidate = selectedForListSave[saveIndex];
           const saveRow = await saveBatchCandidateWithRetry({
@@ -3650,6 +3680,38 @@ async function handleRunAccountBatch(repository, values, logger) {
           });
           saveResults.push(saveRow);
           logger.info(`${accountName} | save ${saveIndex + 1}/${selectedForListSave.length}: ${candidate.fullName} -> ${saveRow.status}`);
+
+          const mode = String(saveRow.selectionMode || '');
+          if (mode === 'created_list' || mode === 'results_row_created_list') {
+            consecutiveCreatedList += 1;
+          } else {
+            consecutiveCreatedList = 0;
+          }
+          if (consecutiveCreatedList >= DUPLICATE_LIST_CIRCUIT_TRIP) {
+            circuitTripped = true;
+            const remaining = selectedForListSave.length - (saveIndex + 1);
+            logger.warn(
+              `${accountName} | CIRCUIT BREAKER tripped: ${DUPLICATE_LIST_CIRCUIT_TRIP} consecutive 'created_list' outcomes. `
+              + `Save loop aborted to prevent duplicate-list spam. ${remaining} leads not attempted. `
+              + `Likely cause: list "${listName}" cannot be matched in Sales Nav UI (truncation, special chars, or stale DOM). `
+              + `Manual cleanup may be needed in Sales Nav.`,
+            );
+            break;
+          }
+        }
+        if (circuitTripped) {
+          for (let pendingIndex = saveResults.length; pendingIndex < selectedForListSave.length; pendingIndex += 1) {
+            const pending = selectedForListSave[pendingIndex];
+            saveResults.push({
+              fullName: pending.fullName,
+              title: pending.title || null,
+              status: 'aborted_duplicate_list_circuit',
+              note: 'skipped to prevent duplicate-list creation; investigate list-name match',
+              salesNavigatorUrl: pending.salesNavigatorUrl || pending.profileUrl || null,
+              score: pending.score ?? null,
+              coverageBucket: pending.coverageBucket || null,
+            });
+          }
         }
         if (!skipSaveVerification) {
           logger.info(`${accountName} | list verification started`);

--- a/src/core/sdr-workflow.js
+++ b/src/core/sdr-workflow.js
@@ -1,19 +1,50 @@
 const { parseAccountNames, renderAccountBatchListNameTemplate } = require('./account-batch');
 
+// Sales Navigator UI truncates list names beyond ~32 chars in the save-to-list
+// dropdown. When the DOM `innerText` returns the truncated string, exact-match
+// list-row detection in playwright-sales-nav.js fails, which causes
+// `tryCreateList` to be called for every single save -> one new duplicate list
+// per saved lead. See runtime/BUG-REPORT-list-duplication-2026-05-12.md.
+const SALES_NAV_LIST_NAME_MAX = 32;
+
+function validateSalesNavListName(listName) {
+  const trimmed = String(listName || '').trim();
+  if (trimmed.length > SALES_NAV_LIST_NAME_MAX) {
+    throw new Error(
+      `List name is ${trimmed.length} chars but Sales Navigator UI truncates beyond ${SALES_NAV_LIST_NAME_MAX} chars, `
+      + `which triggers a list-duplication bug (one new list per saved lead). `
+      + `Shorten "--list-name" to <=${SALES_NAV_LIST_NAME_MAX} chars. Suggestion: "${trimmed.slice(0, SALES_NAV_LIST_NAME_MAX).trim()}"`
+    );
+  }
+  return trimmed;
+}
+
 function buildSdrResearchListName(accountNames = [], {
   listName = null,
   startedAt = new Date().toISOString(),
 } = {}) {
   const explicit = String(listName || '').trim();
   if (explicit) {
-    return explicit;
+    return validateSalesNavListName(explicit);
   }
 
-  return renderAccountBatchListNameTemplate('SDR Research {date} {start_time} ({accounts})', {
+  const auto = renderAccountBatchListNameTemplate('SDR {date} ({accounts})', {
     accountNames,
     startedAt,
     endedAt: startedAt,
   });
+  if (auto.length <= SALES_NAV_LIST_NAME_MAX) {
+    return auto;
+  }
+  // Fall back: shrink to fit, keep date prefix
+  const datePrefix = renderAccountBatchListNameTemplate('SDR {date}', {
+    accountNames,
+    startedAt,
+    endedAt: startedAt,
+  });
+  const room = SALES_NAV_LIST_NAME_MAX - datePrefix.length - 3; // " (...)"
+  const truncatedAccounts = accountNames.join(', ').slice(0, Math.max(0, room - 3));
+  return `${datePrefix} (${truncatedAccounts}...)`.slice(0, SALES_NAV_LIST_NAME_MAX);
 }
 
 function buildSdrResearchBatchValues(values = {}, {
@@ -78,4 +109,6 @@ module.exports = {
   buildSdrResearchBatchValues,
   buildSdrResearchListName,
   renderSdrResearchIntro,
+  validateSalesNavListName,
+  SALES_NAV_LIST_NAME_MAX,
 };

--- a/src/drivers/playwright-sales-nav.js
+++ b/src/drivers/playwright-sales-nav.js
@@ -6,6 +6,11 @@ const { classifyConnectMenuActionLabel } = require('../core/connect-menu');
 const { limitCandidatesByTemplate, normalizeCandidateLimit } = require('../core/candidate-limits');
 const { isSalesNavigatorLeadUrl } = require('../lib/live-readiness');
 const {
+  matchesSalesNavLabel,
+  matchesSalesNavLabelAcrossAttributes,
+  browserSideMatcherSource,
+} = require('../lib/sales-nav-label-match');
+const {
   buildCompanySearchPath,
   buildLeadListReadbackPath,
   buildLeadSearchPath,
@@ -212,7 +217,7 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
       headless: false,
       slowMo: 0,
       settleMs: 350,
-      maxScrollSteps: 10,
+      maxScrollSteps: 30,
       humanize: true,
       userDataDir: null,
       storageState: null,
@@ -407,7 +412,10 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
       return;
     }
 
-    const keywords = (template.keywords || []).join(' ');
+    const keywordList = (template.keywords || []).filter(Boolean);
+    const keywords = keywordList.length > 1
+      ? keywordList.map((kw) => /\s/.test(kw) ? `"${kw}"` : kw).join(' OR ')
+      : (keywordList[0] || '');
     await waitForAnySelector(this.page, DEFAULT_SELECTORS.keywordInputs, 12000).catch(() => {});
     const keywordInput = await findFirstVisible(this.page, DEFAULT_SELECTORS.keywordInputs);
     if (keywordInput && keywords) {
@@ -483,7 +491,7 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
         stagnantScrolls = 0;
       }
 
-      if (stagnantScrolls >= 2) {
+      if (stagnantScrolls >= 5) {
         break;
       }
 
@@ -984,10 +992,20 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
     }
 
     await this.navigateIfNeeded('https://www.linkedin.com/sales/lists/people');
-    const match = await this.page.evaluate((targetName) => {
+    const matcherSrc = browserSideMatcherSource();
+    const match = await this.page.evaluate(({ targetName, matcherFnSrc }) => {
       const normalize = (value) => (value || '').replace(/\s+/g, ' ').trim();
+      // eslint-disable-next-line no-new-func
+      const matchesSalesNavLabel = new Function(`${matcherFnSrc}; return matchesSalesNavLabel;`)();
       const links = [...document.querySelectorAll('a[href*="/sales/lists/people/"]')];
-      const link = links.find((item) => normalize(item.innerText || item.textContent || '') === targetName);
+      const link = links.find((item) => {
+        const text = item.innerText || item.textContent || '';
+        const title = item.getAttribute('title') || '';
+        const aria = item.getAttribute('aria-label') || '';
+        return matchesSalesNavLabel(targetName, text)
+          || matchesSalesNavLabel(targetName, title)
+          || matchesSalesNavLabel(targetName, aria);
+      });
       if (!link) return null;
       const idMatch = String(link.href || '').match(/\/sales\/lists\/people\/(\d+)/i);
       return {
@@ -995,7 +1013,7 @@ class PlaywrightSalesNavigatorDriver extends DriverAdapter {
         listUrl: link.href || '',
         listName: normalize(link.innerText || link.textContent || ''),
       };
-    }, normalized).catch(() => null);
+    }, { targetName: normalized, matcherFnSrc: matcherSrc }).catch(() => null);
 
     if (!match?.listId) {
       const error = new Error(`sales_nav_api: unable to resolve lead list ${normalized}`);
@@ -3136,6 +3154,8 @@ async function evaluateSalesNavListRowSelected(locator) {
 
 async function clickVisibleListRow(page, listName) {
   const escaped = escapeRegex(listName);
+
+  // Pass 1: exact aria-label substring
   const exactAria = page.locator(`button[aria-label*="${listName}"]`);
   const count = await exactAria.count().catch(() => 0);
   for (let index = 0; index < count; index += 1) {
@@ -3157,6 +3177,29 @@ async function clickVisibleListRow(page, listName) {
     return { outcome: 'clicked', listName, selectionMode: 'existing_list' };
   }
 
+  // Pass 2: all buttons - check title attribute + innerText with truncated-prefix match
+  const allButtons = page.locator('button[aria-label], button[title], button');
+  const allCount = await allButtons.count().catch(() => 0);
+  for (let index = 0; index < Math.min(allCount, 200); index += 1) {
+    const locator = allButtons.nth(index);
+    const visible = await locator.isVisible().catch(() => false);
+    if (!visible) continue;
+    const title = await locator.getAttribute('title').catch(() => '') || '';
+    const aria = await locator.getAttribute('aria-label').catch(() => '') || '';
+    const text = await locator.innerText().catch(() => '') || '';
+    const combined = `${text} ${aria} ${title}`.toLowerCase();
+    if (combined.includes('create new list') || combined.includes('saved searches')) continue;
+    if (!matchesSalesNavLabelAcrossAttributes(listName, { text, title, aria })) {
+      continue;
+    }
+    if (await evaluateSalesNavListRowSelected(locator)) {
+      return { outcome: 'already_saved', listName, selectionMode: 'existing_list' };
+    }
+    await locator.click().catch(() => {});
+    return { outcome: 'clicked', listName, selectionMode: 'existing_list' };
+  }
+
+  // Pass 3: regex-by-name (kept for backward compat, may be needed for non-button roles)
   const buttonByText = page.getByRole('button', {
     name: new RegExp(escaped, 'i'),
   });

--- a/src/lib/sales-nav-label-match.js
+++ b/src/lib/sales-nav-label-match.js
@@ -1,0 +1,71 @@
+// Robust list-label matching for Sales Navigator UI.
+//
+// Why this exists: Sales Nav truncates list names in DOM `innerText` once they
+// exceed ~32 chars, but keeps the full string in `title` and `aria-label`.
+// Naive `innerText === target` comparisons fail on truncated text and trigger
+// the list-duplication bug documented in
+// runtime/BUG-REPORT-list-duplication-2026-05-12.md.
+//
+// Match strategy, ordered:
+//   1. exact match against full text / title / aria
+//   2. target contains text (truncated visible is a prefix of full target)
+//   3. text contains target (full target embedded in a longer label)
+//
+// Anti-false-positive guards:
+//   - empty strings never match
+//   - text shorter than MIN_PREFIX_LEN is rejected for prefix-match
+//   - "create new list" / "saved searches" labels are explicitly excluded by callers
+
+const MIN_PREFIX_LEN = 8;
+const TRUNCATION_MARKERS = /…|\.{3}$/u;
+
+function normalizeLabelText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function stripTruncationMarker(value) {
+  return normalizeLabelText(value).replace(TRUNCATION_MARKERS, '').trim();
+}
+
+function matchesSalesNavLabel(fullName, candidateText) {
+  const target = normalizeLabelText(fullName);
+  const candidate = stripTruncationMarker(candidateText);
+  if (!target || !candidate) return false;
+  if (target === candidate) return true;
+  if (candidate.length >= MIN_PREFIX_LEN && target.startsWith(candidate)) return true;
+  if (candidate.toLowerCase().includes(target.toLowerCase())) return true;
+  return false;
+}
+
+function matchesSalesNavLabelAcrossAttributes(fullName, { text, title, aria } = {}) {
+  return (
+    matchesSalesNavLabel(fullName, text)
+    || matchesSalesNavLabel(fullName, title)
+    || matchesSalesNavLabel(fullName, aria)
+  );
+}
+
+// Browser-side equivalent for use inside page.evaluate / harness JS payloads.
+// Returns a serializable function source string so callers can inject it.
+function browserSideMatcherSource() {
+  return `function matchesSalesNavLabel(fullName, candidateText) {
+  var normalize = function (value) { return String(value || '').replace(/\\s+/g, ' ').trim(); };
+  var stripTrunc = function (value) { return normalize(value).replace(/…|\\.{3}$/u, '').trim(); };
+  var target = normalize(fullName);
+  var candidate = stripTrunc(candidateText);
+  if (!target || !candidate) return false;
+  if (target === candidate) return true;
+  if (candidate.length >= 8 && target.startsWith(candidate)) return true;
+  if (candidate.toLowerCase().indexOf(target.toLowerCase()) >= 0) return true;
+  return false;
+}`;
+}
+
+module.exports = {
+  MIN_PREFIX_LEN,
+  matchesSalesNavLabel,
+  matchesSalesNavLabelAcrossAttributes,
+  browserSideMatcherSource,
+  normalizeLabelText,
+  stripTruncationMarker,
+};

--- a/tests/account-coverage.test.js
+++ b/tests/account-coverage.test.js
@@ -33,7 +33,9 @@ test('buildSweepTemplates includes broad crawl and configured sweeps', () => {
   const templates = buildSweepTemplates(config);
 
   assert.equal(templates[0].id, 'broad-crawl');
-  assert.equal(templates[0].maxCandidates, undefined);
+  // v2 config opts into explicit maxCandidates on broadCrawl (200) to bound
+  // the multilingual EMEA sweep expansion. Older v1 config left this undefined.
+  assert.ok(templates[0].maxCandidates === undefined || templates[0].maxCandidates >= 100);
   assert.ok(templates.some((template) => template.id === 'sweep-architecture'));
 });
 
@@ -192,7 +194,8 @@ test('default account coverage config includes multilingual EMEA buyer and opera
 
   assert.ok(templateIds.includes('sweep-emea-data-ai-buyers'));
   assert.ok(templateIds.includes('sweep-emea-it-governance-operators'));
-  assert.ok(templateIds.includes('sweep-emea-localized-observability'));
+  // v2: emea-localized-observability was unified into observability-multilang
+  assert.ok(templateIds.includes('sweep-observability-multilang'));
   assert.ok(keywords.includes('CDO'));
   assert.ok(keywords.includes('Gouvernance SI'));
   assert.ok(keywords.includes('Observabilité'));
@@ -226,11 +229,21 @@ test('buildSweepCacheKey is stable for account targets and template keywords', (
   assert.equal(first, second);
 });
 
-test('default account coverage config has no maxCandidates ceiling', () => {
+test('default account coverage config sets a generous broadCrawl ceiling, not a stingy one', () => {
+  // v2: explicit maxCandidates are intentional. broadCrawl 200, per-sweep 50.
+  // The old "no ceiling" promise was misleading - in practice the driver
+  // capped pages anyway. We now make the cap explicit so it's tunable.
   const config = readJson(resolveProjectPath('config', 'account-coverage', 'default.json'));
 
-  assert.equal(config.broadCrawl.maxCandidates, undefined);
-  assert.equal(config.sweeps.some((sweep) => Object.hasOwn(sweep, 'maxCandidates')), false);
+  assert.ok(
+    config.broadCrawl.maxCandidates === undefined || config.broadCrawl.maxCandidates >= 100,
+    `broadCrawl.maxCandidates should be undefined or >= 100, got ${config.broadCrawl.maxCandidates}`,
+  );
+  for (const sweep of config.sweeps) {
+    if (Object.hasOwn(sweep, 'maxCandidates')) {
+      assert.ok(sweep.maxCandidates >= 25, `sweep ${sweep.id} maxCandidates ${sweep.maxCandidates} too restrictive`);
+    }
+  }
 });
 
 test('consolidateCoverageCandidates dedupes candidates and tracks sweep sources', () => {

--- a/tests/sales-nav-label-match.test.js
+++ b/tests/sales-nav-label-match.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  matchesSalesNavLabel,
+  matchesSalesNavLabelAcrossAttributes,
+  normalizeLabelText,
+  stripTruncationMarker,
+} = require('../src/lib/sales-nav-label-match');
+
+test('matchesSalesNavLabel: exact match', () => {
+  assert.equal(matchesSalesNavLabel('My List', 'My List'), true);
+});
+
+test('matchesSalesNavLabel: truncated visible text (ellipsis) is a prefix of full name', () => {
+  // The Sales Nav UI truncated bug repro: full name vs visible "Foo…"
+  assert.equal(matchesSalesNavLabel('Grafana - Daniel Datsenko - PZU PKO', 'Grafana - Daniel Datsenko - …'), true);
+});
+
+test('matchesSalesNavLabel: truncated visible with three dots is a prefix', () => {
+  assert.equal(matchesSalesNavLabel('Grafana - Daniel Datsenko - PZU PKO', 'Grafana - Daniel Datsenko - ...'), true);
+});
+
+test('matchesSalesNavLabel: full text in title attribute matches even when visible is short', () => {
+  // Caller will pass title attribute separately - matchesSalesNavLabel should treat it as a label
+  assert.equal(matchesSalesNavLabel('My very long list name here', 'My very long list name here'), true);
+});
+
+test('matchesSalesNavLabel: empty inputs never match', () => {
+  assert.equal(matchesSalesNavLabel('', 'My List'), false);
+  assert.equal(matchesSalesNavLabel('My List', ''), false);
+  assert.equal(matchesSalesNavLabel(null, null), false);
+  assert.equal(matchesSalesNavLabel(undefined, 'My List'), false);
+});
+
+test('matchesSalesNavLabel: very short candidate is rejected for prefix-match (anti-false-positive)', () => {
+  // "G..." should NOT match "Grafana - GTM Wave 1" because it's too short to be a meaningful prefix
+  assert.equal(matchesSalesNavLabel('Grafana - GTM Wave 1', 'G…'), false);
+  assert.equal(matchesSalesNavLabel('Grafana - GTM Wave 1', 'Graf'), false);
+});
+
+test('matchesSalesNavLabel: 8-char prefix is the minimum (boundary case)', () => {
+  // After trim+normalize the candidate must be >= 8 chars to count as a prefix match
+  assert.equal(matchesSalesNavLabel('Grafana - GTM Wave', 'Grafana '), false);  // trims to 7 chars
+  assert.equal(matchesSalesNavLabel('Grafana - GTM Wave', 'Grafana -'), true);   // 9 chars, above MIN
+  assert.equal(matchesSalesNavLabel('Grafana - GTM Wave', 'Grafana'), false);   // 7 chars, below MIN_PREFIX_LEN
+});
+
+test('matchesSalesNavLabel: case-insensitive substring match', () => {
+  assert.equal(matchesSalesNavLabel('grafana', 'My Lists: Grafana, Foo'), true);
+});
+
+test('matchesSalesNavLabel: trims whitespace from both sides', () => {
+  assert.equal(matchesSalesNavLabel('  My List  ', 'My List'), true);
+  assert.equal(matchesSalesNavLabel('My List', '  My List  '), true);
+  assert.equal(matchesSalesNavLabel('My  List  Name', 'My List Name'), true);  // collapsed whitespace
+});
+
+test('matchesSalesNavLabelAcrossAttributes: prefers title over truncated text', () => {
+  // The classic bug scenario: visible text truncated, but title has full name
+  const fullName = 'Grafana - Daniel Datsenko - PZU PKO Millennium TVN Polkomtel';
+  const ok = matchesSalesNavLabelAcrossAttributes(fullName, {
+    text: 'Grafana - Daniel Datsenko - PZU PKO Millenni...',
+    title: fullName,
+    aria: '',
+  });
+  assert.equal(ok, true);
+});
+
+test('matchesSalesNavLabelAcrossAttributes: works even when only aria-label has full name', () => {
+  const fullName = 'Some long list name that gets truncated in UI';
+  const ok = matchesSalesNavLabelAcrossAttributes(fullName, {
+    text: 'Some long list...',
+    title: '',
+    aria: fullName,
+  });
+  assert.equal(ok, true);
+});
+
+test('matchesSalesNavLabelAcrossAttributes: no false positive when none of the attributes match', () => {
+  const ok = matchesSalesNavLabelAcrossAttributes('Target List', {
+    text: 'Different List',
+    title: 'Another Thing',
+    aria: 'Saved Searches',
+  });
+  assert.equal(ok, false);
+});
+
+test('normalizeLabelText collapses whitespace and trims', () => {
+  assert.equal(normalizeLabelText('  hello\n  world  '), 'hello world');
+  assert.equal(normalizeLabelText(null), '');
+  assert.equal(normalizeLabelText(undefined), '');
+});
+
+test('stripTruncationMarker removes ellipsis and three-dot patterns', () => {
+  assert.equal(stripTruncationMarker('Hello…'), 'Hello');
+  assert.equal(stripTruncationMarker('Hello...'), 'Hello');
+  assert.equal(stripTruncationMarker('Hello'), 'Hello');
+  // Three dots in middle should NOT be stripped (only trailing)
+  assert.equal(stripTruncationMarker('A...B'), 'A...B');
+});

--- a/tests/sdr-workflow.test.js
+++ b/tests/sdr-workflow.test.js
@@ -5,27 +5,42 @@ const {
   buildSdrResearchBatchValues,
   buildSdrResearchListName,
   renderSdrResearchIntro,
+  validateSalesNavListName,
+  SALES_NAV_LIST_NAME_MAX,
 } = require('../src/core/sdr-workflow');
 
-test('buildSdrResearchListName creates a simple deterministic SDR list name', () => {
+test('buildSdrResearchListName produces a list name within the Sales Nav UI cap', () => {
   const name = buildSdrResearchListName(['Thales Group', 'Skello', 'Oodrive'], {
     startedAt: '2026-05-05T09:15:00.000Z',
   });
 
-  assert.equal(name, 'SDR Research 2026-05-05 0915 (Thales Group, Skello +1)');
+  assert.ok(name.length <= SALES_NAV_LIST_NAME_MAX, `list name "${name}" exceeds ${SALES_NAV_LIST_NAME_MAX} chars`);
+  assert.match(name, /2026-05-05/);
+});
+
+test('validateSalesNavListName throws on names that would be truncated by Sales Nav UI', () => {
+  assert.throws(
+    () => validateSalesNavListName('Grafana - Daniel Datsenko - PZU PKO Millennium TVN Polkomtel'),
+    /truncates beyond 32 chars/,
+  );
+});
+
+test('validateSalesNavListName accepts a 32-char list name', () => {
+  const okName = 'a'.repeat(32);
+  assert.equal(validateSalesNavListName(okName), okName);
 });
 
 test('buildSdrResearchBatchValues maps simple SDR input onto the guarded account batch flow', () => {
   const values = buildSdrResearchBatchValues({
     accounts: 'Thales Group, Skello, Oodrive',
-    'list-name': 'Polly Score Accounts - Guillaume Nolot',
+    'list-name': 'Polly DDS Score Accts',
     'live-save': true,
   }, {
     startedAt: '2026-05-05T09:15:00.000Z',
   });
 
   assert.equal(values['account-names'], 'Thales Group, Skello, Oodrive');
-  assert.equal(values['consolidate-list-name'], 'Polly Score Accounts - Guillaume Nolot');
+  assert.equal(values['consolidate-list-name'], 'Polly DDS Score Accts');
   assert.equal(values.driver, 'playwright');
   assert.equal(values['session-mode'], 'persistent');
   assert.equal(values['coverage-config'], 'config/account-coverage/default.json');
@@ -72,7 +87,7 @@ test('buildSdrResearchBatchValues refuses connect flags', () => {
 test('renderSdrResearchIntro makes live-save and connect behavior explicit', () => {
   const markdown = renderSdrResearchIntro({
     accountNames: ['Thales Group', 'Skello'],
-    listName: 'Polly Score Accounts - Guillaume Nolot',
+    listName: 'Polly DDS Score Accts',
     liveSave: true,
   });
 


### PR DESCRIPTION
## Summary

- **Critical bug fix**: prevents duplicate list creation when `--list-name` exceeds Sales Nav's UI truncation point (~32 chars). One real-world run produced dozens of empty duplicate lists from a single 5-account save.
- **EMEA multilingual coverage** expansion: 37 sweeps (was 23), 7 languages of localized titles, retiree/intern filters in 6 languages.
- **Postmortem** documenting the bug and the defense-in-depth response.

## What changed

### Bug fix (commit 1)
| Layer | Where | What |
|---|---|---|
| 1 — Input validation | `src/core/sdr-workflow.js` | Hard 32-char cap on list names, throws with auto-shortened suggestion |
| 2 — Robust DOM match | `src/lib/sales-nav-label-match.js` (new) | Central matcher: innerText, title, aria-label with truncated-prefix + substring + anti-false-positive guards |
| 3 — Applied to all callsites | `playwright-sales-nav.js`, `cli.js` (4 places) | Replaces 4 brittle `innerText === target` comparisons |
| 4 — Save-loop circuit breaker | `cli.js` save loop | Aborts after 3 consecutive `created_list` outcomes |

### Coverage improvements (commit 2)
- 14 new multilang sweep templates (Kubernetes/Container, ITIL/Incident, Network/Telecom, BI/Hadoop, etc.) — recovered 3 of 14 manually-found gap personas in test against Agirc-Arrco; jumped candidates from 39 to 66 on the same account.
- 6-language retiree + intern + recruiter excludes.
- New `grafana-internal-gtm.json` config for internal network expansion (separate from buyer-discovery defaults).
- Grafana Labs canonical entity pinned (Sales Nav ID 11062162), NextLink Labs homonym excluded.

### Postmortem (commit 3)
Operator-facing documentation at `docs/postmortems/2026-05-12-list-duplication.md`.

## Test plan
- [x] 428/428 tests pass (`npm test`)
- [x] 14 new unit tests for the label matcher with boundary cases, truncation markers, false-positive guards
- [x] Existing sdr-workflow and account-coverage tests updated for new invariants
- [ ] Manual smoke test in Sales Nav with a 50-char list name (post-merge)
- [ ] Manual smoke test with a 32-char list name (boundary)
- [ ] Manual smoke test with circuit-breaker scenario (force a mismatch and verify the save loop aborts at 3 consecutive `created_list`)

## Operator follow-up
Existing duplicate lists in Sales Nav from the 2026-05-12 incident need manual cleanup:
- Liste `Grafana - Daniel Datsenko - PZU PKO Millenni...` (12 May 2026) — dozens of duplicates
- Possibly affected: any prior list created with name >32 chars (`Grafana Internal Network - GTM Wave 1` = 38, several Agirc-Arrco runs = 54+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)